### PR TITLE
Fix ifdef

### DIFF
--- a/android/computeparticles/computeparticles.NativeActivity/android_native_app_glue.h
+++ b/android/computeparticles/computeparticles.NativeActivity/android_native_app_glue.h
@@ -26,7 +26,7 @@
 #include <android/looper.h>
 #include <android/native_activity.h>
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -337,7 +337,7 @@ void android_app_post_exec_cmd(struct android_app* android_app, int8_t cmd);
  */
 extern void android_main(struct android_app* app);
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 }
 #endif
 

--- a/android/mesh/mesh.NativeActivity/android_native_app_glue.h
+++ b/android/mesh/mesh.NativeActivity/android_native_app_glue.h
@@ -26,7 +26,7 @@
 #include <android/looper.h>
 #include <android/native_activity.h>
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -337,7 +337,7 @@ void android_app_post_exec_cmd(struct android_app* android_app, int8_t cmd);
  */
 extern void android_main(struct android_app* app);
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 }
 #endif
 

--- a/android/mesh/mesh.NativeActivity/tiny_obj_loader.h
+++ b/android/mesh/mesh.NativeActivity/tiny_obj_loader.h
@@ -150,7 +150,7 @@ void LoadMtl(std::map<std::string, int> &material_map, // [output]
              std::istream &inStream);
 }
 
-#ifdef TINYOBJLOADER_IMPLEMENTATION
+#if defined(TINYOBJLOADER_IMPLEMENTATION)
 #include <cstdlib>
 #include <cstring>
 #include <cassert>
@@ -369,7 +369,7 @@ fail:
 }
 static inline float parseFloat(const char *&token) {
   token += strspn(token, " \t");
-#ifdef TINY_OBJ_LOADER_OLD_FLOAT_PARSER
+#if defined(TINY_OBJ_LOADER_OLD_FLOAT_PARSER)
   float f = (float)atof(token);
   token += strcspn(token, " \t\r");
 #else
@@ -639,7 +639,7 @@ void LoadMtl(std::map<std::string, int> &material_map,
       // set new mtl name
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
       sscanf(token, "%s", namebuf);
@@ -970,7 +970,7 @@ bool LoadObj(std::vector<shape_t> &shapes,       // [output]
 
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
       sscanf(token, "%s", namebuf);
@@ -1000,7 +1000,7 @@ bool LoadObj(std::vector<shape_t> &shapes,       // [output]
     if ((0 == strncmp(token, "mtllib", 6)) && isSpace((token[6]))) {
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
       sscanf(token, "%s", namebuf);
@@ -1071,7 +1071,7 @@ bool LoadObj(std::vector<shape_t> &shapes,       // [output]
       // @todo { multiple object name? }
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
       sscanf(token, "%s", namebuf);

--- a/android/texture/texture.NativeActivity/android_native_app_glue.h
+++ b/android/texture/texture.NativeActivity/android_native_app_glue.h
@@ -26,7 +26,7 @@
 #include <android/looper.h>
 #include <android/native_activity.h>
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -337,7 +337,7 @@ void android_app_post_exec_cmd(struct android_app* android_app, int8_t cmd);
  */
 extern void android_main(struct android_app* app);
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 }
 #endif
 

--- a/android/triangle/triangle.NativeActivity/android_native_app_glue.h
+++ b/android/triangle/triangle.NativeActivity/android_native_app_glue.h
@@ -26,7 +26,7 @@
 #include <android/looper.h>
 #include <android/native_activity.h>
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -337,7 +337,7 @@ void android_app_post_exec_cmd(struct android_app* android_app, int8_t cmd);
  */
 extern void android_main(struct android_app* app);
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 }
 #endif
 

--- a/base/vulkanMeshLoader.hpp
+++ b/base/vulkanMeshLoader.hpp
@@ -19,7 +19,6 @@
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>
-#else
 #endif
 
 #include "vulkan/vulkan.h"

--- a/base/vulkanMeshLoader.hpp
+++ b/base/vulkanMeshLoader.hpp
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <vector>
 #include <map>
-#ifdef _WIN32
+#if defined(_WIN32)
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>

--- a/base/vulkanandroid.cpp
+++ b/base/vulkanandroid.cpp
@@ -8,7 +8,7 @@
 
 #include "vulkanandroid.h"
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__)
     #include <android/log.h>
     #include <dlfcn.h>
 

--- a/base/vulkanandroid.h
+++ b/base/vulkanandroid.h
@@ -20,7 +20,7 @@
 
 #include "vulkan/vulkan.h"
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__)
 
 // Function pointer prototypes
 // Not complete, just the functions used in the caps viewer!

--- a/base/vulkandebug.h
+++ b/base/vulkandebug.h
@@ -10,12 +10,12 @@
 #include <assert.h>
 #include <stdio.h>
 #include <vector>
-#ifdef _WIN32
+#if defined(_WIN32)
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>
 #endif
-#ifdef __ANDROID__
+#if defined(__ANDROID__)
 #include "vulkanandroid.h"
 #endif
 

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -24,8 +24,9 @@ VkResult VulkanExampleBase::createInstance(bool enableValidation)
 
 #if defined(_WIN32)
 	enabledExtensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-#else
-	// todo : linux/android
+#elif defined(__ANDROID__)
+	// todo : android
+#elif defined(__linux__)
 	enabledExtensions.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
 #endif
 
@@ -333,7 +334,7 @@ void VulkanExampleBase::renderLoop()
 			frameCounter = 0.0f;
 		}
 	}
-#else
+#elif defined(__linux__)
 	xcb_flush(connection);
 	while (!quit)
 	{
@@ -475,9 +476,10 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 	}
 #endif
 
-#if !defined(_WIN32)
+#if defined(__linux__)
 	initxcbConnection();
 #endif
+
 	initVulkan(enableValidation);
 	// Enable console if validation is active
 	// Debug message callback will output to it
@@ -535,7 +537,7 @@ VulkanExampleBase::~VulkanExampleBase()
 
 	vkDestroyInstance(instance, nullptr);
 
-#if !defined(_WIN32)
+#if defined(__linux__)
 	xcb_destroy_window(connection, window);
 	xcb_disconnect(connection);
 #endif
@@ -836,7 +838,7 @@ void VulkanExampleBase::handleMessages(HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
 	}
 }
 
-#else
+#elif defined(__linux__)
 
 // Set up a window using XCB and request event types
 xcb_window_t VulkanExampleBase::setupWindow()
@@ -1151,7 +1153,7 @@ void VulkanExampleBase::initSwapchain()
 {
 #if defined(_WIN32)
 	swapChain.initSurface(windowInstance, window);
-#else
+#elif defined(__linux__)
 	swapChain.initSurface(connection, window);
 #endif
 }

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -22,7 +22,7 @@ VkResult VulkanExampleBase::createInstance(bool enableValidation)
 
 	std::vector<const char*> enabledExtensions = { VK_KHR_SURFACE_EXTENSION_NAME };
 
-#ifdef _WIN32
+#if defined(_WIN32)
 	enabledExtensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #else
 	// todo : linux/android
@@ -293,7 +293,7 @@ void VulkanExampleBase::loadMesh(
 
 void VulkanExampleBase::renderLoop()
 {
-#ifdef _WIN32
+#if defined(_WIN32)
 	MSG msg;
 	while (TRUE)
 	{
@@ -465,7 +465,7 @@ VkSubmitInfo VulkanExampleBase::prepareSubmitInfo(
 VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 {
 	// Check for validation command line flag
-#ifdef _WIN32
+#if defined(_WIN32)
 	for (int32_t i = 0; i < __argc; i++)
 	{
 		if (__argv[i] == std::string("-validation"))
@@ -475,13 +475,13 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 	}
 #endif
 
-#ifndef _WIN32
+#if !defined(_WIN32)
 	initxcbConnection();
 #endif
 	initVulkan(enableValidation);
 	// Enable console if validation is active
 	// Debug message callback will output to it
-#ifdef _WIN32
+#if defined(_WIN32)
 	if (enableValidation)
 	{
 		setupConsole("VulkanExample");
@@ -535,7 +535,7 @@ VulkanExampleBase::~VulkanExampleBase()
 
 	vkDestroyInstance(instance, nullptr);
 
-#ifndef _WIN32
+#if !defined(_WIN32)
 	xcb_destroy_window(connection, window);
 	xcb_disconnect(connection);
 #endif
@@ -636,7 +636,7 @@ void VulkanExampleBase::initVulkan(bool enableValidation)
 	submitInfo.pSignalSemaphores = &semaphores.renderComplete;
 }
 
-#ifdef _WIN32
+#if defined(_WIN32)
 // Win32 : Sets up a console window and redirects standard output to it
 void VulkanExampleBase::setupConsole(std::string title)
 {
@@ -1149,7 +1149,7 @@ void VulkanExampleBase::setupRenderPass()
 
 void VulkanExampleBase::initSwapchain()
 {
-#ifdef _WIN32
+#if defined(_WIN32)
 	swapChain.initSurface(windowInstance, window);
 #else
 	swapChain.initSurface(connection, window);

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#ifdef _WIN32
+#if defined(_WIN32)
 #pragma comment(linker, "/subsystem:windows")
 #include <windows.h>
 #include <fcntl.h>
@@ -146,7 +146,7 @@ public:
 	} depthStencil;
 
 	// OS specific 
-#ifdef _WIN32
+#if defined(_WIN32)
 	HWND window;
 	HINSTANCE windowInstance;
 #else
@@ -168,7 +168,7 @@ public:
 	// Setup the vulkan instance, enable required extensions and connect to the physical device (GPU)
 	void initVulkan(bool enableValidation);
 
-#ifdef _WIN32 
+#if defined(_WIN32 )
 	void setupConsole(std::string title);
 	HWND setupWindow(HINSTANCE hinstance, WNDPROC wndproc);
 	void handleMessages(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -13,8 +13,9 @@
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>
-#else 
-// todo : split linux xcb/x11 and android
+#elif defined(__ANDROID__)
+// todo : android
+#elif defined(__linux__)
 #include <xcb/xcb.h>
 #endif
 
@@ -149,7 +150,7 @@ public:
 #if defined(_WIN32)
 	HWND window;
 	HINSTANCE windowInstance;
-#else
+#elif defined(__linux__)
 	struct {
 		bool left = false;
 		bool right = false;
@@ -159,7 +160,7 @@ public:
 	xcb_screen_t *screen;
 	xcb_window_t window;
 	xcb_intern_atom_reply_t *atom_wm_delete_window;
-#endif	
+#endif
 
 	VulkanExampleBase(bool enableValidation);
 	VulkanExampleBase() : VulkanExampleBase(false) {};
@@ -168,15 +169,16 @@ public:
 	// Setup the vulkan instance, enable required extensions and connect to the physical device (GPU)
 	void initVulkan(bool enableValidation);
 
-#if defined(_WIN32 )
+#if defined(_WIN32)
 	void setupConsole(std::string title);
 	HWND setupWindow(HINSTANCE hinstance, WNDPROC wndproc);
 	void handleMessages(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-#else
+#elif defined(__linux__)
 	xcb_window_t setupWindow();
 	void initxcbConnection();
 	void handleEvent(const xcb_generic_event_t *event);
 #endif
+
 	// Pure virtual render function (override in derived class)
 	virtual void render() = 0;
 	// Called when view change occurs

--- a/base/vulkanswapchain.hpp
+++ b/base/vulkanswapchain.hpp
@@ -17,7 +17,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <vector>
-#ifdef _WIN32
+#if defined(_WIN32)
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>
@@ -27,7 +27,7 @@
 #include <vulkan/vulkan.h>
 #include "vulkantools.h"
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__)
 #include "vulkanandroid.h"
 #endif
 
@@ -89,10 +89,10 @@ public:
 	// Creates an os specific surface
 	// Tries to find a graphics and a present queue
 	void initSurface(
-#ifdef _WIN32
+#if defined(_WIN32)
 		void* platformHandle, void* platformWindow
 #else
-#ifdef __ANDROID__
+#if defined(__ANDROID__)
 		ANativeWindow* window
 #else
 		xcb_connection_t* connection, xcb_window_t window
@@ -103,14 +103,14 @@ public:
 		VkResult err;
 
 		// Create surface depending on OS
-#ifdef _WIN32
+#if defined(_WIN32)
 		VkWin32SurfaceCreateInfoKHR surfaceCreateInfo = {};
 		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
 		surfaceCreateInfo.hinstance = (HINSTANCE)platformHandle;
 		surfaceCreateInfo.hwnd = (HWND)platformWindow;
 		err = vkCreateWin32SurfaceKHR(instance, &surfaceCreateInfo, nullptr, &surface);
 #else
-#ifdef __ANDROID__
+#if defined(__ANDROID__)
 		VkAndroidSurfaceCreateInfoKHR surfaceCreateInfo = {};
 		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
 		surfaceCreateInfo.window = window;

--- a/base/vulkanswapchain.hpp
+++ b/base/vulkanswapchain.hpp
@@ -21,7 +21,6 @@
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>
-#else
 #endif
 
 #include <vulkan/vulkan.h>
@@ -91,12 +90,10 @@ public:
 	void initSurface(
 #if defined(_WIN32)
 		void* platformHandle, void* platformWindow
-#else
-#if defined(__ANDROID__)
+#elif defined(__ANDROID__)
 		ANativeWindow* window
-#else
+#elif defined(__linux__)
 		xcb_connection_t* connection, xcb_window_t window
-#endif
 #endif
 	)
 	{
@@ -109,19 +106,17 @@ public:
 		surfaceCreateInfo.hinstance = (HINSTANCE)platformHandle;
 		surfaceCreateInfo.hwnd = (HWND)platformWindow;
 		err = vkCreateWin32SurfaceKHR(instance, &surfaceCreateInfo, nullptr, &surface);
-#else
-#if defined(__ANDROID__)
+#elif defined(__ANDROID__)
 		VkAndroidSurfaceCreateInfoKHR surfaceCreateInfo = {};
 		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
 		surfaceCreateInfo.window = window;
 		err = vkCreateAndroidSurfaceKHR(instance, &surfaceCreateInfo, NULL, &surface);
-#else
+#elif defined(__linux__)
 		VkXcbSurfaceCreateInfoKHR surfaceCreateInfo = {};
 		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
 		surfaceCreateInfo.connection = connection;
 		surfaceCreateInfo.window = window;
 		err = vkCreateXcbSurfaceKHR(instance, &surfaceCreateInfo, nullptr, &surface);
-#endif
 #endif
 
 		// Get available queue family properties

--- a/base/vulkantools.cpp
+++ b/base/vulkantools.cpp
@@ -8,7 +8,7 @@
 
 #include "vulkantools.h"
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__)
 #include "vulkanandroid.h"
 #endif
 
@@ -251,7 +251,7 @@ namespace vkTools
 
 	void exitFatal(std::string message, std::string caption)
 	{
-#ifdef _WIN32
+#if defined(_WIN32)
 		MessageBox(NULL, message.c_str(), caption.c_str(), MB_OK | MB_ICONERROR);
 #else
 		// TODO : Linux

--- a/base/vulkantools.cpp
+++ b/base/vulkantools.cpp
@@ -253,7 +253,7 @@ namespace vkTools
 	{
 #if defined(_WIN32)
 		MessageBox(NULL, message.c_str(), caption.c_str(), MB_OK | MB_ICONERROR);
-#else
+#elif defined(__linux__)
 		// TODO : Linux
 #endif
 		std::cerr << message << "\n";

--- a/base/vulkantools.h
+++ b/base/vulkantools.h
@@ -24,7 +24,6 @@
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>
-#else
 #endif
 
 // Custom define for better code readability

--- a/base/vulkantools.h
+++ b/base/vulkantools.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include <iostream>
 #include <stdexcept>
-#ifdef _WIN32
+#if defined(_WIN32)
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>

--- a/bloom/bloom.cpp
+++ b/bloom/bloom.cpp
@@ -1305,7 +1305,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -1342,14 +1342,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/bloom/bloom.cpp
+++ b/bloom/bloom.cpp
@@ -1331,7 +1331,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -1340,18 +1340,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/computeparticles/computeparticles.cpp
+++ b/computeparticles/computeparticles.cpp
@@ -766,7 +766,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -775,18 +775,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/computeparticles/computeparticles.cpp
+++ b/computeparticles/computeparticles.cpp
@@ -746,7 +746,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -777,14 +777,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/computeshader/computeshader.cpp
+++ b/computeshader/computeshader.cpp
@@ -864,7 +864,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -873,18 +873,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/computeshader/computeshader.cpp
+++ b/computeshader/computeshader.cpp
@@ -843,7 +843,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -875,14 +875,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/deferred/deferred.cpp
+++ b/deferred/deferred.cpp
@@ -1298,7 +1298,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -1330,14 +1330,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/deferred/deferred.cpp
+++ b/deferred/deferred.cpp
@@ -1318,7 +1318,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -1328,18 +1328,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		// todo : keys
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/displacement/displacement.cpp
+++ b/displacement/displacement.cpp
@@ -618,7 +618,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -659,14 +659,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/displacement/displacement.cpp
+++ b/displacement/displacement.cpp
@@ -647,7 +647,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -657,18 +657,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		// TODO : Keys for tessellation level changes
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/distancefieldfonts/distancefieldfonts.cpp
+++ b/distancefieldfonts/distancefieldfonts.cpp
@@ -726,7 +726,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -760,14 +760,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/distancefieldfonts/distancefieldfonts.cpp
+++ b/distancefieldfonts/distancefieldfonts.cpp
@@ -749,7 +749,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -758,18 +758,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/gears/gears.cpp
+++ b/gears/gears.cpp
@@ -412,7 +412,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -421,18 +421,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/gears/gears.cpp
+++ b/gears/gears.cpp
@@ -401,7 +401,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -423,14 +423,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/geometryshader/geometryshader.cpp
+++ b/geometryshader/geometryshader.cpp
@@ -507,7 +507,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -516,18 +516,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/geometryshader/geometryshader.cpp
+++ b/geometryshader/geometryshader.cpp
@@ -496,7 +496,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -518,14 +518,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/instancing/instancing.cpp
+++ b/instancing/instancing.cpp
@@ -510,7 +510,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -519,18 +519,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/instancing/instancing.cpp
+++ b/instancing/instancing.cpp
@@ -499,7 +499,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -521,14 +521,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -560,7 +560,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -569,18 +569,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -549,7 +549,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -571,14 +571,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/multithreading/multithreading.cpp
+++ b/multithreading/multithreading.cpp
@@ -645,7 +645,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -667,14 +667,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/multithreading/multithreading.cpp
+++ b/multithreading/multithreading.cpp
@@ -656,7 +656,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -665,18 +665,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/occlusionquery/occlusionquery.cpp
+++ b/occlusionquery/occlusionquery.cpp
@@ -97,7 +97,7 @@ public:
 		rotationSpeed = 0.5f;
 		rotation = { 0.0, -123.75, 0.0 };
 		title = "Vulkan Example - Occlusion queries";
-#ifdef _WIN32 
+#if defined(_WIN32 )
 		if (!ENABLE_VALIDATION) 
 		{
 			setupConsole(title);
@@ -691,7 +691,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -713,14 +713,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/occlusionquery/occlusionquery.cpp
+++ b/occlusionquery/occlusionquery.cpp
@@ -702,7 +702,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -711,18 +711,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/offscreen/offscreen.cpp
+++ b/offscreen/offscreen.cpp
@@ -1135,7 +1135,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -1157,14 +1157,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/offscreen/offscreen.cpp
+++ b/offscreen/offscreen.cpp
@@ -1146,7 +1146,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -1155,18 +1155,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/parallaxmapping/parallaxmapping.cpp
+++ b/parallaxmapping/parallaxmapping.cpp
@@ -614,7 +614,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -652,14 +652,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/parallaxmapping/parallaxmapping.cpp
+++ b/parallaxmapping/parallaxmapping.cpp
@@ -640,7 +640,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -650,18 +650,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		// TODO : Keys
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/particlefire/particlefire.cpp
+++ b/particlefire/particlefire.cpp
@@ -824,7 +824,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -846,14 +846,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/particlefire/particlefire.cpp
+++ b/particlefire/particlefire.cpp
@@ -835,7 +835,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -844,18 +844,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/pipelines/pipelines.cpp
+++ b/pipelines/pipelines.cpp
@@ -591,7 +591,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -613,14 +613,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/pipelines/pipelines.cpp
+++ b/pipelines/pipelines.cpp
@@ -602,7 +602,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -611,18 +611,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/pushconstants/pushconstants.cpp
+++ b/pushconstants/pushconstants.cpp
@@ -515,7 +515,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -546,14 +546,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/pushconstants/pushconstants.cpp
+++ b/pushconstants/pushconstants.cpp
@@ -535,7 +535,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -544,18 +544,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/radialblur/radialblur.cpp
+++ b/radialblur/radialblur.cpp
@@ -1102,7 +1102,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -1111,18 +1111,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/radialblur/radialblur.cpp
+++ b/radialblur/radialblur.cpp
@@ -1079,7 +1079,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -1113,14 +1113,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/shadowmapping/shadowmapping.cpp
+++ b/shadowmapping/shadowmapping.cpp
@@ -1190,7 +1190,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -1199,18 +1199,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/shadowmapping/shadowmapping.cpp
+++ b/shadowmapping/shadowmapping.cpp
@@ -1167,7 +1167,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -1201,14 +1201,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/shadowmappingomni/shadowmappingomni.cpp
+++ b/shadowmappingomni/shadowmappingomni.cpp
@@ -1091,7 +1091,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -1122,14 +1122,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/shadowmappingomni/shadowmappingomni.cpp
+++ b/shadowmappingomni/shadowmappingomni.cpp
@@ -1111,7 +1111,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -1120,18 +1120,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/skeletalanimation/skeletalanimation.cpp
+++ b/skeletalanimation/skeletalanimation.cpp
@@ -861,7 +861,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -883,14 +883,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/skeletalanimation/skeletalanimation.cpp
+++ b/skeletalanimation/skeletalanimation.cpp
@@ -872,7 +872,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -881,18 +881,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/sphericalenvmapping/sphericalenvmapping.cpp
+++ b/sphericalenvmapping/sphericalenvmapping.cpp
@@ -514,7 +514,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -536,14 +536,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/sphericalenvmapping/sphericalenvmapping.cpp
+++ b/sphericalenvmapping/sphericalenvmapping.cpp
@@ -525,7 +525,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -534,18 +534,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/tessellation/tessellation.cpp
+++ b/tessellation/tessellation.cpp
@@ -596,7 +596,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -637,14 +637,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/tessellation/tessellation.cpp
+++ b/tessellation/tessellation.cpp
@@ -625,7 +625,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -635,18 +635,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		// TODO : Keys for tessellation level changes
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/texture/texture.cpp
+++ b/texture/texture.cpp
@@ -903,7 +903,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -912,18 +912,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/texture/texture.cpp
+++ b/texture/texture.cpp
@@ -880,7 +880,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -914,14 +914,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/texturearray/texturearray.cpp
+++ b/texturearray/texturearray.cpp
@@ -747,7 +747,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -769,14 +769,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/texturearray/texturearray.cpp
+++ b/texturearray/texturearray.cpp
@@ -758,7 +758,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -767,18 +767,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/texturecubemap/texturecubemap.cpp
+++ b/texturecubemap/texturecubemap.cpp
@@ -762,7 +762,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -771,18 +771,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/texturecubemap/texturecubemap.cpp
+++ b/texturecubemap/texturecubemap.cpp
@@ -751,7 +751,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -773,14 +773,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/triangle/triangle.cpp
+++ b/triangle/triangle.cpp
@@ -880,7 +880,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -889,18 +889,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();

--- a/triangle/triangle.cpp
+++ b/triangle/triangle.cpp
@@ -869,7 +869,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -891,14 +891,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/vulkanscene/vulkanscene.cpp
+++ b/vulkanscene/vulkanscene.cpp
@@ -595,7 +595,7 @@ public:
 
 VulkanExample *vulkanExample;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -617,14 +617,14 @@ static void handleEvent(const xcb_generic_event_t *event)
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 #else
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
-#ifdef _WIN32
+#if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
 #else
 	vulkanExample->setupWindow();

--- a/vulkanscene/vulkanscene.cpp
+++ b/vulkanscene/vulkanscene.cpp
@@ -606,7 +606,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
-#else 
+#elif defined(__linux__)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
@@ -615,18 +615,19 @@ static void handleEvent(const xcb_generic_event_t *event)
 		vulkanExample->handleEvent(event);
 	}
 }
+
 #endif
 
 #if defined(_WIN32)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
-#else
+#elif defined(__linux__)
 int main(const int argc, const char *argv[])
 #endif
 {
 	vulkanExample = new VulkanExample();
 #if defined(_WIN32)
 	vulkanExample->setupWindow(hInstance, WndProc);
-#else
+#elif defined(__linux__)
 	vulkanExample->setupWindow();
 #endif
 	vulkanExample->initSwapchain();


### PR DESCRIPTION
- Rewrite every `#ifdef FOO` as `#if defined(FOO)`  
  Leave the `#ifndef` alone though.
- Fix OS detection  
  Everything that is not Windows isn't necessarily Linux :]

When adding Android support, be careful to add `#elif defined(__ANDROID__)` before `__linux__`, as Android is also a Linux :+1:
