### PR TITLE
Add some debug warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ message(STATUS ${VULKAN_LIB})
 # Set preprocessor defines
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOMINMAX -DVK_PROTOTYPES -D_USE_MATH_DEFINES")
 
+# Debug flags
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Wundef")
+
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 add_definitions(-std=c++11)
 add_definitions(-std=c++0x)


### PR DESCRIPTION
Make use of them by configuring your build type to debug, for instance
by adding `-DCMAKE_BUILD_TYPE=Debug` to your cmake invocation.

Note that you will get a rather large amount of warnings, but most of those should disappear once you pull #92, #94 & #95, and fix #90.
#99 will also get rid of a warning, but I'm not entirely sure it's the right solution. Your call :)
#100 will also fix one those by virtue of upgrading `glm`: g-truc/glm#495

There will still be a couple unused functions, but I think that's a bug and they should be used, not removed. See #102
