### PR TITLE
Move VulkanExample allocation to the stack

### DIFF
--- a/bloom/bloom.cpp
+++ b/bloom/bloom.cpp
@@ -1303,27 +1303,27 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case 0x42:
-				vulkanExample->toggleBloom();
+				vulkanExampleGlobal->toggleBloom();
 				break;
 			case VK_ADD:
-				vulkanExample->changeBlurScale(0.25f);
+				vulkanExampleGlobal->changeBlurScale(0.25f);
 				break;
 			case VK_SUBTRACT:
-				vulkanExample->changeBlurScale(-0.25f);
+				vulkanExampleGlobal->changeBlurScale(-0.25f);
 				break;
 			}
 		}
@@ -1335,9 +1335,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -1348,15 +1348,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/computeparticles/computeparticles.cpp
+++ b/computeparticles/computeparticles.cpp
@@ -744,21 +744,21 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case 0x41:
-				vulkanExample->toggleAnimation();
+				vulkanExampleGlobal->toggleAnimation();
 				break;
 			}
 		}
@@ -770,9 +770,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -783,15 +783,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/computeshader/computeshader.cpp
+++ b/computeshader/computeshader.cpp
@@ -841,22 +841,22 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case VK_ADD:
 			case VK_SUBTRACT:
-				vulkanExample->switchComputePipeline((wParam == VK_ADD) ? 1 : -1);
+				vulkanExampleGlobal->switchComputePipeline((wParam == VK_ADD) ? 1 : -1);
 				break;
 			}
 		}
@@ -868,9 +868,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -881,15 +881,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/deferred/deferred.cpp
+++ b/deferred/deferred.cpp
@@ -1296,21 +1296,21 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case 0x44:
-				vulkanExample->toggleDebugDisplay();
+				vulkanExampleGlobal->toggleDebugDisplay();
 				break;
 			}
 		}
@@ -1322,9 +1322,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 		// todo : keys
 	}
 }
@@ -1336,15 +1336,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/displacement/displacement.cpp
+++ b/displacement/displacement.cpp
@@ -616,30 +616,30 @@ public:
 
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case VK_ADD:
-				vulkanExample->changeTessellationLevel(0.25);
+				vulkanExampleGlobal->changeTessellationLevel(0.25);
 				break;
 			case VK_SUBTRACT:
-				vulkanExample->changeTessellationLevel(-0.25);
+				vulkanExampleGlobal->changeTessellationLevel(-0.25);
 				break;
 			case 0x57:
-				vulkanExample->togglePipelines();
+				vulkanExampleGlobal->togglePipelines();
 				break;
 			case 0x53:
-				vulkanExample->toggleSplitScreen();
+				vulkanExampleGlobal->toggleSplitScreen();
 				break;
 			}
 		}
@@ -651,9 +651,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 		// TODO : Keys for tessellation level changes
 	}
 }
@@ -665,15 +665,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/distancefieldfonts/distancefieldfonts.cpp
+++ b/distancefieldfonts/distancefieldfonts.cpp
@@ -724,24 +724,24 @@ public:
 
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case 0x53:
-				vulkanExample->toggleSplitScreen();
+				vulkanExampleGlobal->toggleSplitScreen();
 				break;
 			case 0x4F:
-				vulkanExample->toggleFontOutline();
+				vulkanExampleGlobal->toggleFontOutline();
 				break;
 			}
 		}
@@ -753,9 +753,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -766,15 +766,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/gears/gears.cpp
+++ b/gears/gears.cpp
@@ -399,15 +399,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -416,9 +416,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -429,15 +429,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/geometryshader/geometryshader.cpp
+++ b/geometryshader/geometryshader.cpp
@@ -494,15 +494,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -511,9 +511,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -524,15 +524,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/instancing/instancing.cpp
+++ b/instancing/instancing.cpp
@@ -497,15 +497,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -514,9 +514,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -527,15 +527,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -547,15 +547,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -564,9 +564,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -577,15 +577,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/multithreading/multithreading.cpp
+++ b/multithreading/multithreading.cpp
@@ -643,15 +643,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -660,9 +660,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -673,15 +673,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/occlusionquery/occlusionquery.cpp
+++ b/occlusionquery/occlusionquery.cpp
@@ -689,15 +689,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -706,9 +706,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -719,15 +719,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/offscreen/offscreen.cpp
+++ b/offscreen/offscreen.cpp
@@ -1133,15 +1133,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -1150,9 +1150,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -1163,15 +1163,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/parallaxmapping/parallaxmapping.cpp
+++ b/parallaxmapping/parallaxmapping.cpp
@@ -612,27 +612,27 @@ public:
 
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case 0x4F:
-				vulkanExample->toggleParallaxOffset();
+				vulkanExampleGlobal->toggleParallaxOffset();
 				break;
 			case 0x4E:
-				vulkanExample->toggleNormalMapDisplay();
+				vulkanExampleGlobal->toggleNormalMapDisplay();
 				break;
 			case 0x53:
-				vulkanExample->toggleSplitScreen();
+				vulkanExampleGlobal->toggleSplitScreen();
 				break;
 			}
 		}
@@ -644,9 +644,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 		// TODO : Keys
 	}
 }
@@ -658,15 +658,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/particlefire/particlefire.cpp
+++ b/particlefire/particlefire.cpp
@@ -822,15 +822,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -839,9 +839,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -852,15 +852,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/pipelines/pipelines.cpp
+++ b/pipelines/pipelines.cpp
@@ -589,15 +589,15 @@ public:
 
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -606,9 +606,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -619,15 +619,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/pushconstants/pushconstants.cpp
+++ b/pushconstants/pushconstants.cpp
@@ -513,21 +513,21 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case 0x41:
-				vulkanExample->toggleAnimation();
+				vulkanExampleGlobal->toggleAnimation();
 				break;
 			}
 		}
@@ -539,9 +539,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -552,15 +552,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/radialblur/radialblur.cpp
+++ b/radialblur/radialblur.cpp
@@ -1077,24 +1077,24 @@ public:
 
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case 0x42:
-				vulkanExample->toggleBlur();
+				vulkanExampleGlobal->toggleBlur();
 				break;
 			case 0x54:
-				vulkanExample->toggleTextureDisplay();
+				vulkanExampleGlobal->toggleTextureDisplay();
 				break;
 			}
 		}
@@ -1106,9 +1106,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -1119,15 +1119,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/shadowmapping/shadowmapping.cpp
+++ b/shadowmapping/shadowmapping.cpp
@@ -1165,24 +1165,24 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case 0x53:
-				vulkanExample->toggleShadowMapDisplay();
+				vulkanExampleGlobal->toggleShadowMapDisplay();
 				break;
 			case 0x4C:
-				vulkanExample->toogleLightPOV();
+				vulkanExampleGlobal->toogleLightPOV();
 				break;
 			}
 		}
@@ -1194,9 +1194,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -1207,15 +1207,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/shadowmappingomni/shadowmappingomni.cpp
+++ b/shadowmappingomni/shadowmappingomni.cpp
@@ -1089,21 +1089,21 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case 0x44:
-				vulkanExample->toggleCubeMapDisplay();
+				vulkanExampleGlobal->toggleCubeMapDisplay();
 				break;
 			}
 		}
@@ -1115,9 +1115,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -1128,15 +1128,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/skeletalanimation/skeletalanimation.cpp
+++ b/skeletalanimation/skeletalanimation.cpp
@@ -859,15 +859,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -876,9 +876,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -889,15 +889,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/sphericalenvmapping/sphericalenvmapping.cpp
+++ b/sphericalenvmapping/sphericalenvmapping.cpp
@@ -512,15 +512,15 @@ public:
 
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -529,9 +529,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -542,15 +542,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/tessellation/tessellation.cpp
+++ b/tessellation/tessellation.cpp
@@ -594,30 +594,30 @@ public:
 
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case VK_ADD:
-				vulkanExample->changeTessellationLevel(0.25);
+				vulkanExampleGlobal->changeTessellationLevel(0.25);
 				break;
 			case VK_SUBTRACT:
-				vulkanExample->changeTessellationLevel(-0.25);
+				vulkanExampleGlobal->changeTessellationLevel(-0.25);
 				break;
 			case 0x57:
-				vulkanExample->togglePipelines();
+				vulkanExampleGlobal->togglePipelines();
 				break;
 			case 0x53:
-				vulkanExample->toggleSplitScreen();
+				vulkanExampleGlobal->toggleSplitScreen();
 				break;
 			}
 		}
@@ -629,9 +629,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 		// TODO : Keys for tessellation level changes
 	}
 }
@@ -643,15 +643,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/texture/texture.cpp
+++ b/texture/texture.cpp
@@ -878,24 +878,24 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 		if (uMsg == WM_KEYDOWN)
 		{
 			switch (wParam)
 			{
 			case VK_ADD:
-				vulkanExample->changeLodBias(0.1f);
+				vulkanExampleGlobal->changeLodBias(0.1f);
 				break;
 			case VK_SUBTRACT:
-				vulkanExample->changeLodBias(-0.1f);
+				vulkanExampleGlobal->changeLodBias(-0.1f);
 				break;
 			}
 		}
@@ -907,9 +907,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -920,15 +920,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/texturearray/texturearray.cpp
+++ b/texturearray/texturearray.cpp
@@ -745,15 +745,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -762,9 +762,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -775,15 +775,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/texturecubemap/texturecubemap.cpp
+++ b/texturecubemap/texturecubemap.cpp
@@ -749,15 +749,15 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -766,9 +766,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -779,15 +779,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }

--- a/triangle/triangle.cpp
+++ b/triangle/triangle.cpp
@@ -876,14 +876,14 @@ public:
 	}
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -895,9 +895,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 #else
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -920,25 +920,25 @@ int main(const int argc, const char *argv[])
 	// which would make the application crash at start
 	app_dummy();
 #endif
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #if defined(_WIN32)
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #elif defined(__ANDROID__)
 	// Attach vulkan example to global android application state
-	state->userData = vulkanExample;
+	state->userData = &vulkanExample;
 	state->onAppCmd = VulkanExample::handleAppCommand;
 	state->onInputEvent = VulkanExample::handleAppInput;
-	vulkanExample->androidApp = state;
+	vulkanExample.androidApp = state;
 #elif defined(__linux__)
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
 #if !defined(__ANDROID__)
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
 #endif
-	vulkanExample->renderLoop();
+	vulkanExample.renderLoop();
 #if !defined(__ANDROID__)
-	delete(vulkanExample);
 	return 0;
 #endif
 }

--- a/vulkanscene/vulkanscene.cpp
+++ b/vulkanscene/vulkanscene.cpp
@@ -593,15 +593,15 @@ public:
 
 };
 
-VulkanExample *vulkanExample;
+VulkanExample *vulkanExampleGlobal;
 
 #ifdef _WIN32
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);
+		vulkanExampleGlobal->handleMessages(hWnd, uMsg, wParam, lParam);
 	}
 	return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
@@ -610,9 +610,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 static void handleEvent(const xcb_generic_event_t *event)
 {
-	if (vulkanExample != NULL)
+	if (vulkanExampleGlobal != NULL)
 	{
-		vulkanExample->handleEvent(event);
+		vulkanExampleGlobal->handleEvent(event);
 	}
 }
 #endif
@@ -623,15 +623,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLin
 int main(const int argc, const char *argv[])
 #endif
 {
-	vulkanExample = new VulkanExample();
+	VulkanExample vulkanExample;
+	vulkanExampleGlobal = &vulkanExample;
 #ifdef _WIN32
-	vulkanExample->setupWindow(hInstance, WndProc);
+	vulkanExample.setupWindow(hInstance, WndProc);
 #else
-	vulkanExample->setupWindow();
+	vulkanExample.setupWindow();
 #endif
-	vulkanExample->initSwapchain();
-	vulkanExample->prepare();
-	vulkanExample->renderLoop();
-	delete(vulkanExample);
+	vulkanExample.initSwapchain();
+	vulkanExample.prepare();
+	vulkanExample.renderLoop();
 	return 0;
 }


### PR DESCRIPTION
As I mentioned in #96, this is a rewrite of all the `VulkanExample` allocations onto the stack.

The pattern applied to all those changes is:
- Move allocation to the stack (`vulkanExample = new VulkanExample();` → `VulkanExample vulkanExample;`)
- Rename global object (`VulkanExample *vulkanExample;` → `VulkanExample *vulkanExampleGlobal;`)
- Give global pointer to local object (`vulkanExampleGlobal = &vulkanExample;`)

It does silence the compiler warning mentioned in #96, but I'm not sure this actually fixes the issue, so it should still be addressed.

Also, [don't hesitate to just close any of my PR if they don't align with what you want to do](https://github.com/blog/2124-kindly-closing-pull-requests) :wink:
