### PR TITLE
Add use of VK_EXT_debug_marker

### DIFF
--- a/base/vulkandebug.cpp
+++ b/base/vulkandebug.cpp
@@ -88,4 +88,138 @@ namespace vkDebug
 			// DestroyDebugReportCallback(instance, msgCallback, nullptr);
 		}
 	}
+
+	PFN_vkDebugMarkerSetObjectNameEXT DebugMarkerSetObjectName = NULL;
+	PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBegin = NULL;
+	PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEnd = NULL;
+	PFN_vkCmdDebugMarkerInsertEXT CmdDebugMarkerInsert = NULL;
+
+	// Set up the debug marker function pointers
+	void setupDebugMarkers(VkDevice device)
+	{
+		DebugMarkerSetObjectName = (PFN_vkDebugMarkerSetObjectNameEXT)vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT");
+		CmdDebugMarkerBegin = (PFN_vkCmdDebugMarkerBeginEXT)vkGetDeviceProcAddr(device, "vkCmdDebugMarkerBeginEXT");
+		CmdDebugMarkerEnd = (PFN_vkCmdDebugMarkerEndEXT)vkGetDeviceProcAddr(device, "vkCmdDebugMarkerEndEXT");
+		CmdDebugMarkerInsert = (PFN_vkCmdDebugMarkerInsertEXT)vkGetDeviceProcAddr(device, "vkCmdDebugMarkerInsertEXT");
+	}
+
+	void insertDebugMarker(
+		VkCommandBuffer cmdbuffer,
+		const char* pMarkerName,
+		float color[4])
+	{
+		// need to check if the function pointer is valid - extension might not be present
+		if (CmdDebugMarkerInsert)
+		{
+			VkDebugMarkerMarkerInfoEXT markerInfo = {};
+			markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
+			memcpy(markerInfo.color, color, sizeof(float)*4);
+			markerInfo.pMarkerName = pMarkerName;
+			CmdDebugMarkerInsert(cmdbuffer, &markerInfo);
+		}
+	}
+
+	void insertDebugMarker(
+		VkCommandBuffer cmdbuffer,
+		const char* pMarkerName)
+	{
+		// need to check if the function pointer is valid - extension might not be present
+		if (CmdDebugMarkerInsert)
+		{
+			VkDebugMarkerMarkerInfoEXT markerInfo = {};
+			markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
+			markerInfo.pMarkerName = pMarkerName;
+			CmdDebugMarkerInsert(cmdbuffer, &markerInfo);
+		}
+	}
+
+	DebugMarkerRegion::DebugMarkerRegion(VkCommandBuffer cmdbuffer,
+		const char* pMarkerName,
+		float color[4])
+	{
+		cmd = cmdbuffer;
+		// need to check if the function pointer is valid - extension might not be present
+		if (CmdDebugMarkerBegin)
+		{
+			VkDebugMarkerMarkerInfoEXT markerInfo = {};
+			markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
+			memcpy(markerInfo.color, color, sizeof(float)*4);
+			markerInfo.pMarkerName = pMarkerName;
+			CmdDebugMarkerBegin(cmd, &markerInfo);
+		}
+	}
+
+	DebugMarkerRegion::DebugMarkerRegion(VkCommandBuffer cmdbuffer,
+		const char* pMarkerName)
+	{
+		cmd = cmdbuffer;
+		// need to check if the function pointer is valid - extension might not be present
+		if (CmdDebugMarkerBegin)
+		{
+			VkDebugMarkerMarkerInfoEXT markerInfo = {};
+			markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
+			markerInfo.pMarkerName = pMarkerName;
+			CmdDebugMarkerBegin(cmd, &markerInfo);
+		}
+	}
+
+	DebugMarkerRegion::~DebugMarkerRegion()
+	{
+		// need to check if the function pointer is valid - extension might not be present
+		if (CmdDebugMarkerEnd)
+			CmdDebugMarkerEnd(cmd);
+	}
+
+	// we specialise this template for each object type
+	template<typename VulkanType>
+	VkDebugReportObjectTypeEXT GetObjectTypeEnum(VulkanType object);
+
+#define OBJECT_TYPE(enumName, objectType) template<> VkDebugReportObjectTypeEXT GetObjectTypeEnum(objectType o) { (void)o; return VK_DEBUG_REPORT_OBJECT_TYPE_ ##enumName ##_EXT; }
+	OBJECT_TYPE(INSTANCE, VkInstance);
+	OBJECT_TYPE(PHYSICAL_DEVICE, VkPhysicalDevice);
+	OBJECT_TYPE(DEVICE, VkDevice);
+	OBJECT_TYPE(QUEUE, VkQueue);
+	OBJECT_TYPE(SEMAPHORE, VkSemaphore);
+	OBJECT_TYPE(COMMAND_BUFFER, VkCommandBuffer);
+	OBJECT_TYPE(FENCE, VkFence);
+	OBJECT_TYPE(DEVICE_MEMORY, VkDeviceMemory);
+	OBJECT_TYPE(BUFFER, VkBuffer);
+	OBJECT_TYPE(IMAGE, VkImage);
+	OBJECT_TYPE(EVENT, VkEvent);
+	OBJECT_TYPE(QUERY_POOL, VkQueryPool);
+	OBJECT_TYPE(BUFFER_VIEW, VkBufferView);
+	OBJECT_TYPE(IMAGE_VIEW, VkImageView);
+	OBJECT_TYPE(SHADER_MODULE, VkShaderModule);
+	OBJECT_TYPE(PIPELINE_CACHE, VkPipelineCache);
+	OBJECT_TYPE(PIPELINE_LAYOUT, VkPipelineLayout);
+	OBJECT_TYPE(RENDER_PASS, VkRenderPass);
+	OBJECT_TYPE(PIPELINE, VkPipeline);
+	OBJECT_TYPE(DESCRIPTOR_SET_LAYOUT, VkDescriptorSetLayout);
+	OBJECT_TYPE(SAMPLER, VkSampler);
+	OBJECT_TYPE(DESCRIPTOR_POOL, VkDescriptorPool);
+	OBJECT_TYPE(DESCRIPTOR_SET, VkDescriptorSet);
+	OBJECT_TYPE(FRAMEBUFFER, VkFramebuffer);
+	OBJECT_TYPE(COMMAND_POOL, VkCommandPool);
+	OBJECT_TYPE(SURFACE_KHR, VkSurfaceKHR);
+	OBJECT_TYPE(SWAPCHAIN_KHR, VkSwapchainKHR);
+	OBJECT_TYPE(DEBUG_REPORT, VkDebugReportCallbackEXT);                       
+#undef OBJECT_TYPE
+
+	void SetObjectName(
+		VkDevice device,
+		VkDebugReportObjectTypeEXT objectType,
+		uint64_t object,
+		const char* pObjectName)
+	{
+		// need to check if the function pointer is valid - extension might not be present
+		if (DebugMarkerSetObjectName)
+		{
+			VkDebugMarkerObjectNameInfoEXT nameInfo = {};
+			nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
+			nameInfo.objectType = objectType;
+			nameInfo.object = object;
+			nameInfo.pObjectName = pObjectName;
+			DebugMarkerSetObjectName(device, &nameInfo);
+		}
+	}
 }

--- a/base/vulkandebug.h
+++ b/base/vulkandebug.h
@@ -44,4 +44,52 @@ namespace vkDebug
 		VkDebugReportCallbackEXT callBack);
 	// Clear debug callback
 	void freeDebugCallback(VkInstance instance);
+
+	// Set up the debug marker function pointers
+	void setupDebugMarkers(VkDevice device);
+
+	// insert a debug label into the command buffer, with or
+	// without a color
+	void insertDebugMarker(
+		VkCommandBuffer cmdbuffer,
+		const char* pMarkerName,
+		float color[4]);
+	void insertDebugMarker(
+		VkCommandBuffer cmdbuffer,
+		const char* pMarkerName);
+
+	// helper class for pushing and popping a debug region
+	// around some section of code.
+	struct DebugMarkerRegion 
+	{
+		DebugMarkerRegion(VkCommandBuffer cmdbuffer,
+			const char* pMarkerName,
+			float color[4]);
+		DebugMarkerRegion(VkCommandBuffer cmdbuffer,
+			const char* pMarkerName);
+		~DebugMarkerRegion();
+
+		VkCommandBuffer cmd;
+	};
+
+	// associate a friendly name with an object
+	void SetObjectName(
+		VkDevice device,
+		VkDebugReportObjectTypeEXT objectType,
+		uint64_t object,
+		const char* pObjectName);
+
+	// specialised in vulkandebug.cpp for each object type
+	template<typename VulkanType>
+	VkDebugReportObjectTypeEXT GetObjectTypeEnum(VulkanType object);
+
+	// templated helper function for SetObjectName
+	template<typename VulkanType>
+	void SetObjectName(
+		VkDevice device,
+		VulkanType object,
+		const char* pObjectName)
+	{
+		SetObjectName(device, GetObjectTypeEnum(object), (uint64_t)object, pObjectName);
+	}
 }

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -1358,6 +1358,8 @@ void VulkanExampleBase::setupDepthStencil()
 	getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &mem_alloc.memoryTypeIndex);
 	err = vkAllocateMemory(device, &mem_alloc, nullptr, &depthStencil.mem);
 	assert(!err);
+	
+	vkDebug::SetObjectName(device, depthStencil.image, "Backbuffer depth-stencil");
 
 	err = vkBindImageMemory(device, depthStencil.image, depthStencil.mem, 0);
 	assert(!err);

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -61,6 +61,13 @@ VkResult VulkanExampleBase::createDevice(VkDeviceQueueCreateInfo requestedQueues
 	deviceCreateInfo.pQueueCreateInfos = &requestedQueues;
 	deviceCreateInfo.pEnabledFeatures = NULL;
 
+	// enable the debug marker extension if it is present (likely meaning a debugging tool is present)
+	if (vkTools::checkDeviceExtensionPresent(physicalDevice, VK_EXT_DEBUG_MARKER_EXTENSION_NAME))
+	{
+		enabledExtensions.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+		enableDebugMarkers = true;
+	}
+
 	if (enabledExtensions.size() > 0)
 	{
 		deviceCreateInfo.enabledExtensionCount = (uint32_t)enabledExtensions.size();
@@ -248,6 +255,10 @@ void VulkanExampleBase::prepare()
 	if (enableValidation)
 	{
 		vkDebug::setupDebugging(instance, VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT, NULL);
+	}
+	if (enableDebugMarkers)
+	{
+		vkDebug::setupDebugMarkers(device);
 	}
 	createCommandPool();
 	createSetupCommandBuffer();

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -45,6 +45,8 @@ class VulkanExampleBase
 private:	
 	// Set to true when example is created with enabled validation layers
 	bool enableValidation = false;
+	// Set to true when the debug marker extension is detected
+	bool enableDebugMarkers = false;
 	// fps timer (one second interval)
 	float fpsTimer = 0.0f;
 	// Create application wide Vulkan instance

--- a/external/vulkan/vulkan.h
+++ b/external/vulkan/vulkan.h
@@ -8,24 +8,17 @@ extern "C" {
 /*
 ** Copyright (c) 2015-2016 The Khronos Group Inc.
 **
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and/or associated documentation files (the
-** "Materials"), to deal in the Materials without restriction, including
-** without limitation the rights to use, copy, modify, merge, publish,
-** distribute, sublicense, and/or sell copies of the Materials, and to
-** permit persons to whom the Materials are furnished to do so, subject to
-** the following conditions:
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
 **
-** The above copyright notice and this permission notice shall be included
-** in all copies or substantial portions of the Materials.
+**     http://www.apache.org/licenses/LICENSE-2.0
 **
-** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
 */
 
 /*
@@ -50,7 +43,7 @@ extern "C" {
 #define VK_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3ff)
 #define VK_VERSION_PATCH(version) ((uint32_t)(version) & 0xfff)
 // Version of this file
-#define VK_HEADER_VERSION 8
+#define VK_HEADER_VERSION 12
 
 
 #define VK_NULL_HANDLE 0
@@ -217,6 +210,10 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR = 1000008000,
     VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR = 1000009000,
     VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT = 1000011000,
+    VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD = 1000018000,
+    VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT = 1000022000,
+    VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT = 1000022001,
+    VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT = 1000022002,
     VK_STRUCTURE_TYPE_BEGIN_RANGE = VK_STRUCTURE_TYPE_APPLICATION_INFO,
     VK_STRUCTURE_TYPE_END_RANGE = VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO,
     VK_STRUCTURE_TYPE_RANGE_SIZE = (VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO - VK_STRUCTURE_TYPE_APPLICATION_INFO + 1),
@@ -3278,7 +3275,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfacePresentModesKHR(
 #define VK_KHR_swapchain 1
 VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkSwapchainKHR)
 
-#define VK_KHR_SWAPCHAIN_SPEC_VERSION     67
+#define VK_KHR_SWAPCHAIN_SPEC_VERSION     68
 #define VK_KHR_SWAPCHAIN_EXTENSION_NAME   "VK_KHR_swapchain"
 
 typedef VkFlags VkSwapchainCreateFlagsKHR;
@@ -3434,7 +3431,7 @@ typedef VkResult (VKAPI_PTR *PFN_vkGetPhysicalDeviceDisplayPropertiesKHR)(VkPhys
 typedef VkResult (VKAPI_PTR *PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR)(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount, VkDisplayPlanePropertiesKHR* pProperties);
 typedef VkResult (VKAPI_PTR *PFN_vkGetDisplayPlaneSupportedDisplaysKHR)(VkPhysicalDevice physicalDevice, uint32_t planeIndex, uint32_t* pDisplayCount, VkDisplayKHR* pDisplays);
 typedef VkResult (VKAPI_PTR *PFN_vkGetDisplayModePropertiesKHR)(VkPhysicalDevice physicalDevice, VkDisplayKHR display, uint32_t* pPropertyCount, VkDisplayModePropertiesKHR* pProperties);
-typedef VkResult (VKAPI_PTR *PFN_vkCreateDisplayModeKHR)(VkPhysicalDevice physicalDevice, VkDisplayKHR display, const VkDisplayModeCreateInfoKHR*pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode);
+typedef VkResult (VKAPI_PTR *PFN_vkCreateDisplayModeKHR)(VkPhysicalDevice physicalDevice, VkDisplayKHR display, const VkDisplayModeCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode);
 typedef VkResult (VKAPI_PTR *PFN_vkGetDisplayPlaneCapabilitiesKHR)(VkPhysicalDevice physicalDevice, VkDisplayModeKHR mode, uint32_t planeIndex, VkDisplayPlaneCapabilitiesKHR* pCapabilities);
 typedef VkResult (VKAPI_PTR *PFN_vkCreateDisplayPlaneSurfaceKHR)(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
 
@@ -3834,6 +3831,85 @@ VKAPI_ATTR void VKAPI_CALL vkDebugReportMessageEXT(
 #define VK_IMG_FILTER_CUBIC_SPEC_VERSION  1
 #define VK_IMG_FILTER_CUBIC_EXTENSION_NAME "VK_IMG_filter_cubic"
 
+
+#define VK_AMD_rasterization_order 1
+#define VK_AMD_RASTERIZATION_ORDER_SPEC_VERSION 1
+#define VK_AMD_RASTERIZATION_ORDER_EXTENSION_NAME "VK_AMD_rasterization_order"
+
+
+typedef enum VkRasterizationOrderAMD {
+    VK_RASTERIZATION_ORDER_STRICT_AMD = 0,
+    VK_RASTERIZATION_ORDER_RELAXED_AMD = 1,
+    VK_RASTERIZATION_ORDER_BEGIN_RANGE_AMD = VK_RASTERIZATION_ORDER_STRICT_AMD,
+    VK_RASTERIZATION_ORDER_END_RANGE_AMD = VK_RASTERIZATION_ORDER_RELAXED_AMD,
+    VK_RASTERIZATION_ORDER_RANGE_SIZE_AMD = (VK_RASTERIZATION_ORDER_RELAXED_AMD - VK_RASTERIZATION_ORDER_STRICT_AMD + 1),
+    VK_RASTERIZATION_ORDER_MAX_ENUM_AMD = 0x7FFFFFFF
+} VkRasterizationOrderAMD;
+
+typedef struct VkPipelineRasterizationStateRasterizationOrderAMD {
+    VkStructureType            sType;
+    const void*                pNext;
+    VkRasterizationOrderAMD    rasterizationOrder;
+} VkPipelineRasterizationStateRasterizationOrderAMD;
+
+
+
+#define VK_EXT_debug_marker 1
+#define VK_EXT_DEBUG_MARKER_SPEC_VERSION  3
+#define VK_EXT_DEBUG_MARKER_EXTENSION_NAME "VK_EXT_debug_marker"
+
+typedef struct VkDebugMarkerObjectNameInfoEXT {
+    VkStructureType               sType;
+    const void*                   pNext;
+    VkDebugReportObjectTypeEXT    objectType;
+    uint64_t                      object;
+    const char*                   pObjectName;
+} VkDebugMarkerObjectNameInfoEXT;
+
+typedef struct VkDebugMarkerObjectTagInfoEXT {
+    VkStructureType               sType;
+    const void*                   pNext;
+    VkDebugReportObjectTypeEXT    objectType;
+    uint64_t                      object;
+    uint64_t                      tagName;
+    size_t                        tagSize;
+    const void*                   pTag;
+} VkDebugMarkerObjectTagInfoEXT;
+
+typedef struct VkDebugMarkerMarkerInfoEXT {
+    VkStructureType    sType;
+    const void*        pNext;
+    const char*        pMarkerName;
+    float              color[4];
+} VkDebugMarkerMarkerInfoEXT;
+
+
+typedef VkResult (VKAPI_PTR *PFN_vkDebugMarkerSetObjectTagEXT)(VkDevice device, VkDebugMarkerObjectTagInfoEXT* pTagInfo);
+typedef VkResult (VKAPI_PTR *PFN_vkDebugMarkerSetObjectNameEXT)(VkDevice device, VkDebugMarkerObjectNameInfoEXT* pNameInfo);
+typedef void (VKAPI_PTR *PFN_vkCmdDebugMarkerBeginEXT)(VkCommandBuffer commandBuffer, VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
+typedef void (VKAPI_PTR *PFN_vkCmdDebugMarkerEndEXT)(VkCommandBuffer commandBuffer);
+typedef void (VKAPI_PTR *PFN_vkCmdDebugMarkerInsertEXT)(VkCommandBuffer commandBuffer, VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR VkResult VKAPI_CALL vkDebugMarkerSetObjectTagEXT(
+    VkDevice                                    device,
+    VkDebugMarkerObjectTagInfoEXT*              pTagInfo);
+
+VKAPI_ATTR VkResult VKAPI_CALL vkDebugMarkerSetObjectNameEXT(
+    VkDevice                                    device,
+    VkDebugMarkerObjectNameInfoEXT*             pNameInfo);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdDebugMarkerBeginEXT(
+    VkCommandBuffer                             commandBuffer,
+    VkDebugMarkerMarkerInfoEXT*                 pMarkerInfo);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdDebugMarkerEndEXT(
+    VkCommandBuffer                             commandBuffer);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdDebugMarkerInsertEXT(
+    VkCommandBuffer                             commandBuffer,
+    VkDebugMarkerMarkerInfoEXT*                 pMarkerInfo);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hey! I'm playing evangelist for a bit :).

This PR adds the use of new functions exposed in VK_EXT_debug_marker, to allow object labelling and command buffer annotation. Currently RenderDoc supports this in the latest version (v0.29), but I imagine other tools and likely the validation layers will support it in future.

I've committed the latest header from the KhronosGroup/Vulkan-Docs repository, but if you want you can wait until the next SDK drop to merge this and replace that commit with the vulkan header from that SDK, it's up to you.

I also added example usage to the bloom sample - you don't have to take that commit either I just wanted to show what it would look like. Here's some screenshots of RenderDoc showing some of what it does:

![Buffer naming](https://cloud.githubusercontent.com/assets/661798/15099703/0324138e-155d-11e6-95bd-ee87fd122b7d.png)

![Shader and image naming](https://cloud.githubusercontent.com/assets/661798/15099704/05710da4-155d-11e6-96dd-fb13e41ef1b5.png)

![Command buffer annotation](https://cloud.githubusercontent.com/assets/661798/15099705/07fb40e4-155d-11e6-82e5-cbf715958177.png)