### PR TITLE
Add missing <functional> include.

### DIFF
--- a/base/threadpool.hpp
+++ b/base/threadpool.hpp
@@ -11,6 +11,7 @@
 #include <queue>
 #include <mutex>
 #include <condition_variable>
+#include <functional>
 
 // make_unique is not available in C++11
 // Taken from Herb Sutter's blog (https://herbsutter.com/gotw/_102/)


### PR DESCRIPTION
`<functional>` is needed for `std::function` as per http://en.cppreference.com/w/cpp/utility/functional/function.
This fixes a compile error with GCC (_gcc (Gentoo 7.0.0_alpha20170219) 7.0.0-alpha20170219 20170219 (experimental)_)