### PR TITLE
Cleaned macros in VulkanBaseExample::VulkanBaseExample(bool)

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -475,9 +475,7 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 			enableValidation = true;
 		}
 	}
-#endif
-
-#ifndef _WIN32
+#else
 	initxcbConnection();
 #endif
 	initVulkan(enableValidation);


### PR DESCRIPTION
I made the macro in VulkanBaseExample::VulkanBaseExample(bool) which "checks for validation command line flag" cleaner. It had 2 ifs that could be merged into one, and this new one is easier on my eyes. :) 