### PR TITLE
Don't tell the GPU to store attachments we don't care about

### DIFF
--- a/subpasses/subpasses.cpp
+++ b/subpasses/subpasses.cpp
@@ -261,7 +261,7 @@ public:
 		attachments[1].format = this->attachments.position.format;
 		attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
 		attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-		attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+		attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -270,7 +270,7 @@ public:
 		attachments[2].format = this->attachments.normal.format;
 		attachments[2].samples = VK_SAMPLE_COUNT_1_BIT;
 		attachments[2].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-		attachments[2].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+		attachments[2].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[2].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[2].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[2].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -279,7 +279,7 @@ public:
 		attachments[3].format = this->attachments.albedo.format;
 		attachments[3].samples = VK_SAMPLE_COUNT_1_BIT;
 		attachments[3].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-		attachments[3].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+		attachments[3].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[3].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[3].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[3].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -288,7 +288,7 @@ public:
 		attachments[4].format = depthFormat;
 		attachments[4].samples = VK_SAMPLE_COUNT_1_BIT;
 		attachments[4].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-		attachments[4].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+		attachments[4].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[4].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[4].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[4].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;


### PR DESCRIPTION
The subpass example currently sets all the attachments to `VK_ATTACHMENT_STORE_OP_STORE`.  However, the only attachment whose contents we care about is the color buffer, which holds the output, so the other attachments should be set to  `VK_ATTACHMENT_STORE_OP_DONT_CARE`.

