### PR TITLE
Fix for vs2015 unicode builds.

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -536,7 +536,7 @@ void VulkanExampleBase::setupConsole(std::string title)
 	AllocConsole();
 	AttachConsole(GetCurrentProcessId());
 	freopen("CON", "w", stdout);
-	SetConsoleTitle(TEXT(title.c_str()));
+	SetConsoleTitleA(title.c_str());
 	if (enableValidation)
 	{
 		std::cout << "Validation enabled:\n";
@@ -558,9 +558,9 @@ HWND VulkanExampleBase::setupWindow(HINSTANCE hinstance, WNDPROC wndproc)
 		}
 	}
 
-	WNDCLASSEX wndClass;
+	WNDCLASSEXA wndClass;
 
-	wndClass.cbSize = sizeof(WNDCLASSEX);
+	wndClass.cbSize = sizeof(WNDCLASSEXA);
 	wndClass.style = CS_HREDRAW | CS_VREDRAW;
 	wndClass.lpfnWndProc = wndproc;
 	wndClass.cbClsExtra = 0;
@@ -573,7 +573,7 @@ HWND VulkanExampleBase::setupWindow(HINSTANCE hinstance, WNDPROC wndproc)
 	wndClass.lpszClassName = name.c_str();
 	wndClass.hIconSm = LoadIcon(NULL, IDI_WINLOGO);
 
-	if (!RegisterClassEx(&wndClass))
+	if (!RegisterClassExA(&wndClass))
 	{
 		std::cout << "Could not register window class!\n";
 		fflush(stdout);
@@ -597,7 +597,7 @@ HWND VulkanExampleBase::setupWindow(HINSTANCE hinstance, WNDPROC wndproc)
 		{
 			if (ChangeDisplaySettings(&dmScreenSettings, CDS_FULLSCREEN) != DISP_CHANGE_SUCCESSFUL)
 			{
-				if (MessageBox(NULL, "Fullscreen Mode not supported!\n Switch to window mode?", "Error", MB_YESNO | MB_ICONEXCLAMATION) == IDYES)
+				if (MessageBox(NULL, TEXT("Fullscreen Mode not supported!\n Switch to window mode?"), TEXT("Error"), MB_YESNO | MB_ICONEXCLAMATION) == IDYES)
 				{
 					fullscreen = FALSE;
 				}
@@ -642,7 +642,7 @@ HWND VulkanExampleBase::setupWindow(HINSTANCE hinstance, WNDPROC wndproc)
 
 	AdjustWindowRectEx(&windowRect, dwStyle, FALSE, dwExStyle);
 
-	window = CreateWindowEx(0,
+	window = CreateWindowExA(0,
 		name.c_str(),
 		title.c_str(),
 		//		WS_OVERLAPPEDWINDOW | WS_VISIBLE | WS_SYSMENU,

--- a/base/vulkantools.cpp
+++ b/base/vulkantools.cpp
@@ -207,7 +207,7 @@ namespace vkTools
 	void exitFatal(std::string message, std::string caption)
 	{
 #ifdef _WIN32
-		MessageBox(NULL, message.c_str(), caption.c_str(), MB_OK | MB_ICONERROR);
+		MessageBoxA(NULL, message.c_str(), caption.c_str(), MB_OK | MB_ICONERROR);
 #else
 		// TODO : Linux
 #endif


### PR DESCRIPTION
Found some small issues with windows API wide functions and std::string mixing and the TEXT macro.

Regards.
