### PR TITLE
fix handle_event -> handleEvent in shadowmapping

### DIFF
--- a/shadowmapping/shadowmapping.cpp
+++ b/shadowmapping/shadowmapping.cpp
@@ -1166,11 +1166,11 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 #else 
 
-static void handle_event(const xcb_generic_event_t *event)
+static void handleEvent(const xcb_generic_event_t *event)
 {
 	if (vulkanExample != NULL)
 	{
-		vulkanExample->handle_event(event);
+		vulkanExample->handleEvent(event);
 	}
 }
 #endif


### PR DESCRIPTION
The shadow mapping example didn't build for me:
```
shadowmapping/shadowmapping.cpp:1177:18: Fehler: »class VulkanExample« has no member named »handle_event«
```
In all the other examples it's handleEvent instead of handle_event and that works.

For some reason the github interface seems to display the commit wrong, maybe, because of the line endings?