### PR TITLE
Fix spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Additional documentation for several base classes and some Presentations can be 
 ## [Triangle](triangle/)
 <img src="./screenshots/basic_triangle.png" height="96px" align="right">
 
-Most basic example. Renders a colored triangle using an indexed vertex buffer. Vertex and index data are uploaded to device local memory using so-called "staging buffers". Uses a single pipeline with basic shaders loaded from SPIR-V and and single uniform block for passing matrices that is updated on changing the view.
+Most basic example. Renders a colored triangle using an indexed vertex buffer. Vertex and index data are uploaded to device local memory using so-called "staging buffers". Uses a single pipeline with basic shaders loaded from SPIR-V and single uniform block for passing matrices that is updated on changing the view.
 
 This example is far more explicit than the other examples and is meant to be a starting point for learning Vulkan from the ground up. Much of the code is boilerplate that you'd usually encapsulate in helper functions and classes (which is what the other examples do).
 <br><br>
@@ -219,7 +219,7 @@ Demonstrates the use of a separate compute queue (and command buffer) to apply d
 ## [(Geometry shader) Normal debugging](geometryshader/)
 <img src="./screenshots/geom_normals.png" height="96px" align="right">
 
-Renders the vertex normals of a complex mesh with the use of a geometry shader. The mesh is rendered solid first and the a geometry shader that generates lines from the face normals is used in the second pass.
+Renders the vertex normals of a complex mesh with the use of a geometry shader. The mesh is rendered solid first and then a geometry shader that generates lines from the face normals is used in the second pass.
 <br><br>
 
 ## [Vulkan demo scene](vulkanscene/)

--- a/android/README.md
+++ b/android/README.md
@@ -5,7 +5,7 @@
 Since Vulkan is not yet part of the Android OS (like OpenGL ES) the library and function pointers need to be dynamically loaded before using any of the Vulkan functions. See the **vulkanandroid.h** and **vulkanandroid.cpp** files in the base folder of the repositoy root for how this is done.
 
 ## Device support
-- **To run these examples you need a device with an Android image that suports Vulkan**
+- **To run these examples you need a device with an Android image that supports Vulkan**
 - Builds currently only support arm-v7, x86 may follow at a later point
 - Android TV leanback launcher is supported, so the examples will show up on the launcher
 - Basic gamepad support is available too (zoom and rotate)

--- a/base/threadpool.hpp
+++ b/base/threadpool.hpp
@@ -89,7 +89,7 @@ namespace vkTools
 	public:
 		std::vector<std::unique_ptr<Thread>> threads;
 
-		// Sets the number of threads to be allocted in this pool
+		// Sets the number of threads to be allocated in this pool
 		void setThreadCount(uint32_t count)
 		{
 			threads.clear();

--- a/base/vulkanMeshLoader.hpp
+++ b/base/vulkanMeshLoader.hpp
@@ -81,7 +81,7 @@ namespace vkMeshLoader
 		return vSize;
 	}
 
-	// Stores some additonal info and functions for 
+	// Stores some additional info and functions for 
 	// specifying pipelines, vertex bindings, etc.
 	class Mesh
 	{

--- a/base/vulkanTextureLoader.hpp
+++ b/base/vulkanTextureLoader.hpp
@@ -100,7 +100,7 @@ namespace vkTools
 			texture->height = (uint32_t)tex2D[0].dimensions().y;
 			texture->mipLevels = tex2D.levels();
 
-			// Get device properites for the requested texture format
+			// Get device properties for the requested texture format
 			VkFormatProperties formatProperties;
 			vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 
@@ -458,7 +458,7 @@ namespace vkTools
 			texture->width = (uint32_t)texCube[0].dimensions().x;
 			texture->height = (uint32_t)texCube[0].dimensions().y;
 
-			// Get device properites for the requested texture format
+			// Get device properties for the requested texture format
 			VkFormatProperties formatProperties;
 			vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 
@@ -677,7 +677,7 @@ namespace vkTools
 			texture->height = tex2DArray.dimensions().y;
 			texture->layerCount = tex2DArray.layers();
 
-			// Get device properites for the requested texture format
+			// Get device properties for the requested texture format
 			VkFormatProperties formatProperties;
 			vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -20,7 +20,7 @@ VkResult VulkanExampleBase::createInstance(bool enableValidation)
 
 	std::vector<const char*> enabledExtensions = { VK_KHR_SURFACE_EXTENSION_NAME };
 
-	// Enable surface extensions depending on os
+	// Enable surface extensions depending on OS
 #if defined(_WIN32)
 	enabledExtensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #elif defined(__ANDROID__)
@@ -110,7 +110,7 @@ void VulkanExampleBase::createCommandBuffers()
 	// in the swap chain
 	// Command buffers store a reference to the
 	// frame buffer inside their render pass info
-	// so for static usage withouth having to rebuild
+	// so for static usage without having to rebuild
 	// them each frame, we use one per frame buffer
 
 	drawCmdBuffers.resize(swapChain.imageCount);
@@ -681,7 +681,7 @@ void VulkanExampleBase::initVulkan(bool enableValidation)
 	err = vkEnumeratePhysicalDevices(instance, &gpuCount, physicalDevices.data());
 	if (err)
 	{
-		vkTools::exitFatal("Could not enumerate phyiscal devices : \n" + vkTools::errorString(err), "Fatal error");
+		vkTools::exitFatal("Could not enumerate physical devices : \n" + vkTools::errorString(err), "Fatal error");
 	}
 
 	// Note :
@@ -739,11 +739,11 @@ void VulkanExampleBase::initVulkan(bool enableValidation)
 	// Create synchronization objects
 	VkSemaphoreCreateInfo semaphoreCreateInfo = vkTools::initializers::semaphoreCreateInfo();
 	// Create a semaphore used to synchronize image presentation
-	// Ensures that the image is displayed before we start submitting new commands to the queu
+	// Ensures that the image is displayed before we start submitting new commands to the queue
 	err = vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &semaphores.presentComplete);
 	assert(!err);
 	// Create a semaphore used to synchronize command submission
-	// Ensures that the image is not presented until all commands have been sumbitted and executed
+	// Ensures that the image is not presented until all commands have been submitted and executed
 	err = vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &semaphores.renderComplete);
 	assert(!err);
 
@@ -1174,12 +1174,12 @@ void VulkanExampleBase::handleEvent(const xcb_generic_event_t *event)
 
 void VulkanExampleBase::viewChanged()
 {
-	// Can be overrdiden in derived class
+	// Can be overridden in derived class
 }
 
 void VulkanExampleBase::keyPressed(uint32_t keyCode)
 {
-	// Can be overriden in derived class
+	// Can be overridden in derived class
 }
 
 VkBool32 VulkanExampleBase::getMemoryType(uint32_t typeBits, VkFlags properties, uint32_t * typeIndex)

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -60,7 +60,7 @@ protected:
 	uint32_t frameCounter = 0;
 	// Vulkan instance, stores all per-application states
 	VkInstance instance;
-	// Physical device (GPU) that Vulkan will ise
+	// Physical device (GPU) that Vulkan will use
 	VkPhysicalDevice physicalDevice;
 	// Stores physical device properties (for e.g. checking device limits)
 	VkPhysicalDeviceProperties deviceProperties;
@@ -112,7 +112,7 @@ protected:
 	} semaphores;
 	// Simple texture loader
 	vkTools::VulkanTextureLoader *textureLoader = nullptr;
-	// Returns the base asset path (for shaders, models, textures) depending on the os
+	// Returns the base asset path (for shaders, models, textures) depending on the OS
 	const std::string getAssetPath();
 public: 
 	bool prepared = false;
@@ -205,11 +205,11 @@ public:
 	// Pure virtual render function (override in derived class)
 	virtual void render() = 0;
 	// Called when view change occurs
-	// Can be overriden in derived class to e.g. update uniform buffers 
-	// Containing view dependant matrices
+	// Can be overridden in derived class to e.g. update uniform buffers 
+	// Containing view dependent matrices
 	virtual void viewChanged();
 	// Called if a key is pressed
-	// Can be overriden in derived class to do custom key handling
+	// Can be overridden in derived class to do custom key handling
 	virtual void keyPressed(uint32_t keyCode);
 
 	// Get memory type for a given memory allocation (flags and bits)
@@ -220,10 +220,10 @@ public:
 	// Setup default depth and stencil views
 	void setupDepthStencil();
 	// Create framebuffers for all requested swap chain images
-	// Can be overriden in derived class to setup a custom framebuffer (e.g. for MSAA)
+	// Can be overridden in derived class to setup a custom framebuffer (e.g. for MSAA)
 	virtual void setupFrameBuffer();
 	// Setup a default render pass
-	// Can be overriden in derived class to setup a custom render pass (e.g. for MSAA)
+	// Can be overridden in derived class to setup a custom render pass (e.g. for MSAA)
 	virtual void setupRenderPass();
 
 	// Connect and prepare the swap chain
@@ -240,7 +240,7 @@ public:
 	void destroyCommandBuffers();
 	// Create command buffer for setup commands
 	void createSetupCommandBuffer();
-	// Finalize setup command bufferm submit it to the queue and remove it
+	// Finalize setup command buffer, submit it to the queue and remove it
 	void flushSetupCommandBuffer();
 
 	// Create a cache pool for rendering pipelines

--- a/base/vulkanswapchain.hpp
+++ b/base/vulkanswapchain.hpp
@@ -83,10 +83,10 @@ public:
 	std::vector<VkImage> images;
 	std::vector<SwapChainBuffer> buffers;
 
-	// Index of the deteced graphics and presenting device queue
+	// Index of the detected graphics and presenting device queue
 	uint32_t queueNodeIndex = UINT32_MAX;
 
-	// Creates an os specific surface
+	// Creates an OS specific surface
 	// Tries to find a graphics and a present queue
 	void initSurface(
 #ifdef _WIN32
@@ -201,7 +201,7 @@ public:
 		assert(!err);
 
 		// If the surface format list only includes one entry with VK_FORMAT_UNDEFINED,
-		// there is no preferered format, so we assume VK_FORMAT_B8G8R8A8_UNORM
+		// there is no preferred format, so we assume VK_FORMAT_B8G8R8A8_UNORM
 		if ((formatCount == 1) && (surfaceFormats[0].format == VK_FORMAT_UNDEFINED))
 		{
 			colorFormat = VK_FORMAT_B8G8R8A8_UNORM;
@@ -217,7 +217,7 @@ public:
 		colorSpace = surfaceFormats[0].colorSpace;
 	}
 
-	// Connect to the instance und device and get all required function pointers
+	// Connect to the instance and device and get all required function pointers
 	void connect(VkInstance instance, VkPhysicalDevice physicalDevice, VkDevice device)
 	{
 		this->instance = instance;
@@ -327,7 +327,7 @@ public:
 		err = fpCreateSwapchainKHR(device, &swapchainCI, nullptr, &swapChain);
 		assert(!err);
 
-		// If an existing sawp chain is re-created, destroy the old swap chain
+		// If an existing swap chain is re-created, destroy the old swap chain
 		// This also cleans up all the presentable images
 		if (oldSwapchain != VK_NULL_HANDLE) 
 		{ 

--- a/base/vulkantools.cpp
+++ b/base/vulkantools.cpp
@@ -177,7 +177,7 @@ namespace vkTools
 		// Target layouts (new)
 
 		// New layout is transfer destination (copy, blit)
-		// Make sure any copyies to the image have been finished
+		// Make sure any copies to the image have been finished
 		if (newImageLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
 		{
 			imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -192,7 +192,7 @@ namespace vkTools
 		}
 
 		// New layout is color attachment
-		// Make sure any writes to the color buffer hav been finished
+		// Make sure any writes to the color buffer have been finished
 		if (newImageLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
 		{
 			imageMemoryBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;

--- a/base/vulkantools.h
+++ b/base/vulkantools.h
@@ -67,7 +67,7 @@ namespace vkTools
 
 	// Display error message and exit on fatal error
 	void exitFatal(std::string message, std::string caption);
-	// Load a text file (e.g. GLGL shader) into a std::string
+	// Load a text file (e.g. GLSL shader) into a std::string
 	std::string readTextFile(const char *fileName);
 	// Load a binary file into a buffer (e.g. SPIR-V)
 	char *readBinaryFile(const char *filename, size_t *psize);

--- a/bloom/bloom.cpp
+++ b/bloom/bloom.cpp
@@ -195,7 +195,7 @@ public:
 		textureLoader->destroyTexture(textures.cubemap);
 	}
 
-	// Preapre an empty texture as the blit target from 
+	// Prepare an empty texture as the blit target from 
 	// the offscreen framebuffer
 	void prepareTextureTarget(vkTools::VulkanTexture *tex, uint32_t width, uint32_t height, VkFormat format)
 	{
@@ -204,7 +204,7 @@ public:
 		VkFormatProperties formatProperties;
 		VkResult err;
 
-		// Get device properites for the requested texture format
+		// Get device properties for the requested texture format
 		vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 		// Check if blit destination is supported for the requested format
 		// Only try for optimal tiling, linear tiling usually won't support blit as destination anyway
@@ -715,7 +715,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Gather command buffers to be sumitted to the queue
+		// Gather command buffers to be submitted to the queue
 		std::vector<VkCommandBuffer> submitCmdBuffers;
 		// Submit offscreen rendering command buffer 
 		if (bloom)
@@ -746,7 +746,7 @@ public:
 		loadMesh(getAssetPath() + "models/cube.obj", &meshes.skyBox, vertexLayout, 1.0f);
 	}
 
-	// Setup vertices for a single uv-mapped quad
+	// Setup vertices for a single UV-mapped quad
 	void generateQuad()
 	{
 		struct Vertex {
@@ -868,7 +868,7 @@ public:
 				VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
 				VK_SHADER_STAGE_FRAGMENT_BIT,
 				1),
-			// Binding 2 : Framgnet shader image sampler
+			// Binding 2 : Fragment shader image sampler
 			vkTools::initializers::descriptorSetLayoutBinding(
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 				VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -1180,7 +1180,7 @@ public:
 			&uniformData.vsSkyBox.memory,
 			&uniformData.vsSkyBox.descriptor);
 
-		// Intialize uniform buffers
+		// Initialize uniform buffers
 		updateUniformBuffersScene();
 		updateUniformBuffersScreen();
 	}

--- a/computeparticles/computeparticles.cpp
+++ b/computeparticles/computeparticles.cpp
@@ -230,7 +230,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -319,7 +319,7 @@ public:
 		vkUnmapMemory(device, stagingBuffer.memory);
 		vkTools::checkResult(vkBindBufferMemory(device, stagingBuffer.buffer, stagingBuffer.memory, 0));
 
-		// Allocate device local storage buffer ojbect
+		// Allocate device local storage buffer object
 		vBufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 		vkTools::checkResult(vkCreateBuffer(device, &vBufferInfo, nullptr, &computeStorageBuffer.buffer));
 		vkGetBufferMemoryRequirements(device, computeStorageBuffer.buffer, &memReqs);

--- a/computeshader/computeshader.cpp
+++ b/computeshader/computeshader.cpp
@@ -313,7 +313,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -341,7 +341,7 @@ public:
 		assert(!err);
 	}
 
-	// Setup vertices for a single uv-mapped quad
+	// Setup vertices for a single UV-mapped quad
 	void generateQuad()
 	{
 #define dim 1.0f

--- a/data/shaders/multithreading/starsphere.frag
+++ b/data/shaders/multithreading/starsphere.frag
@@ -21,11 +21,11 @@ float hash33(vec3 p3)
 float starField(vec3 pos)
 {
 	vec3 color = vec3(0.0);
-    float threshhold = (1.0 - STARFREQUENCY);
+    float threshold = (1.0 - STARFREQUENCY);
     float rnd = hash33(pos);
-    if (rnd >= threshhold)
+    if (rnd >= threshold)
     {
-        float starCol = pow((rnd - threshhold) / (1.0 - threshhold), 16.0);
+        float starCol = pow((rnd - threshold) / (1.0 - threshold), 16.0);
 		color += vec3(starCol);
     }	
 	return color;

--- a/deferred/deferred.cpp
+++ b/deferred/deferred.cpp
@@ -193,7 +193,7 @@ public:
 		textureLoader->destroyTexture(textures.colorMap);
 	}
 
-	// Preapre an empty texture as the blit target from 
+	// Prepare an empty texture as the blit target from 
 	// the offscreen framebuffer
 	void prepareTextureTarget(vkTools::VulkanTexture *target, VkFormat format)
 	{
@@ -581,7 +581,7 @@ public:
 
 		VkCommandBufferBeginInfo cmdBufInfo = vkTools::initializers::commandBufferBeginInfo();
 
-		// Clear values for all attachments written in the fragment sahder
+		// Clear values for all attachments written in the fragment shader
 		std::array<VkClearValue,4> clearValues;
 		clearValues[0].color = { { 0.0f, 0.0f, 0.0f, 0.0f } };
 		clearValues[1].color = { { 0.0f, 0.0f, 0.0f, 0.0f } };
@@ -732,7 +732,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Gather command buffers to be sumitted to the queue
+		// Gather command buffers to be submitted to the queue
 		std::vector<VkCommandBuffer> submitCmdBuffers = {
 			offScreenCmdBuffer,
 			drawCmdBuffers[currentBuffer],

--- a/displacement/displacement.cpp
+++ b/displacement/displacement.cpp
@@ -214,7 +214,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -283,7 +283,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses two ubos and two image samplers
+		// Example uses two UBOs and two image samplers
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2),
@@ -304,12 +304,12 @@ public:
 	{
 		std::vector<VkDescriptorSetLayoutBinding> setLayoutBindings =
 		{
-			// Binding 0 : Tessellation control shader ubo
+			// Binding 0 : Tessellation control shader UBO
 			vkTools::initializers::descriptorSetLayoutBinding(
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 
 				VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, 
 				0),
-			// Binding 1 : Tessellation evaluation shader ubo
+			// Binding 1 : Tessellation evaluation shader UBO
 			vkTools::initializers::descriptorSetLayoutBinding(
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 				VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, 
@@ -370,13 +370,13 @@ public:
 
 		std::vector<VkWriteDescriptorSet> writeDescriptorSets =
 		{
-			// Binding 0 : Tessellation control shader ubo
+			// Binding 0 : Tessellation control shader UBO
 			vkTools::initializers::writeDescriptorSet(
 				descriptorSet, 
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 
 				0, 
 				&uniformDataTC.descriptor),
-			// Binding 1 : Tessellation evaluation shader ubo
+			// Binding 1 : Tessellation evaluation shader UBO
 			vkTools::initializers::writeDescriptorSet(
 				descriptorSet, 
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,

--- a/distancefieldfonts/distancefieldfonts.cpp
+++ b/distancefieldfonts/distancefieldfonts.cpp
@@ -304,7 +304,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -659,7 +659,7 @@ public:
 			&uniformData.vs.memory,
 			&uniformData.vs.descriptor);
 
-		// Fragment sahder uniform buffer block
+		// Fragment shader uniform buffer block
 		// Contains font rendering parameters
 		createBuffer(
 			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,

--- a/documentation/examplebaseclass.md
+++ b/documentation/examplebaseclass.md
@@ -20,7 +20,7 @@ class MyVulkanExample : public VulkanExampleBase
 }
 ```
 ##### Validation layers
-The example base class offers a constructor overload for enabling a default set of Vulkan validation layers (for debugging purposes). If you want to use this functionality, simply use the construtor override :
+The example base class offers a constructor overload for enabling a default set of Vulkan validation layers (for debugging purposes). If you want to use this functionality, simply use the constructor override :
 ```cpp
 VulkanExample() : VulkanExampleBase(true)
 {

--- a/gears/gears.cpp
+++ b/gears/gears.cpp
@@ -132,7 +132,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 

--- a/geometryshader/geometryshader.cpp
+++ b/geometryshader/geometryshader.cpp
@@ -169,7 +169,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -239,7 +239,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses two ubos
+		// Example uses two UBOs
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2),
@@ -259,12 +259,12 @@ public:
 	{
 		std::vector<VkDescriptorSetLayoutBinding> setLayoutBindings =
 		{
-			// Binding 0 : Vertex shader ubo
+			// Binding 0 : Vertex shader UBO
 			vkTools::initializers::descriptorSetLayoutBinding(
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 				VK_SHADER_STAGE_VERTEX_BIT,
 				0),
-			// Binding 1 : Geometry shader ubo
+			// Binding 1 : Geometry shader UBO
 			vkTools::initializers::descriptorSetLayoutBinding(
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 				VK_SHADER_STAGE_GEOMETRY_BIT,
@@ -301,13 +301,13 @@ public:
 
 		std::vector<VkWriteDescriptorSet> writeDescriptorSets =
 		{
-			// Binding 0 : Vertex shader shader ubo
+			// Binding 0 : Vertex shader UBO
 			vkTools::initializers::writeDescriptorSet(
 				descriptorSet,
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 				0,
 				&uniformData.VS.descriptor),
-			// Binding 1 : Geometry shader ubo
+			// Binding 1 : Geometry shader UBO
 			vkTools::initializers::writeDescriptorSet(
 				descriptorSet,
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,

--- a/instancing/instancing.cpp
+++ b/instancing/instancing.cpp
@@ -65,7 +65,7 @@ public:
 			glm::mat4 projection;
 			glm::mat4 view;
 		} matrices;
-		// Seperate data for each instance
+		// Separate data for each instance
 		UboInstanceData *instance;		
 	} uboVS;
 
@@ -178,7 +178,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -251,7 +251,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo 
+		// Example uses one UBO 
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1),
@@ -366,7 +366,7 @@ public:
 				dynamicStateEnables.size(),
 				0);
 
-		// Instacing pipeline
+		// Instancing pipeline
 		// Load shaders
 		std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages;
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -180,7 +180,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -319,7 +319,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo and one combined image sampler
+		// Example uses one UBO and one combined image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1),

--- a/models/README.md
+++ b/models/README.md
@@ -36,7 +36,7 @@ A test scene with a high triangle count made up by all the single models listed 
 
 **As with the Vulkan Logo:** Please regard Khronos' [API logo usage and word mark guidelines](https://www.khronos.org/legal/trademarks/) when using this!
 
-If you plan on using this for anything public I'd love know, sp please let me know!
+If you plan on using this for anything public I'd love know, so please let me know!
 
 
 ## Vulkan Logo
@@ -76,7 +76,7 @@ Based on the Stanford Dragon : http://graphics.stanford.edu/data/3Dscanrep/
 
 (Please read their note on [inappropriate uses for this model](http://graphics.stanford.edu/data/3Dscanrep/#uses))
 
-I did some optimizations on the model to lower the triangle count without loosing too mich detail and put some spheres in for the eyes and under the claw to make them pop out a bit more.
+I did some optimizations on the model to lower the triangle count without losing too much detail and put some spheres in for the eyes and under the claw to make them pop out a bit more.
 
 Triangle count : 102,880
 

--- a/multisampling/multisampling.cpp
+++ b/multisampling/multisampling.cpp
@@ -214,7 +214,7 @@ public:
 	}
 
 	// Setup a render pass for using a multi sampled attachment 
-	// and a resolve attachment that the msaa image is resolved 
+	// and a resolve attachment that the MSAA image is resolved 
 	// to at the end of the render pass
 	void setupRenderPass()
 	{
@@ -339,7 +339,7 @@ public:
 
 		createSetupCommandBuffer();
 
-		// Tansform MSAA color target
+		// Transform MSAA color target
 		vkTools::setImageLayout(
 			setupCmdBuffer,
 			multisampleTarget.color.image,
@@ -347,7 +347,7 @@ public:
 			VK_IMAGE_LAYOUT_UNDEFINED,
 			VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
-		// Tansform MSAA depth target
+		// Transform MSAA depth target
 		vkTools::setImageLayout(
 			setupCmdBuffer,
 			multisampleTarget.depth.image,
@@ -408,7 +408,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -485,7 +485,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo and one combined image sampler
+		// Example uses one UBO and one combined image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1),

--- a/multithreading/multithreading.cpp
+++ b/multithreading/multithreading.cpp
@@ -107,7 +107,7 @@ public:
 
 	vkTools::ThreadPool threadPool;
 
-	// Max. dimension of the ufo mesh for use as the sphere
+	// Max. dimension of the UFO mesh for use as the sphere
 	// radius for frustum culling
 	float objectSphereDim;
 
@@ -121,7 +121,7 @@ public:
 		rotationSpeed = 0.5f;
 		rotation = { 0.0f, 37.5f, 0.0f };
 		title = "Vulkan Example - Multi threaded rendering";
-		// Get number of max. concurrrent threads
+		// Get number of max. concurrent threads
 		numThreads = std::thread::hardware_concurrency();
 		assert(numThreads > 0);
 #if defined(__ANDROID__)

--- a/occlusionquery/occlusionquery.cpp
+++ b/occlusionquery/occlusionquery.cpp
@@ -1,5 +1,5 @@
 /*
-* Vulkan Example - Using occlusion query for visbility testing
+* Vulkan Example - Using occlusion query for visibility testing
 *
 * Copyright (C) 2016 by Sascha Willems - www.saschawillems.de
 *
@@ -333,7 +333,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 

--- a/offscreen/offscreen.cpp
+++ b/offscreen/offscreen.cpp
@@ -109,7 +109,7 @@ public:
 		int32_t width, height;
 		VkFramebuffer frameBuffer;		
 		FrameBufferAttachment color, depth;
-		// Texture target for framebugger blut
+		// Texture target for framebuffer blit
 		vkTools::VulkanTexture textureTarget;
 	} offScreenFrameBuf;
 
@@ -171,7 +171,7 @@ public:
 		vkFreeCommandBuffers(device, cmdPool, 1, &offScreenCmdBuffer);
 	}
 
-	// Preapre an empty texture as the blit target from 
+	// Prepare an empty texture as the blit target from 
 	// the offscreen framebuffer
 	void prepareTextureTarget(uint32_t width, uint32_t height, VkFormat format)
 	{
@@ -180,7 +180,7 @@ public:
 		VkFormatProperties formatProperties;
 		VkResult err;
 
-		// Get device properites for the requested texture format
+		// Get device properties for the requested texture format
 		vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 		// Check if blit destination is supported for the requested format
 		// Only try for optimal tiling, linear tiling usually won't support blit as destination anyway
@@ -507,7 +507,7 @@ public:
 			VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
 		// Transform texture target back to shader read
-		// Makes sure that writes to the textuer are finished before
+		// Makes sure that writes to the texture are finished before
 		// it's accessed in the shader
 		vkTools::setImageLayout(
 			offScreenCmdBuffer,
@@ -610,7 +610,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Gather command buffers to be sumitted to the queue
+		// Gather command buffers to be submitted to the queue
 		std::vector<VkCommandBuffer> submitCmdBuffers = {
 			offScreenCmdBuffer,
 			drawCmdBuffers[currentBuffer],
@@ -647,7 +647,7 @@ public:
 
 	void generateQuad()
 	{
-		// Setup vertices for a single uv-mapped quad
+		// Setup vertices for a single UV-mapped quad
 		struct Vertex {
 			float pos[3];
 			float uv[2];

--- a/parallaxmapping/parallaxmapping.cpp
+++ b/parallaxmapping/parallaxmapping.cpp
@@ -221,7 +221,7 @@ void reBuildCommandBuffers()
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -301,7 +301,7 @@ void reBuildCommandBuffers()
 
 	void setupDescriptorPool()
 	{
-		// Example uses two ubos and two image sampler
+		// Example uses two UBOs and two image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2),
@@ -500,7 +500,7 @@ void reBuildCommandBuffers()
 
 	void prepareUniformBuffers()
 	{
-		// Vertex shader ubo
+		// Vertex shader UBO
 		createBuffer(
 			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
 			sizeof(ubos.vertexShader),
@@ -509,7 +509,7 @@ void reBuildCommandBuffers()
 			&uniformData.vertexShader.memory,
 			&uniformData.vertexShader.descriptor);
 
-		// Fragment shader ubo
+		// Fragment shader UBO
 		createBuffer(
 			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
 			sizeof(ubos.fragmentShader),

--- a/particlefire/particlefire.cpp
+++ b/particlefire/particlefire.cpp
@@ -61,7 +61,7 @@ public:
 			vkTools::VulkanTexture smoke;
 			vkTools::VulkanTexture fire;
 			// We use a custom sampler to change some sampler
-			// attributes required for rotation the uv coordinates
+			// attributes required for rotation the UV coordinates
 			// inside the shader for alpha blended textures
 			VkSampler sampler;
 		} particles;
@@ -231,7 +231,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -473,7 +473,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo and one image sampler
+		// Example uses one UBO and one image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2),
@@ -691,7 +691,7 @@ public:
 
 		depthStencilState.depthWriteEnable = VK_FALSE;
 
-		// Premulitplied alpha
+		// Premultiplied alpha
 		blendAttachmentState.blendEnable = VK_TRUE;
 		blendAttachmentState.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
 		blendAttachmentState.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;

--- a/pipelines/pipelines.cpp
+++ b/pipelines/pipelines.cpp
@@ -189,7 +189,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -206,7 +206,7 @@ public:
 		assert(!err);
 	}
 
-	// Create vertices and buffers for uv mapped cube
+	// Create vertices and buffers for UV mapped cube
 	void generateCube()
 	{
 
@@ -325,7 +325,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo and one combined image sampler 
+		// Example uses one UBO and one combined image sampler 
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1),

--- a/pushconstants/pushconstants.cpp
+++ b/pushconstants/pushconstants.cpp
@@ -208,7 +208,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -281,7 +281,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo 
+		// Example uses one UBO 
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1),

--- a/radialblur/radialblur.cpp
+++ b/radialblur/radialblur.cpp
@@ -171,7 +171,7 @@ public:
 		vkFreeCommandBuffers(device, cmdPool, 1, &offScreenCmdBuffer);
 	}
 
-	// Preapre an empty texture as the blit target from 
+	// Prepare an empty texture as the blit target from 
 	// the offscreen framebuffer
 	void prepareTextureTarget(vkTools::VulkanTexture *tex, uint32_t width, uint32_t height, VkFormat format)
 	{
@@ -180,7 +180,7 @@ public:
 		VkFormatProperties formatProperties;
 		VkResult err;
 
-		// Get device properites for the requested texture format
+		// Get device properties for the requested texture format
 		vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 		// Check if blit destination is supported for the requested format
 		// Only try for optimal tiling, linear tiling usually won't support blit as destination anyway
@@ -604,7 +604,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Gather command buffers to be sumitted to the queue
+		// Gather command buffers to be submitted to the queue
 		std::vector<VkCommandBuffer> submitCmdBuffers = {
 			offScreenCmdBuffer,
 			drawCmdBuffers[currentBuffer],
@@ -630,7 +630,7 @@ public:
 		loadMesh(getAssetPath() + "models/glowsphere.dae", &meshes.example, vertexLayout, 0.05f);
 	}
 
-	// Setup vertices for a single uv-mapped quad
+	// Setup vertices for a single UV-mapped quad
 	void generateQuad()
 	{
 		struct Vertex {
@@ -719,7 +719,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses three ubos and one image sampler
+		// Example uses three UBOs and one image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 4),

--- a/raytracing/raytracing.cpp
+++ b/raytracing/raytracing.cpp
@@ -286,7 +286,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -314,7 +314,7 @@ public:
 		assert(!err);
 	}
 
-	// Setup vertices for a single uv-mapped quad
+	// Setup vertices for a single UV-mapped quad
 	void generateQuad()
 	{
 #define dim 1.0f

--- a/shadowmapping/shadowmapping.cpp
+++ b/shadowmapping/shadowmapping.cpp
@@ -188,7 +188,7 @@ public:
 		vkFreeCommandBuffers(device, cmdPool, 1, &offScreenCmdBuffer);
 	}
 
-	// Preapre an empty texture as the blit target from 
+	// Prepare an empty texture as the blit target from 
 	// the offscreen framebuffer
 	void prepareTextureTarget(uint32_t width, uint32_t height, VkFormat format)
 	{
@@ -196,7 +196,7 @@ public:
 
 		VkResult err;
 
-		// Get device properites for the requested texture format
+		// Get device properties for the requested texture format
 		VkFormatProperties formatProperties;
 		vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 		// Check if format is supported for optimal tiling
@@ -590,7 +590,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Gather command buffers to be sumitted to the queue
+		// Gather command buffers to be submitted to the queue
 		std::vector<VkCommandBuffer> submitCmdBuffers = {
 			offScreenCmdBuffer,
 			drawCmdBuffers[currentBuffer],
@@ -618,7 +618,7 @@ public:
 
 	void generateQuad()
 	{
-		// Setup vertices for a single uv-mapped quad
+		// Setup vertices for a single UV-mapped quad
 		struct Vertex {
 			float pos[3];
 			float uv[2];
@@ -705,7 +705,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses three ubos and two image samplers
+		// Example uses three UBOs and two image samplers
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 6),
@@ -956,7 +956,7 @@ public:
 			&uniformDataVS.memory,
 			&uniformDataVS.descriptor);
 
-		// Offsvreen vertex shader uniform buffer block
+		// Offscreen vertex shader uniform buffer block
 		createBuffer(
 			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
 			sizeof(uboOffscreenVS),
@@ -1103,7 +1103,7 @@ public:
 			VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 
 		// Transform texture target back to shader read
-		// Makes sure that writes to the textuer are finished before
+		// Makes sure that writes to the texture are finished before
 		// it's accessed in the shader
 		vkTools::setImageLayout(
 			offScreenCmdBuffer,

--- a/shadowmappingomni/shadowmappingomni.cpp
+++ b/shadowmappingomni/shadowmappingomni.cpp
@@ -153,7 +153,7 @@ public:
 
 		vkDestroyFramebuffer(device, offScreenFrameBuf.frameBuffer, nullptr);
 
-		// Pipelibes
+		// Pipelines
 		vkDestroyPipeline(device, pipelines.scene, nullptr);
 		vkDestroyPipeline(device, pipelines.offscreen, nullptr);
 		vkDestroyPipeline(device, pipelines.cubeMap, nullptr);
@@ -250,7 +250,7 @@ public:
 
 		VkFence nullFence = { VK_NULL_HANDLE };
 
-		// Submit command buffer to graphis queue
+		// Submit command buffer to graphics queue
 		VkSubmitInfo submitInfo = vkTools::initializers::submitInfo();
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &cmdBuffer;
@@ -691,7 +691,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Gather command buffers to be sumitted to the queue
+		// Gather command buffers to be submitted to the queue
 		std::vector<VkCommandBuffer> submitCmdBuffers = {
 			offScreenCmdBuffer,
 			drawCmdBuffers[currentBuffer],
@@ -768,7 +768,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses three ubos and two image samplers
+		// Example uses three UBOs and two image samplers
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 3),

--- a/skeletalanimation/skeletalanimation.cpp
+++ b/skeletalanimation/skeletalanimation.cpp
@@ -95,7 +95,7 @@ public:
 		std::vector<BoneInfo> boneInfo;
 		// Number of bones present
 		uint32_t numBones = 0;
-		// Root inverese transform matrix
+		// Root inverse transform matrix
 		aiMatrix4x4 globalInverseTransform;
 		// Per-vertex bone info
 		std::vector<VertexBoneData> bones;
@@ -232,7 +232,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -619,7 +619,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo and one combined image sampler
+		// Example uses one UBO and one combined image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1),

--- a/sphericalenvmapping/sphericalenvmapping.cpp
+++ b/sphericalenvmapping/sphericalenvmapping.cpp
@@ -179,7 +179,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -252,7 +252,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo and one image sampler
+		// Example uses one UBO and one image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1),

--- a/tessellation/tessellation.cpp
+++ b/tessellation/tessellation.cpp
@@ -200,7 +200,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -277,7 +277,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses two ubos and one combined image sampler
+		// Example uses two UBOs and one combined image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2),
@@ -298,12 +298,12 @@ public:
 	{
 		std::vector<VkDescriptorSetLayoutBinding> setLayoutBindings =
 		{
-			// Binding 0 : Tessellation control shader ubo
+			// Binding 0 : Tessellation control shader UBO
 			vkTools::initializers::descriptorSetLayoutBinding(
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 				VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
 				0),
-			// Binding 1 : Tessellation evaluation shader ubo
+			// Binding 1 : Tessellation evaluation shader UBO
 			vkTools::initializers::descriptorSetLayoutBinding(
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 				VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
@@ -351,13 +351,13 @@ public:
 
 		std::vector<VkWriteDescriptorSet> writeDescriptorSets =
 		{
-			// Binding 0 : Tessellation control shader ubo
+			// Binding 0 : Tessellation control shader UBO
 			vkTools::initializers::writeDescriptorSet(
 			descriptorSet,
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 				0,
 				&uniformDataTC.descriptor),
-			// Binding 1 : Tessellation evaluation shader ubo
+			// Binding 1 : Tessellation evaluation shader UBO
 			vkTools::initializers::writeDescriptorSet(
 				descriptorSet,
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,

--- a/texture/texture.cpp
+++ b/texture/texture.cpp
@@ -201,7 +201,7 @@ public:
 		texture.height = tex2D[0].dimensions().y;
 		texture.mipLevels = tex2D.levels();
 
-		// Get device properites for the requested texture format
+		// Get device properties for the requested texture format
 		vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 
 		// Only use linear tiling if requested (and supported by the device)
@@ -564,7 +564,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -583,7 +583,7 @@ public:
 
 	void generateQuad()
 	{
-		// Setup vertices for a single uv-mapped quad
+		// Setup vertices for a single UV-mapped quad
 #define dim 1.0f
 		std::vector<Vertex> vertexBuffer =
 		{
@@ -649,7 +649,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo and one image sampler
+		// Example uses one UBO and one image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1),

--- a/texturearray/texturearray.cpp
+++ b/texturearray/texturearray.cpp
@@ -66,7 +66,7 @@ public:
 			glm::mat4 projection;
 			glm::mat4 view;
 		} matrices;
-		// Seperate data for each instance
+		// Separate data for each instance
 		UboInstanceData *instance;		
 	} uboVS;
 
@@ -135,7 +135,7 @@ public:
 		textureArray.height = tex2DArray.dimensions().y;
 		layerCount = tex2DArray.layers();
 
-		// Get device properites for the requested texture format
+		// Get device properties for the requested texture format
 		VkFormatProperties formatProperties;
 		vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 
@@ -296,7 +296,7 @@ public:
 
 		VkFence nullFence = { VK_NULL_HANDLE };
 
-		// Submit command buffer to graphis queue
+		// Submit command buffer to graphics queue
 		VkSubmitInfo submitInfo = vkTools::initializers::submitInfo();
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &cmdBuffer;
@@ -420,7 +420,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -437,7 +437,7 @@ public:
 		assert(!err);
 	}
 
-	// Setup vertices for a single uv-mapped quad
+	// Setup vertices for a single UV-mapped quad
 	void generateQuad()
 	{
 #define dim 2.5f
@@ -641,7 +641,7 @@ public:
 				dynamicStateEnables.size(),
 				0);
 
-		// Instacing pipeline
+		// Instancing pipeline
 		// Load shaders
 		std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages;
 

--- a/texturecubemap/texturecubemap.cpp
+++ b/texturecubemap/texturecubemap.cpp
@@ -127,7 +127,7 @@ public:
 		cubeMap.width = texCube[0].dimensions().x;
 		cubeMap.height = texCube[0].dimensions().y;
 
-		// Get device properites for the requested texture format
+		// Get device properties for the requested texture format
 		VkFormatProperties formatProperties;
 		vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
 
@@ -291,7 +291,7 @@ public:
 
 		VkFence nullFence = { VK_NULL_HANDLE };
 
-		// Submit command buffer to graphis queue
+		// Submit command buffer to graphics queue
 		VkSubmitInfo submitInfo = vkTools::initializers::submitInfo();
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &cmdBuffer;
@@ -415,7 +415,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -675,7 +675,7 @@ public:
 	// Prepare and initialize uniform buffer containing shader uniforms
 	void prepareUniformBuffers()
 	{
-		// 3D objact 
+		// 3D object 
 		createBuffer(
 			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
 			sizeof(uboVS),

--- a/triangle/triangle.cpp
+++ b/triangle/triangle.cpp
@@ -263,7 +263,7 @@ public:
 		err = vkQueueWaitIdle(queue);
 		assert(!err);
 
-		// The submit infor strcuture contains a list of
+		// The submit info structure contains a list of
 		// command buffers and semaphores to be submitted to a queue
 		// If you want to submit multiple command buffers, pass an array
 		VkPipelineStageFlags pipelineStages = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
@@ -271,7 +271,7 @@ public:
 		submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 		submitInfo.pWaitDstStageMask = &pipelineStages;
 		// The wait semaphore ensures that the image is presented 
-		// before we start submitting command buffers agein
+		// before we start submitting command buffers again
 		submitInfo.waitSemaphoreCount = 1;
 		submitInfo.pWaitSemaphores = &semaphores.presentComplete;
 		// Submit the currently active command buffer
@@ -295,7 +295,7 @@ public:
 		assert(!err);
 	}
 
-	// Create synchronzation semaphores
+	// Create synchronization semaphores
 	void prepareSemaphore()
 	{
 		VkSemaphoreCreateInfo semaphoreCreateInfo = {};
@@ -671,7 +671,7 @@ public:
 		pipelineCreateInfo.renderPass = renderPass;
 
 		// Vertex input state
-		// Describes the topoloy used with this pipeline
+		// Describes the topology used with this pipeline
 		VkPipelineInputAssemblyStateCreateInfo inputAssemblyState = {};
 		inputAssemblyState.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
 		// This pipeline renders vertex data as triangle lists
@@ -724,7 +724,7 @@ public:
 		dynamicState.dynamicStateCount = dynamicStateEnables.size();
 
 		// Depth and stencil state
-		// Describes depth and stenctil test and compare ops
+		// Describes depth and stencil test and compare ops
 		VkPipelineDepthStencilStateCreateInfo depthStencilState = {};
 		// Basic depth compare setup with depth writes and depth test enabled
 		// No stencil used 
@@ -747,7 +747,7 @@ public:
 		multisampleState.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
 		// Load shaders
-		// Shaders are loaded from the SPIR-V format, which can be generated from glsl
+		// Shaders are loaded from the SPIR-V format, which can be generated from GLSL
 		std::array<VkPipelineShaderStageCreateInfo,2> shaderStages;
 		shaderStages[0] = loadShader(getAssetPath() + "shaders/triangle.vert.spv", VK_SHADER_STAGE_VERTEX_BIT);
 		shaderStages[1] = loadShader(getAssetPath() + "shaders/triangle.frag.spv", VK_SHADER_STAGE_FRAGMENT_BIT);

--- a/vulkanscene/vulkanscene.cpp
+++ b/vulkanscene/vulkanscene.cpp
@@ -1,7 +1,7 @@
 /*
 * Vulkan Demo Scene 
 *
-* Don't take this a an example, it's more of a personal playground
+* Don't take this as an example, it's more of a personal playground
 *
 * Copyright (C) 2016 by Sascha Willems - www.saschawillems.de
 *
@@ -188,7 +188,7 @@ public:
 
 		submitPostPresentBarrier(swapChain.buffers[currentBuffer].image);
 
-		// Command buffer to be sumitted to the queue
+		// Command buffer to be submitted to the queue
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &drawCmdBuffers[currentBuffer];
 
@@ -347,7 +347,7 @@ public:
 
 	void setupDescriptorPool()
 	{
-		// Example uses one ubo and one image sampler
+		// Example uses one UBO and one image sampler
 		std::vector<VkDescriptorPoolSize> poolSizes =
 		{
 			vkTools::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2),


### PR DESCRIPTION
Most of those are spelling fixes, but I took the liberty of uppercasing acronyms like `OS`, `UBO`, `MSAA`, etc.

I can't guarantee no mistake is left, but at least there are 153 fewer now :stuck_out_tongue_winking_eye:
