### PR TITLE
queue submitted twice

### DIFF
--- a/triangle/triangle.cpp
+++ b/triangle/triangle.cpp
@@ -230,9 +230,6 @@ public:
 		submitInfo.commandBufferCount = 1;
 		submitInfo.pCommandBuffers = &commandBuffer;
 
-		VK_CHECK_RESULT(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
-		VK_CHECK_RESULT(vkQueueWaitIdle(queue));
-
 		// Create fence to ensure that the command buffer has finished executing
 		VkFenceCreateInfo fenceCreateInfo = {};
 		fenceCreateInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;


### PR DESCRIPTION
It looks like the queue is submitted twice and synchronized once with wait idle and once with a fence.