### PR TITLE
Fix circular/modulo arithmetic

### DIFF
--- a/sphericalenvmapping/sphericalenvmapping.cpp
+++ b/sphericalenvmapping/sphericalenvmapping.cpp
@@ -496,17 +496,10 @@ public:
 		}
 	}
 
-	void changeMatCapIndex(uint32_t delta)
+	void changeMatCapIndex(int32_t delta)
 	{
-		uboVS.texIndex += delta;
-		if (uboVS.texIndex < 0)
-		{
-			uboVS.texIndex = textures.matCapArray.layerCount-1;
-		}
-		if (uboVS.texIndex >= textures.matCapArray.layerCount)
-		{
-			uboVS.texIndex = 0;
-		}
+		uboVS.texIndex = (uboVS.texIndex + delta + textures.matCapArray.layerCount)
+		                                         % textures.matCapArray.layerCount;
 		updateUniformBuffers();
 	}
 


### PR DESCRIPTION
The input param was also unsigned, leading to an overflow when passing `-1`.
