### PR TITLE
Fix getMemoryType not checking actual number of memory types

### DIFF
--- a/base/vulkanTextureLoader.hpp
+++ b/base/vulkanTextureLoader.hpp
@@ -44,7 +44,7 @@ namespace vkTools
 		// Get appropriate memory type index for a memory allocation
 		uint32_t getMemoryType(uint32_t typeBits, VkFlags properties)
 		{
-			for (uint32_t i = 0; i < 32; i++)
+			for (uint32_t i = 0; i < deviceMemoryProperties.memoryTypeCount; i++)
 			{
 				if ((typeBits & 1) == 1)
 				{


### PR DESCRIPTION
The function is currently iterating over the maximum number of possible memory types (which should be `VK_MAX_MEMORY_TYPES` instead of `32`) instead of the actual number.