### PR TITLE
Make the keys work on Linux

### DIFF
--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -50,9 +50,59 @@
 #define GAMEPAD_BUTTON_R1 0x1005
 #define GAMEPAD_BUTTON_START 0x1006
 
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#define KEY_W 25
+#define KEY_A 38
+#define KEY_S 39
+#define KEY_D 40
+
+#define KEY_Q 24
+#define KEY_E 26
+#define KEY_F 41
+#define KEY_B 56
+#define KEY_O 32
+#define KEY_N 57
+#define KEY_T 28
+#define KEY_L 46
+
+#define KEY_LEFT 113
+#define KEY_RIGHT 114
+#define KEY_UP 111
+#define KEY_DOWN 116
+
+#define KEY_SPACE 65
+#define KEY_RETURN 36
+#define KEY_ESC 9
+
+#define KEY_LSHIFT 50
+#define KEY_RSHIFT 62
+
+#define KEY_NP_PLUS 86
+#define KEY_NP_MINUS 82
+
+#else
+
+#define KEY_W 0x57
+#define KEY_S 0x53
+#define KEY_D 0x44
+
+#define KEY_B 0x42
+#define KEY_O 0x4F
+#define KEY_N 0x4E
+#define KEY_T 0x54
+#define KEY_L 0x4C
+
+#define KEY_SPACE 0x20
+
+#define KEY_NP_PLUS 0x6B
+#define KEY_NP_MINUS 0x6D
+
+#endif
+
 class VulkanExampleBase
 {
-private:	
+private:
 	// Set to true when example is created with enabled validation layers
 	bool enableValidation = false;
 	// Set to true when the debug marker extension is detected
@@ -138,7 +188,7 @@ protected:
 	vkTools::VulkanTextureLoader *textureLoader = nullptr;
 	// Returns the base asset path (for shaders, models, textures) depending on the os
 	const std::string getAssetPath();
-public: 
+public:
 	bool prepared = false;
 	uint32_t width = 1280;
 	uint32_t height = 720;
@@ -152,7 +202,7 @@ public:
 	float timer = 0.0f;
 	// Multiplier for speeding up (or slowing down) the global timer
 	float timerSpeed = 0.25f;
-	
+
 	bool paused = false;
 
 	bool enableTextOverlay = false;
@@ -172,7 +222,7 @@ public:
 	std::string title = "Vulkan Example";
 	std::string name = "vulkanExample";
 
-	struct 
+	struct
 	{
 		VkImage image;
 		VkDeviceMemory mem;
@@ -192,7 +242,7 @@ public:
 		} axes;
 	} gamePadState;
 
-	// OS specific 
+	// OS specific
 #if defined(_WIN32)
 	HWND window;
 	HINSTANCE windowInstance;
@@ -238,7 +288,7 @@ public:
 	// Pure virtual render function (override in derived class)
 	virtual void render() = 0;
 	// Called when view change occurs
-	// Can be overriden in derived class to e.g. update uniform buffers 
+	// Can be overriden in derived class to e.g. update uniform buffers
 	// Containing view dependant matrices
 	virtual void viewChanged();
 	// Called if a key is pressed
@@ -277,7 +327,7 @@ public:
 	// Create command buffers for drawing commands
 	void createCommandBuffers();
 	// Destroy all command buffers and set their handles to VK_NULL_HANDLE
-	// May be necessary during runtime if options are toggled 
+	// May be necessary during runtime if options are toggled
 	void destroyCommandBuffers();
 	// Create command buffer for setup commands
 	void createSetupCommandBuffer();
@@ -299,7 +349,7 @@ public:
 
 	// Load a SPIR-V shader
 	VkPipelineShaderStageCreateInfo loadShader(std::string fileName, VkShaderStageFlagBits stage);
-	
+
 	// Create a buffer, fill it with data (if != NULL) and bind buffer memory
 	VkBool32 createBuffer(
 		VkBufferUsageFlags usageFlags,
@@ -364,14 +414,14 @@ public:
 	virtual void getOverlayText(VulkanTextOverlay * textOverlay);
 
 	// Prepare the frame for workload submission
-	// - Acquires the next image from the swap chain 
+	// - Acquires the next image from the swap chain
 	// - Submits a post present barrier
 	// - Sets the default wait and signal semaphores
 	void prepareFrame();
 
-	// Submit the frames' workload 
+	// Submit the frames' workload
 	// - Submits the text overlay (if enabled)
-	// - 
+	// -
 	void submitFrame();
 
 };

--- a/base/vulkantextoverlay.hpp
+++ b/base/vulkantextoverlay.hpp
@@ -26,7 +26,7 @@
 // STB font files can be found at http://nothings.org/stb/font/
 #define STB_FONT_NAME stb_font_consolas_24_latin1
 #define STB_FONT_WIDTH STB_FONT_consolas_24_latin1_BITMAP_WIDTH
-#define STB_FONT_HEIGHT STB_FONT_consolas_24_latin1_BITMAP_HEIGHT 
+#define STB_FONT_HEIGHT STB_FONT_consolas_24_latin1_BITMAP_HEIGHT
 #define STB_FIRST_CHAR STB_FONT_consolas_24_latin1_FIRST_CHAR
 #define STB_NUM_CHARS STB_FONT_consolas_24_latin1_NUM_CHARS
 
@@ -538,7 +538,7 @@ public:
 		VK_CHECK_RESULT(vkCreateRenderPass(device, &renderPassInfo, nullptr, &renderPass));
 	}
 
-	// Map buffer 
+	// Map buffer
 	void beginTextUpdate()
 	{
 		mappedLocal = mapped;
@@ -653,7 +653,7 @@ public:
 
 			VkRect2D scissor = vkTools::initializers::rect2D(*frameBufferWidth, *frameBufferHeight, 0, 0);
 			vkCmdSetScissor(cmdBuffers[i], 0, 1, &scissor);
-			
+
 			vkCmdBindPipeline(cmdBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
 			vkCmdBindDescriptorSets(cmdBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &descriptorSet, 0, NULL);
 

--- a/bloom/bloom.cpp
+++ b/bloom/bloom.cpp
@@ -1113,15 +1113,15 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x6B:
+		case KEY_NP_PLUS:
 		case GAMEPAD_BUTTON_R1:
 			changeBlurScale(0.25f);
 			break;
-		case 0x6D:
+		case KEY_NP_MINUS:
 		case GAMEPAD_BUTTON_L1:
 			changeBlurScale(-0.25f);
 			break;
-		case 0x42:
+		case KEY_B:
 		case GAMEPAD_BUTTON_A:
 			toggleBloom();
 			break;

--- a/computeshader/computeshader.cpp
+++ b/computeshader/computeshader.cpp
@@ -774,11 +774,11 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x6B:
+		case KEY_NP_PLUS:
 		case GAMEPAD_BUTTON_R1:
 			switchComputePipeline(1);
 			break;
-		case 0x6D:
+		case KEY_NP_MINUS:
 		case GAMEPAD_BUTTON_L1:
 			switchComputePipeline(-1);
 			break;

--- a/deferred/deferred.cpp
+++ b/deferred/deferred.cpp
@@ -1135,7 +1135,7 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x44:
+		case KEY_D:
 		case GAMEPAD_BUTTON_A:
 			toggleDebugDisplay();
 			updateTextOverlay();

--- a/displacement/displacement.cpp
+++ b/displacement/displacement.cpp
@@ -557,19 +557,19 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x6B:
+		case KEY_NP_PLUS:
 		case GAMEPAD_BUTTON_R1:
 			changeTessellationStrength(0.025);
 			break;
-		case 0x6D:
+		case KEY_NP_MINUS:
 		case GAMEPAD_BUTTON_L1:
 			changeTessellationStrength(-0.025);
 			break;
-		case 0x44:
+		case KEY_D:
 		case GAMEPAD_BUTTON_A:
 			toggleDisplacement();
 			break;
-		case 0x53:
+		case KEY_S:
 		case GAMEPAD_BUTTON_X:
 			toggleSplitScreen();
 			break;

--- a/distancefieldfonts/distancefieldfonts.cpp
+++ b/distancefieldfonts/distancefieldfonts.cpp
@@ -716,15 +716,14 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x53:
-		case GAMEPAD_BUTTON_X:
-			toggleSplitScreen();
-			break;
-		case 0x4F:
+		case KEY_O:
 		case GAMEPAD_BUTTON_A:
 			toggleFontOutline();
 			break;
-
+		case KEY_S:
+		case GAMEPAD_BUTTON_X:
+			toggleSplitScreen();
+			break;
 		}
 	}
 

--- a/geometryshader/geometryshader.cpp
+++ b/geometryshader/geometryshader.cpp
@@ -478,7 +478,7 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x4E:
+		case KEY_N:
 		case GAMEPAD_BUTTON_A:
 			toggleNormals();
 			break;

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -94,14 +94,14 @@ public:
 
 	~VulkanExample()
 	{
-		// Clean up used Vulkan resources 
+		// Clean up used Vulkan resources
 		// Note : Inherited destructor cleans up resources stored in base class
 		vkDestroyPipeline(device, pipelines.solid, nullptr);
 
 		vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
 		vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
 
-		// Destroy and free mesh resources 
+		// Destroy and free mesh resources
 		vkDestroyBuffer(device, mesh.vertices.buf, nullptr);
 		vkFreeMemory(device, mesh.vertices.mem, nullptr);
 		vkDestroyBuffer(device, mesh.indices.buf, nullptr);
@@ -171,7 +171,7 @@ public:
 		}
 	}
 
-	// Load a mesh based on data read via assimp 
+	// Load a mesh based on data read via assimp
 	// The other example will use the VulkanMesh loader which has some additional functionality for loading meshes
 	void loadMesh()
 	{
@@ -443,7 +443,7 @@ public:
 				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
 				0,
 				&uniformData.vsScene.descriptor),
-			// Binding 1 : Color map 
+			// Binding 1 : Color map
 			vkTools::initializers::writeDescriptorSet(
 				descriptorSet,
 				VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
@@ -613,7 +613,7 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x57:
+		case KEY_W:
 		case GAMEPAD_BUTTON_A:
 			wireframe = !wireframe;
 			reBuildCommandBuffers();
@@ -665,7 +665,7 @@ int main(const int argc, const char *argv[])
 #endif
 {
 #if defined(__ANDROID__)
-	// Removing this may cause the compiler to omit the main entry point 
+	// Removing this may cause the compiler to omit the main entry point
 	// which would make the application crash at start
 	app_dummy();
 #endif

--- a/offscreen/offscreen.cpp
+++ b/offscreen/offscreen.cpp
@@ -995,7 +995,7 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x44:
+		case KEY_D:
 		case GAMEPAD_BUTTON_A:
 			toggleDebugDisplay();
 			break;

--- a/parallaxmapping/parallaxmapping.cpp
+++ b/parallaxmapping/parallaxmapping.cpp
@@ -583,15 +583,15 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x4F:
+		case KEY_O:
 		case GAMEPAD_BUTTON_A:
 			toggleParallaxOffset();
 			break;
-		case 0x4E:
+		case KEY_N:
 		case GAMEPAD_BUTTON_X:
 			toggleNormalMapDisplay();
 			break;
-		case 0x53:
+		case KEY_S:
 		case GAMEPAD_BUTTON_Y:
 			toggleSplitScreen();
 			break;

--- a/radialblur/radialblur.cpp
+++ b/radialblur/radialblur.cpp
@@ -980,11 +980,11 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x42:
+		case KEY_B:
 		case GAMEPAD_BUTTON_A:
 			toggleBlur();
 			break;
-		case 0x54:
+		case KEY_T:
 		case GAMEPAD_BUTTON_X:
 			toggleTextureDisplay();
 			break;

--- a/shadowmapping/shadowmapping.cpp
+++ b/shadowmapping/shadowmapping.cpp
@@ -1019,11 +1019,11 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x53:
+		case KEY_S:
 		case GAMEPAD_BUTTON_A:
 			toggleShadowMapDisplay();
 			break;
-		case 0x4C:
+		case KEY_L:
 		case GAMEPAD_BUTTON_X:
 			toogleLightPOV();
 			break;

--- a/shadowmappingomni/shadowmappingomni.cpp
+++ b/shadowmappingomni/shadowmappingomni.cpp
@@ -1068,7 +1068,7 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x44:
+		case KEY_D:
 		case GAMEPAD_BUTTON_A:
 			toggleCubeMapDisplay();
 			break;

--- a/skeletalanimation/skeletalanimation.cpp
+++ b/skeletalanimation/skeletalanimation.cpp
@@ -1036,11 +1036,11 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x6B:
+		case KEY_NP_PLUS:
 		case GAMEPAD_BUTTON_R1:
 			changeAnimationSpeed(0.1f);
 			break;
-		case 0x6D:
+		case KEY_NP_MINUS:
 		case GAMEPAD_BUTTON_L1:
 			changeAnimationSpeed(-0.1f);
 			break;

--- a/sphericalenvmapping/sphericalenvmapping.cpp
+++ b/sphericalenvmapping/sphericalenvmapping.cpp
@@ -452,12 +452,12 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x6B:
-		case 0x20:
+		case KEY_NP_PLUS:
+		case KEY_SPACE:
 		case GAMEPAD_BUTTON_A:
 			changeMatCapIndex(1);
 			break;
-		case 0x6D:
+		case KEY_NP_MINUS:
 		case GAMEPAD_BUTTON_X:
 			changeMatCapIndex(-1);
 			break;

--- a/tessellation/tessellation.cpp
+++ b/tessellation/tessellation.cpp
@@ -533,19 +533,19 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x6B:
+		case KEY_NP_PLUS:
 		case GAMEPAD_BUTTON_R1:
 			changeTessellationLevel(0.25);
 			break;
-		case 0x6D:
+		case KEY_NP_MINUS:
 		case GAMEPAD_BUTTON_L1:
 			changeTessellationLevel(-0.25);
 			break;
-		case 0x57:
+		case KEY_W:
 		case GAMEPAD_BUTTON_A:
 			togglePipelines();
 			break;
-		case 0x53:
+		case KEY_S:
 		case GAMEPAD_BUTTON_X:
 			toggleSplitScreen();
 			break;

--- a/textoverlay/textoverlay.cpp
+++ b/textoverlay/textoverlay.cpp
@@ -1228,8 +1228,8 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x6B:
-		case 0x20:
+		case KEY_NP_PLUS:
+		case KEY_SPACE:
 			textOverlay->visible = !textOverlay->visible;
 		}
 	}

--- a/textoverlay/textoverlay.cpp
+++ b/textoverlay/textoverlay.cpp
@@ -42,7 +42,7 @@ std::vector<vkMeshLoader::VertexLayout> vertexLayout =
 // STB font files can be found at http://nothings.org/stb/font/
 #define STB_FONT_NAME stb_font_consolas_24_latin1
 #define STB_FONT_WIDTH STB_FONT_consolas_24_latin1_BITMAP_WIDTH
-#define STB_FONT_HEIGHT STB_FONT_consolas_24_latin1_BITMAP_HEIGHT 
+#define STB_FONT_HEIGHT STB_FONT_consolas_24_latin1_BITMAP_HEIGHT
 #define STB_FIRST_CHAR STB_FONT_consolas_24_latin1_FIRST_CHAR
 #define STB_NUM_CHARS STB_FONT_consolas_24_latin1_NUM_CHARS
 
@@ -260,7 +260,7 @@ public:
 		VkCommandBuffer copyCmd;
 		cmdBufAllocateInfo.commandBufferCount = 1;
 		VK_CHECK_RESULT(vkAllocateCommandBuffers(device, &cmdBufAllocateInfo, &copyCmd));
-	
+
 		VkCommandBufferBeginInfo cmdBufInfo = vkTools::initializers::commandBufferBeginInfo();
 		VK_CHECK_RESULT(vkBeginCommandBuffer(copyCmd, &cmdBufInfo));
 
@@ -545,7 +545,7 @@ public:
 		VK_CHECK_RESULT(vkCreateRenderPass(device, &renderPassInfo, nullptr, &renderPass));
 	}
 
-	// Map buffer 
+	// Map buffer
 	void beginTextUpdate()
 	{
 		VK_CHECK_RESULT(vkMapMemory(device, memory, 0, VK_WHOLE_SIZE, 0, (void **)&mapped));
@@ -827,7 +827,7 @@ public:
 		textOverlay->addText(ss.str(), 5.0f, 25.0f, TextOverlay::alignLeft);
 
 		textOverlay->addText(deviceProperties.deviceName, 5.0f, 45.0f, TextOverlay::alignLeft);
-		
+
 		textOverlay->addText("Press \"space\" to toggle text overlay", 5.0f, height - 20.0f, TextOverlay::alignLeft);
 
 		// Display projected cube vertices
@@ -1025,7 +1025,7 @@ public:
 				0,
 				&uniformData.vsScene.descriptor));
 
-		// Binding 1 : Color map 
+		// Binding 1 : Color map
 		writeDescriptorSets.push_back(
 			vkTools::initializers::writeDescriptorSet(
 				descriptorSets.background,
@@ -1269,7 +1269,7 @@ int main(const int argc, const char *argv[])
 #endif
 {
 #if defined(__ANDROID__)
-	// Removing this may cause the compiler to omit the main entry point 
+	// Removing this may cause the compiler to omit the main entry point
 	// which would make the application crash at start
 	app_dummy();
 #endif

--- a/textoverlay/textoverlay.cpp
+++ b/textoverlay/textoverlay.cpp
@@ -47,7 +47,7 @@ std::vector<vkMeshLoader::VertexLayout> vertexLayout =
 #define STB_NUM_CHARS STB_FONT_consolas_24_latin1_NUM_CHARS
 
 // Max. number of chars the text overlay buffer can hold
-#define MAX_CHAR_COUNT 2048
+#define TEXTOVERLAY_MAX_CHAR_COUNT 2048
 
 // Mostly self-contained text overlay class
 class TextOverlay
@@ -187,7 +187,7 @@ public:
 		VK_CHECK_RESULT(vkAllocateCommandBuffers(device, &cmdBufAllocateInfo, cmdBuffers.data()));
 
 		// Vertex buffer
-		VkDeviceSize bufferSize = MAX_CHAR_COUNT * sizeof(glm::vec4);
+		VkDeviceSize bufferSize = TEXTOVERLAY_MAX_CHAR_COUNT * sizeof(glm::vec4);
 
 		VkBufferCreateInfo bufferInfo = vkTools::initializers::bufferCreateInfo(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, bufferSize);
 		VK_CHECK_RESULT(vkCreateBuffer(device, &bufferInfo, nullptr, &buffer));

--- a/texture/texture.cpp
+++ b/texture/texture.cpp
@@ -848,11 +848,11 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x6B:
+		case KEY_NP_PLUS:
 		case GAMEPAD_BUTTON_R1:
 			changeLodBias(0.1f);
 			break;
-		case 0x6D:
+		case KEY_NP_MINUS:
 		case GAMEPAD_BUTTON_L1:
 			changeLodBias(-0.1f);
 			break;

--- a/texturecubemap/texturecubemap.cpp
+++ b/texturecubemap/texturecubemap.cpp
@@ -737,19 +737,19 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x53:
+		case KEY_S:
 		case GAMEPAD_BUTTON_A:
 			toggleSkyBox();
 			break;
-		case 0x20:
+		case KEY_SPACE:
 		case GAMEPAD_BUTTON_X:
 			toggleObject();
 			break;
-		case 0x6B:
+		case KEY_NP_PLUS:
 		case GAMEPAD_BUTTON_R1:
 			changeLodBias(0.1f);
 			break;
-		case 0x6D:
+		case KEY_NP_MINUS:
 		case GAMEPAD_BUTTON_L1:
 			changeLodBias(-0.1f);
 			break;


### PR DESCRIPTION
* Added defines for keyboard scancodes on Linux in `vulkanexamplebase.h`.
* Moved the hardcoded values for keys on Windows into `vulkanexamplebase.h` as well, so that for instance `KEY_S` will work regardless of platform.
* Minor changes to the formatting (removed trailing whitespace a couple of places).

All the keybindings of all the Vulkan samples now work here, on Linux.

It might be even better to use an existing library for handling keys, like SDL2, but this pull request should solve the problem for now.