### PR TITLE
Fixed problems with layouts and formats

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -227,7 +227,7 @@ void VulkanExampleBase::prepare()
 			vulkanDevice,
 			queue,
 			frameBuffers,
-			colorformat,
+			swapChain.colorFormat,
 			depthFormat,
 			&width,
 			&height,
@@ -1520,7 +1520,7 @@ void VulkanExampleBase::setupRenderPass()
 {
 	std::array<VkAttachmentDescription, 2> attachments = {};
 	// Color attachment
-	attachments[0].format = colorformat;
+	attachments[0].format = swapChain.colorFormat;
 	attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
 	attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 	attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -93,8 +93,6 @@ protected:
 	vk::VulkanDevice *vulkanDevice;
 	// Handle to the device graphics queue that command buffers are submitted to
 	VkQueue queue;
-	// Color buffer format
-	VkFormat colorformat = VK_FORMAT_B8G8R8A8_UNORM;
 	// Depth buffer format
 	// Depth format is selected during Vulkan initialization
 	VkFormat depthFormat;

--- a/base/vulkanframebuffer.hpp
+++ b/base/vulkanframebuffer.hpp
@@ -139,7 +139,6 @@ namespace vk
 			attachment.format = createinfo.format;
 
 			VkImageAspectFlags aspectMask = VK_FLAGS_NONE;
-			VkImageLayout imageLayout;
 
 			// Select aspect mask and layout depending on usage
 
@@ -148,7 +147,6 @@ namespace vk
 			{
 				aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 				attachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-				imageLayout = (createinfo.usage & VK_IMAGE_USAGE_SAMPLED_BIT) ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 			}
 
 			// Depth (and/or stencil) attachment
@@ -163,7 +161,6 @@ namespace vk
 					aspectMask = aspectMask | VK_IMAGE_ASPECT_STENCIL_BIT;
 				}
 				attachment.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-				imageLayout = (createinfo.usage & VK_IMAGE_USAGE_SAMPLED_BIT) ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 			}
 
 			assert(aspectMask > 0);
@@ -218,11 +215,11 @@ namespace vk
 			// If not, final layout depends on attachment type
 			if (attachment.hasDepth() || attachment.hasStencil())
 			{
-				attachment.description.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+				attachment.description.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
 			}
 			else
 			{
-				attachment.description.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+				attachment.description.finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 			}
 
 			attachments.push_back(attachment);

--- a/deferred/deferred.cpp
+++ b/deferred/deferred.cpp
@@ -774,19 +774,19 @@ public:
 			vkTools::initializers::descriptorImageInfo(
 				colorSampler,
 				offScreenFrameBuf.position.view,
-				VK_IMAGE_LAYOUT_GENERAL);
+				VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 		VkDescriptorImageInfo texDescriptorNormal =
 			vkTools::initializers::descriptorImageInfo(
 				colorSampler,
 				offScreenFrameBuf.normal.view,
-				VK_IMAGE_LAYOUT_GENERAL);
+				VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 		VkDescriptorImageInfo texDescriptorAlbedo =
 			vkTools::initializers::descriptorImageInfo(
 				colorSampler,
 				offScreenFrameBuf.albedo.view,
-				VK_IMAGE_LAYOUT_GENERAL);
+				VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 		writeDescriptorSets = {
 			// Binding 0 : Vertex shader uniform buffer

--- a/deferredshadows/deferredshadows.cpp
+++ b/deferredshadows/deferredshadows.cpp
@@ -669,25 +669,25 @@ public:
 			vkTools::initializers::descriptorImageInfo(
 				frameBuffers.deferred->sampler,
 				frameBuffers.deferred->attachments[0].view,
-				VK_IMAGE_LAYOUT_GENERAL);
+				VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 		VkDescriptorImageInfo texDescriptorNormal =
 			vkTools::initializers::descriptorImageInfo(
 				frameBuffers.deferred->sampler,
 				frameBuffers.deferred->attachments[1].view,
-				VK_IMAGE_LAYOUT_GENERAL);
+				VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 		VkDescriptorImageInfo texDescriptorAlbedo =
 			vkTools::initializers::descriptorImageInfo(
 				frameBuffers.deferred->sampler,
 				frameBuffers.deferred->attachments[2].view,
-				VK_IMAGE_LAYOUT_GENERAL);
+				VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 		VkDescriptorImageInfo texDescriptorShadowMap =
 			vkTools::initializers::descriptorImageInfo(
 				frameBuffers.shadow->sampler,
 				frameBuffers.shadow->attachments[0].view,
-				VK_IMAGE_LAYOUT_GENERAL);
+				VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL);
 
 		writeDescriptorSets = {
 			// Binding 0: Vertex shader uniform buffer

--- a/multisampling/multisampling.cpp
+++ b/multisampling/multisampling.cpp
@@ -124,7 +124,7 @@ public:
 		// Color target
 		VkImageCreateInfo info = vkTools::initializers::imageCreateInfo();
 		info.imageType = VK_IMAGE_TYPE_2D;
-		info.format = colorformat;
+		info.format = swapChain.colorFormat;
 		info.extent.width = width;
 		info.extent.height = height;
 		info.extent.depth = 1;
@@ -159,7 +159,7 @@ public:
 		VkImageViewCreateInfo viewInfo = vkTools::initializers::imageViewCreateInfo();
 		viewInfo.image = multisampleTarget.color.image;
 		viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-		viewInfo.format = colorformat;
+		viewInfo.format = swapChain.colorFormat;
 		viewInfo.components.r = VK_COMPONENT_SWIZZLE_R;
 		viewInfo.components.g = VK_COMPONENT_SWIZZLE_G;
 		viewInfo.components.b = VK_COMPONENT_SWIZZLE_B;
@@ -225,7 +225,7 @@ public:
 		std::array<VkAttachmentDescription, 4> attachments = {};
 
 		// Multisampled attachment that we render to
-		attachments[0].format = colorformat;
+		attachments[0].format = swapChain.colorFormat;
 		attachments[0].samples = SAMPLE_COUNT;
 		attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 		// No longer required after resolve, this may save some bandwidth on certain GPUs
@@ -237,7 +237,7 @@ public:
 
 		// This is the frame buffer attachment to where the multisampled image
 		// will be resolved to and which will be presented to the swapchain
-		attachments[1].format = colorformat;
+		attachments[1].format = swapChain.colorFormat;
 		attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
 		attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;

--- a/textoverlay/textoverlay.cpp
+++ b/textoverlay/textoverlay.cpp
@@ -1150,7 +1150,7 @@ public:
 			vulkanDevice,
 			queue,
 			frameBuffers,
-			colorformat,
+			swapChain.colorFormat,
 			depthFormat,
 			&width,
 			&height,

--- a/triangle/triangle.cpp
+++ b/triangle/triangle.cpp
@@ -738,7 +738,7 @@ public:
 		std::array<VkAttachmentDescription, 2> attachments = {};
 
 		// Color attachment
-		attachments[0].format = colorformat;
+		attachments[0].format = swapChain.colorFormat;
 		attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;									// We don't use multi sampling in this example
 		attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;							// Clear this attachment at the start of the render pass
 		attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;							// Keep it's contents after the render pass is finished (for displaying it)


### PR DESCRIPTION
Images were transitioned to different after the render passes and different layouts were specified for descriptor sets.
Different color format were specified for image views and render passes.
Improved performance on some devices by changing layout from GENERAL to READ_ONLY_OPTIMAL.