### PR TITLE
Set VkExampleBase::colorformat after swapChainInit

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -1700,6 +1700,8 @@ void VulkanExampleBase::initSwapchain()
 #elif defined(__linux__)
 	swapChain.initSurface(connection, window);
 #endif
+	// Update internal color format
+	colorformat = swapChain.colorFormat;
 }
 
 void VulkanExampleBase::setupSwapChain()


### PR DESCRIPTION
The validation layers gives me errors (and the intel anv driver
crashes) if the framebuffer attachments and render pass attachments
doesn't match.

Only tested on Ubuntu 16.10 with mesa-git. Recent updates to the driver
enables SRGB and UNORM, in that order.