### PR TITLE
cmake: Add scenerendering demo to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(EXAMPLES
 	pushconstants
 	raytracing
 	radialblur
+	scenerendering
 	shadowmapping
 	shadowmappingomni
 	skeletalanimation


### PR DESCRIPTION
Simple commit that adds the scenerendering demo back into CMakeLists.txt so that it builds on Linux and macOS.