### PR TITLE
explicitely choose VK_FORMAT_B8G8R8A8_UNORM

### DIFF
--- a/base/vulkanswapchain.hpp
+++ b/base/vulkanswapchain.hpp
@@ -225,16 +225,33 @@ public:
 		if ((formatCount == 1) && (surfaceFormats[0].format == VK_FORMAT_UNDEFINED))
 		{
 			colorFormat = VK_FORMAT_B8G8R8A8_UNORM;
+			colorSpace = surfaceFormats[0].colorSpace;
 		}
 		else
 		{
-			// Always select the first available color format
-			// If you need a specific format (e.g. SRGB) you'd need to
 			// iterate over the list of available surface format and
-			// check for it's presence
-			colorFormat = surfaceFormats[0].format;
+			// check for the presence of VK_FORMAT_B8G8R8A8_UNORM
+			bool found_B8G8R8A8_UNORM = false;
+			for (auto&& surfaceFormat : surfaceFormats)
+			{
+				if (surfaceFormat.format == VK_FORMAT_B8G8R8A8_UNORM)
+				{
+					colorFormat = surfaceFormat.format;
+					colorSpace = surfaceFormat.colorSpace;
+					found_B8G8R8A8_UNORM = true;
+					break;
+				}
+			}
+
+			// in case VK_FORMAT_B8G8R8A8_UNORM is not available
+			// select the first available color format
+			if (!found_B8G8R8A8_UNORM)
+			{
+				colorFormat = surfaceFormats[0].format;
+				colorSpace = surfaceFormats[0].colorSpace;
+			}
 		}
-		colorSpace = surfaceFormats[0].colorSpace;
+
 	}
 
 	/**


### PR DESCRIPTION
The radv driver renders the examples much brighter than amdgpu-pro.

This has been a known issue for a while that appeared in The Talos Principle too:
https://lists.freedesktop.org/archives/mesa-dev/2016-October/132435.html

As the mailing list post says, radv puts VK_FORMAT_B8G8R8A8_SRGB first in the list to intentionally break applications that just use the first available format. Presumably the Vulkan spec allows drivers to put them into any order, so if applications require a specific one to render correctly, they should always look for it in this list.

Not sure if drivers are allowed not to support `VK_FORMAT_B8G8R8A8_UNORM`, so I put in a fallback to use `surfaceFormats[0]` then.

Screenshot showing the difference:
![radv-amdgpu-pro](https://cloud.githubusercontent.com/assets/781076/22469894/c779b44e-e7cd-11e6-965b-0056c5bed9fa.png)