### PR TITLE
Fix asset filename in multisampling

### DIFF
--- a/multisampling/multisampling.cpp
+++ b/multisampling/multisampling.cpp
@@ -432,7 +432,7 @@ public:
 
 	void loadMeshes()
 	{
-		loadMesh(getAssetPath() + "models/voyager/voyager.obj", &meshes.example, vertexLayout, 1.0f);
+		loadMesh(getAssetPath() + "models/voyager/voyager.dae", &meshes.example, vertexLayout, 1.0f);
 	}
 
 	void setupVertexDescriptions()


### PR DESCRIPTION
Looks like voyager.obj went missing. (The .dae file is used in the mesh example.)