### PR TITLE
FPS counter is not visible on Linux/XCB and nvidia drivers

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -468,6 +468,7 @@ void VulkanExampleBase::renderLoop()
 			xcb_change_property(connection, XCB_PROP_MODE_REPLACE,
 				window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8,
 				windowTitle.size(), windowTitle.c_str());
+			xcb_flush(connection);
 			fpsTimer = 0.0f;
 			frameCounter = 0.0f;
 		}


### PR DESCRIPTION
Add missing ```xcb_flush()```, see the example: http://www.x.org/archive/X11R7.7/doc/man/man3/xcb_change_property.3.xhtml :)