### PR TITLE
Fix CMake project name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 cmake_policy(VERSION 2.8)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
-set(NAME bloom)
+set(NAME vulkanExamples)
 
 project(${NAME})
 


### PR DESCRIPTION
The CMake project name is set to be the same as the name of the first example.
I suggest it gets changed to the name of the Visual Studio solution included in the repository.