### PR TITLE
Unrecognized keyboard input in mesh example on Linux

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -613,7 +613,7 @@ public:
 	{
 		switch (keyCode)
 		{
-		case 0x57:
+		case KEY_W:
 		case GAMEPAD_BUTTON_A:
 			wireframe = !wireframe;
 			reBuildCommandBuffers();


### PR DESCRIPTION
This fixes a minor issue on Linux systems, where the Windows-specific key code is not working for toggling the visibility of the wireframe. Instead, I used the `KEY_W` macro defined for multi-platform purposes.