### PR TITLE
Fix crash by setting valid physical device enumeration parameter

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -470,7 +470,7 @@ void VulkanExampleBase::initVulkan(bool enableValidation)
 
 	// Physical device
 	// Note : This example will always use the first physical device reported
-	uint32_t gpuCount;
+	uint32_t gpuCount = 1;
 	err = vkEnumeratePhysicalDevices(instance, &gpuCount, &physicalDevice);
 	if (err)
 	{


### PR DESCRIPTION
If pPhysicalDevices is not NULL for vkEnumeratePhysicalDevices(),
have to properly set pPhysicalDeviceCount.

This fixed crash on intel vulkan driver.