### PR TITLE
Platform independent mouse handling.

### DIFF
--- a/base/VirtualMouseButtonFlags.hpp
+++ b/base/VirtualMouseButtonFlags.hpp
@@ -1,0 +1,54 @@
+/*
+* Platform independent virtual mouse button flags
+*
+* Copyright (C) 2017 by Sascha Willems - www.saschawillems.de
+*
+* This code is licensed under the MIT license (MIT) (http://opensource.org/licenses/MIT)
+*/
+
+#pragma once
+#ifndef VKS_BASE_VIRTUALMOUSEBUTTONFLAGS
+#define VKS_BASE_VIRTUALMOUSEBUTTONFLAGS
+
+#include <cstdint>
+
+namespace vks
+{
+	//! A very simple version of platform independent mouse button flags
+	struct VirtualMouseButtonFlags
+	{
+		enum Flags
+		{
+			Left = 0x01,
+			Middle = 0x02,
+			Right = 0x04,
+		};
+
+		uint32_t Value = 0;
+
+		bool IsEnabled(const Flags flags) const
+		{
+			return (Value & flags) == flags;
+		}
+
+		void SetFlag(const Flags flags, const bool value)
+		{
+			if (value)
+				Value |= static_cast<uint32_t>(flags);
+			else
+				Value &= ~static_cast<uint32_t>(flags);
+		}
+
+		bool operator==(const VirtualMouseButtonFlags& rhs) const
+		{
+			return (Value == rhs.Value);
+		}
+
+		bool operator!=(const VirtualMouseButtonFlags& rhs) const
+		{
+			return !(*this == rhs);
+		}
+	};
+}
+
+#endif

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -1756,7 +1756,8 @@ void VulkanExampleBase::handleEvent(const xcb_generic_event_t *event)
 	case XCB_MOTION_NOTIFY:
 	{
 		xcb_motion_notify_event_t *motion = (xcb_motion_notify_event_t *)event;
-		handleMouseMove(mouseButtonFlags, glm::vec2(static_cast<float>(motion->event_x), static_cast<float>(motion->event_y)));
+    mousePosition = glm::vec2(static_cast<float>(motion->event_x), static_cast<float>(motion->event_y));
+		handleMouseMove(mouseButtonFlags, mousePosition);
 	}
 	break;
 	case XCB_BUTTON_PRESS:
@@ -1766,11 +1767,11 @@ void VulkanExampleBase::handleEvent(const xcb_generic_event_t *event)
 		if (press->detail == XCB_BUTTON_INDEX_1)
 			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Left, true);
 		if (press->detail == XCB_BUTTON_INDEX_2)
-			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Middle, truefalse);
+			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Middle, true);
 		if (press->detail == XCB_BUTTON_INDEX_3)
 			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Right, true);
 
-		handleMouseButton(mouseButtonFlags, glm::vec2(static_cast<float>(motion->event_x), static_cast<float>(motion->event_y)));
+		handleMouseButton(mouseButtonFlags, mousePosition);
 	}
 	break;
 	case XCB_BUTTON_RELEASE:
@@ -1783,7 +1784,7 @@ void VulkanExampleBase::handleEvent(const xcb_generic_event_t *event)
 		if (press->detail == XCB_BUTTON_INDEX_3)
 			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Right, false);
 
-		handleMouseButton(mouseButtonFlags, glm::vec2(static_cast<float>(motion->event_x), static_cast<float>(motion->event_y)));
+		handleMouseButton(mouseButtonFlags, mousePosition);
 	}
 	break;
 	case XCB_KEY_PRESS:

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -896,6 +896,72 @@ void VulkanExampleBase::initVulkan()
 #endif	
 }
 
+
+void VulkanExampleBase::handleMouseButton(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position)
+{
+	// Only react to differences in the flags
+	if (currentMouseButtonFlags == buttonFlags)
+		return;
+	currentMouseButtonFlags = buttonFlags;
+
+	mousePos = position;
+
+	// Give examples a chance to handle the event
+	onMouseButton(buttonFlags, position);
+}
+
+
+void VulkanExampleBase::handleMouseMove(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position)
+{
+	using namespace vks;
+
+	const float dx = mousePos.x - position.x;
+	const float dy = mousePos.y - position.y;
+
+	if (buttonFlags.IsEnabled(VirtualMouseButtonFlags::Right))
+	{
+		zoom += dy * .005f * zoomSpeed;
+		camera.translate(glm::vec3(-0.0f, 0.0f, dy * .005f * zoomSpeed));
+		// NOTE: the old windows handler only sets this on mouse downs
+		//mousePos = position;
+		viewUpdated = true;
+	}
+	if (buttonFlags.IsEnabled(VirtualMouseButtonFlags::Left))
+	{
+		rotation.x += dy * 1.25f * rotationSpeed;
+		rotation.y -= dx * 1.25f * rotationSpeed;
+		camera.rotate(glm::vec3(dy * camera.rotationSpeed, -dx * camera.rotationSpeed, 0.0f));
+		// NOTE: the old windows handler only sets this on mouse downs
+		//mousePos = position;
+		viewUpdated = true;
+	}
+	if (buttonFlags.IsEnabled(VirtualMouseButtonFlags::Middle))
+	{
+		cameraPos.x -= dx * 0.01f;
+		cameraPos.y -= dy * 0.01f;
+		camera.translate(glm::vec3(-dx * 0.01f, -dy * 0.01f, 0.0f));
+		// NOTE: the old windows handler only sets this on mouse downs
+		//mousePos = position;
+		viewUpdated = true;
+	}
+
+	// NOTE: the other 'old' handlers sets it all the time
+	mousePos = position;
+
+	// Give examples a chance to handle the event
+	onMouseMove(buttonFlags, position);
+}
+
+void VulkanExampleBase::handleMouseWheel(const float delta)
+{
+	zoom += delta * 0.005f * zoomSpeed;
+	camera.translate(glm::vec3(0.0f, 0.0f, delta * 0.005f * zoomSpeed));
+	viewUpdated = true;
+
+	// Give examples a chance to handle the event
+	onMouseWheel(delta);
+}
+
 #if defined(_WIN32)
 // Win32 : Sets up a console window and redirects standard output to it
 void VulkanExampleBase::setupConsole(std::string title)
@@ -1096,49 +1162,28 @@ void VulkanExampleBase::handleMessages(HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
 	case WM_RBUTTONDOWN:
 	case WM_LBUTTONDOWN:
 	case WM_MBUTTONDOWN:
-		mousePos.x = (float)LOWORD(lParam);
-		mousePos.y = (float)HIWORD(lParam);
+	{
+		vks::VirtualMouseButtonFlags buttonFlags;
+		buttonFlags.Value |= (wParam & MK_RBUTTON) ? vks::VirtualMouseButtonFlags::Right : 0;
+		buttonFlags.Value |= (wParam & MK_LBUTTON) ? vks::VirtualMouseButtonFlags::Left : 0;
+		buttonFlags.Value |= (wParam & MK_MBUTTON) ? vks::VirtualMouseButtonFlags::Middle : 0;
+		handleMouseButton(buttonFlags, glm::vec2(static_cast<float>(LOWORD(lParam)), static_cast<float>(HIWORD(lParam))));
 		break;
+	}
 	case WM_MOUSEWHEEL:
 	{
-		short wheelDelta = GET_WHEEL_DELTA_WPARAM(wParam);
-		zoom += (float)wheelDelta * 0.005f * zoomSpeed;
-		camera.translate(glm::vec3(0.0f, 0.0f, (float)wheelDelta * 0.005f * zoomSpeed));
-		viewUpdated = true;
+		handleMouseWheel(static_cast<float>(GET_WHEEL_DELTA_WPARAM(wParam)));
 		break;
 	}
 	case WM_MOUSEMOVE:
-		if (wParam & MK_RBUTTON)
-		{
-			int32_t posx = LOWORD(lParam);
-			int32_t posy = HIWORD(lParam);
-			zoom += (mousePos.y - (float)posy) * .005f * zoomSpeed;
-			camera.translate(glm::vec3(-0.0f, 0.0f, (mousePos.y - (float)posy) * .005f * zoomSpeed));
-			mousePos = glm::vec2((float)posx, (float)posy);
-			viewUpdated = true;
-		}
-		if (wParam & MK_LBUTTON)
-		{
-			int32_t posx = LOWORD(lParam);
-			int32_t posy = HIWORD(lParam);
-			rotation.x += (mousePos.y - (float)posy) * 1.25f * rotationSpeed;
-			rotation.y -= (mousePos.x - (float)posx) * 1.25f * rotationSpeed;
-			camera.rotate(glm::vec3((mousePos.y - (float)posy) * camera.rotationSpeed, -(mousePos.x - (float)posx) * camera.rotationSpeed, 0.0f));
-			mousePos = glm::vec2((float)posx, (float)posy);
-			viewUpdated = true;
-		}
-		if (wParam & MK_MBUTTON)
-		{
-			int32_t posx = LOWORD(lParam);
-			int32_t posy = HIWORD(lParam);
-			cameraPos.x -= (mousePos.x - (float)posx) * 0.01f;
-			cameraPos.y -= (mousePos.y - (float)posy) * 0.01f;
-			camera.translate(glm::vec3(-(mousePos.x - (float)posx) * 0.01f, -(mousePos.y - (float)posy) * 0.01f, 0.0f));
-			viewUpdated = true;
-			mousePos.x = (float)posx;
-			mousePos.y = (float)posy;
-		}
+	{
+		vks::VirtualMouseButtonFlags buttonFlags;
+		buttonFlags.Value |= (wParam & MK_RBUTTON) ? vks::VirtualMouseButtonFlags::Right : 0;
+		buttonFlags.Value |= (wParam & MK_LBUTTON) ? vks::VirtualMouseButtonFlags::Left : 0;
+		buttonFlags.Value |= (wParam & MK_MBUTTON) ? vks::VirtualMouseButtonFlags::Middle : 0;
+		handleMouseMove(buttonFlags, glm::vec2(static_cast<float>(LOWORD(lParam)), static_cast<float>(HIWORD(lParam))));
 		break;
+	}
 	case WM_SIZE:
 		if ((prepared) && (wParam != SIZE_MINIMIZED))
 		{
@@ -1361,33 +1406,7 @@ void VulkanExampleBase::pointerMotion(wl_pointer *pointer, uint32_t time,
 	double x = wl_fixed_to_double(sx);
 	double y = wl_fixed_to_double(sy);
 
-	double dx = mousePos.x - x;
-	double dy = mousePos.y - y;
-
-	if (mouseButtons.left)
-	{
-		rotation.x += dy * 1.25f * rotationSpeed;
-		rotation.y -= dx * 1.25f * rotationSpeed;
-		camera.rotate(glm::vec3(
-				dy * camera.rotationSpeed,
-				-dx * camera.rotationSpeed,
-				0.0f));
-		viewUpdated = true;
-	}
-	if (mouseButtons.right)
-	{
-		zoom += dy * .005f * zoomSpeed;
-		camera.translate(glm::vec3(-0.0f, 0.0f, dy * .005f * zoomSpeed));
-		viewUpdated = true;
-	}
-	if (mouseButtons.middle)
-	{
-		cameraPos.x -= dx * 0.01f;
-		cameraPos.y -= dy * 0.01f;
-		camera.translate(glm::vec3(-dx * 0.01f, -dy * 0.01f, 0.0f));
-		viewUpdated = true;
-	}
-	mousePos = glm::vec2(x, y);
+	handleMouseMove(mouseButtonFlags, glm::vec2(static_cast<float>(x), static_cast<float>(y));
 }
 
 /*static*/void VulkanExampleBase::pointerButtonCb(void *data,
@@ -1404,16 +1423,21 @@ void VulkanExampleBase::pointerButton(struct wl_pointer *pointer,
 	switch (button)
 	{
 	case BTN_LEFT:
-		mouseButtons.left = !!state;
+		mouseButtonFlags.Set(VirtualMouseButtonFlags::Left, !!state);
 		break;
 	case BTN_MIDDLE:
-		mouseButtons.middle = !!state;
+		mouseButtonFlags.Set(VirtualMouseButtonFlags::Middle, !!state);
 		break;
 	case BTN_RIGHT:
-		mouseButtons.right = !!state;
+		mouseButtonFlags.Set(VirtualMouseButtonFlags::Right, !!state);
 		break;
 	default:
 		break;
+	}
+
+	if (modified)
+	{
+		handleMouseMove(mouseButtonFlags, glm::vec2(static_cast<float>(x), static_cast<float>(y));
 	}
 }
 
@@ -1432,9 +1456,7 @@ void VulkanExampleBase::pointerAxis(wl_pointer *pointer, uint32_t time,
 	switch (axis)
 	{
 	case REL_X:
-		zoom += d * 0.005f * zoomSpeed;
-		camera.translate(glm::vec3(0.0f, 0.0f, d * 0.005f * zoomSpeed));
-		viewUpdated = true;
+		handleMouseWheel(static_cast<float>(d));
 		break;
 	default:
 		break;
@@ -1734,51 +1756,34 @@ void VulkanExampleBase::handleEvent(const xcb_generic_event_t *event)
 	case XCB_MOTION_NOTIFY:
 	{
 		xcb_motion_notify_event_t *motion = (xcb_motion_notify_event_t *)event;
-		if (mouseButtons.left)
-		{
-			rotation.x += (mousePos.y - (float)motion->event_y) * 1.25f;
-			rotation.y -= (mousePos.x - (float)motion->event_x) * 1.25f;
-			camera.rotate(glm::vec3((mousePos.y - (float)motion->event_y) * camera.rotationSpeed, -(mousePos.x - (float)motion->event_x) * camera.rotationSpeed, 0.0f));
-			viewUpdated = true;
-		}
-		if (mouseButtons.right)
-		{
-			zoom += (mousePos.y - (float)motion->event_y) * .005f;
-			camera.translate(glm::vec3(-0.0f, 0.0f, (mousePos.y - (float)motion->event_y) * .005f * zoomSpeed));
-			viewUpdated = true;
-		}
-		if (mouseButtons.middle)
-		{
-			cameraPos.x -= (mousePos.x - (float)motion->event_x) * 0.01f;
-			cameraPos.y -= (mousePos.y - (float)motion->event_y) * 0.01f;
-			camera.translate(glm::vec3(-(mousePos.x - (float)(float)motion->event_x) * 0.01f, -(mousePos.y - (float)motion->event_y) * 0.01f, 0.0f));
-			viewUpdated = true;
-			mousePos.x = (float)motion->event_x;
-			mousePos.y = (float)motion->event_y;
-		}
-		mousePos = glm::vec2((float)motion->event_x, (float)motion->event_y);
+		handleMouseMove(mouseButtonFlags, glm::vec2(static_cast<float>(motion->event_x), static_cast<float>(motion->event_y)));
 	}
 	break;
 	case XCB_BUTTON_PRESS:
 	{
 		xcb_button_press_event_t *press = (xcb_button_press_event_t *)event;
+
 		if (press->detail == XCB_BUTTON_INDEX_1)
-			mouseButtons.left = true;
+			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Left, true);
 		if (press->detail == XCB_BUTTON_INDEX_2)
-			mouseButtons.middle = true;
+			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Middle, truefalse);
 		if (press->detail == XCB_BUTTON_INDEX_3)
-			mouseButtons.right = true;
+			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Right, true);
+
+		handleMouseButton(mouseButtonFlags, glm::vec2(static_cast<float>(motion->event_x), static_cast<float>(motion->event_y)));
 	}
 	break;
 	case XCB_BUTTON_RELEASE:
 	{
 		xcb_button_press_event_t *press = (xcb_button_press_event_t *)event;
 		if (press->detail == XCB_BUTTON_INDEX_1)
-			mouseButtons.left = false;
+			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Left, false);
 		if (press->detail == XCB_BUTTON_INDEX_2)
-			mouseButtons.middle = false;
+			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Middle, false);
 		if (press->detail == XCB_BUTTON_INDEX_3)
-			mouseButtons.right = false;
+			mouseButtonFlags.SetFlag(vks::VirtualMouseButtonFlags::Right, false);
+
+		handleMouseButton(mouseButtonFlags, glm::vec2(static_cast<float>(motion->event_x), static_cast<float>(motion->event_y)));
 	}
 	break;
 	case XCB_KEY_PRESS:

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "VirtualMouseButtonFlags.hpp"
+
 #ifdef _WIN32
 #pragma comment(linker, "/subsystem:windows")
 #include <windows.h>
@@ -51,6 +53,8 @@
 class VulkanExampleBase
 {
 private:	
+	vks::VirtualMouseButtonFlags currentMouseButtonFlags;
+
 	// fps timer (one second interval)
 	float fpsTimer = 0.0f;
 	// Get window title with example name, device, et.
@@ -218,17 +222,9 @@ public:
 	wl_surface *surface = nullptr;
 	wl_shell_surface *shell_surface = nullptr;
 	bool quit = false;
-	struct {
-		bool left = false;
-		bool right = false;
-		bool middle = false;
-	} mouseButtons;
+	vks::VirtualMouseButtonFlags  mouseButtonFlags;
 #elif defined(__linux__)
-	struct {
-		bool left = false;
-		bool right = false;
-		bool middle = false;
-	} mouseButtons;
+	vks::VirtualMouseButtonFlags  mouseButtonFlags;
 	bool quit = false;
 	xcb_connection_t *connection;
 	xcb_screen_t *screen;
@@ -244,6 +240,11 @@ public:
 
 	// Setup the vulkan instance, enable required extensions and connect to the physical device (GPU)
 	void initVulkan();
+
+	//! Platform independent mouse handling
+	void handleMouseButton(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position);
+	void handleMouseMove(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position);
+	void handleMouseWheel(const float delta);
 
 #if defined(_WIN32)
 	void setupConsole(std::string title);
@@ -315,6 +316,16 @@ public:
 	// Called if a key is pressed
 	// Can be overriden in derived class to do custom key handling
 	virtual void keyPressed(uint32_t keyCode);
+	// Called if a mouse button event occurs
+	// Can be overridden in derived class to do custom handling
+	virtual void onMouseButton(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position) {}
+	// Called if a mouse move event occurs
+	// Can be overridden in derived class to do custom handling
+	virtual void onMouseMove(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position) {}
+	// Called if a mouse wheel event occurs
+	// Can be overridden in derived class to do custom handling
+	virtual void onMouseWheel(const float delta) {}
+
 	// Called when the window has been resized
 	// Can be overriden in derived class to recreate or rebuild resources attached to the frame buffer / swapchain
 	virtual void windowResized();

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -225,6 +225,7 @@ public:
 	vks::VirtualMouseButtonFlags  mouseButtonFlags;
 #elif defined(__linux__)
 	vks::VirtualMouseButtonFlags  mouseButtonFlags;
+  glm::vec2 mousePosition;
 	bool quit = false;
 	xcb_connection_t *connection;
 	xcb_screen_t *screen;

--- a/vulkanExamples.sln
+++ b/vulkanExamples.sln
@@ -79,6 +79,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Base", "Base", "{09B9A54B-F
 		base\frustum.hpp = base\frustum.hpp
 		base\keycodes.hpp = base\keycodes.hpp
 		base\threadpool.hpp = base\threadpool.hpp
+		base\VirtualMouseButtonFlags.hpp = base\VirtualMouseButtonFlags.hpp
 		base\VulkanAndroid.cpp = base\VulkanAndroid.cpp
 		base\VulkanAndroid.h = base\VulkanAndroid.h
 		base\VulkanBuffer.hpp = base\VulkanBuffer.hpp


### PR DESCRIPTION
Introduced a VirtualMouseButtonFlags struct in the vks namespace. It represents virtual mouse button states.
Currently Android is still handled different as it has vastly different actions being tanken on touch.

Removed all the duplicated mouse handling code and moved it into
    void handleMouseButton(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position);
    void handleMouseMove(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position);
    void handleMouseWheel(const float delta);

Added custom mouse event handling methods for examples that want to handle mouse events.
    virtual void onMouseButton(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position);
    virtual void onMouseMove(const vks::VirtualMouseButtonFlags& buttonFlags, const glm::vec2& position);
    virtual void onMouseWheel(const float delta);