### PR TITLE
WSI Direct2Display

### DIFF
--- a/base/VulkanSwapChain.hpp
+++ b/base/VulkanSwapChain.hpp
@@ -601,7 +601,7 @@ public:
 		VkDisplayKHR* pDisplays = NULL;
 		for(uint32_t i = 0; i < planePropertyCount; i++)
 		{
-			uint32_t planeIndex=i;
+			planeIndex=i;
 			uint32_t displayCount;
 			vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, &displayCount, NULL);
 			if (pDisplays)

--- a/base/VulkanSwapChain.hpp
+++ b/base/VulkanSwapChain.hpp
@@ -555,7 +555,8 @@ public:
 		VkDisplayModeKHR displayMode;
 		VkDisplayModePropertiesKHR* pModeProperties;
 		bool foundMode = false;
-
+		std::stringstream output;
+		output << displayPropertyCount << " display available " << std::endl;
 	   	for(uint32_t i = 0; i < displayPropertyCount;++i)
 	   	{
 			display = pDisplayProperties[i].display;
@@ -563,11 +564,11 @@ public:
 			vkGetDisplayModePropertiesKHR(physicalDevice, display, &modeCount, NULL);
 			pModeProperties = new VkDisplayModePropertiesKHR[modeCount];
 			vkGetDisplayModePropertiesKHR(physicalDevice, display, &modeCount, pModeProperties);
-
+			output << " -display " << i << " (" << pDisplayProperties[i].displayName << ") supports " << modeCount << " modes" << std::endl;
 			for (uint32_t j = 0; j < modeCount; ++j)
 			{
 				const VkDisplayModePropertiesKHR* mode = &pModeProperties[j];
-
+				output << "  -mode " << mode->parameters.visibleRegion.width << "x" << mode->parameters.visibleRegion.height << "@" << (uint32_t)(mode->parameters.refreshRate/1000) << "Hz" << std::endl;
 				if (mode->parameters.visibleRegion.width == width && mode->parameters.visibleRegion.height == height)
 				{
 					displayMode = mode->displayMode;
@@ -584,7 +585,8 @@ public:
 
 		if(!foundMode)
 		{
-			vks::tools::exitFatal("Can't find a display and a display mode!", "Fatal error");
+			output << "Can't find a display mode " << width << "x" << height <<" ! please select from above!" << std::endl;
+			vks::tools::exitFatal(output.str(), "Fatal error");
 			return;
 		}
 

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -670,6 +670,14 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 			uint32_t w = strtol(args[i + 1], &endptr, 10);
 			if (endptr != args[i + 1]) { width = w; };
 		}
+#if defined(_DIRECT2DISPLAY)
+		if (args[i] == std::string("-display"))
+		{
+			char* endptr;
+			uint32_t d = strtol(args[i + 1], &endptr, 10);
+			if (endptr != args[i + 1]) { displayId = d; };
+		}
+#endif
 		if ((args[i] == std::string("-h")) || (args[i] == std::string("-height")))
 		{
 			char* endptr;
@@ -2117,7 +2125,7 @@ void VulkanExampleBase::initSwapchain()
 #elif defined(__ANDROID__)	
 	swapChain.initSurface(androidApp->window);
 #elif defined(_DIRECT2DISPLAY)
-	swapChain.initSurface(width, height);
+	swapChain.initSurface(width, height, displayId);
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
 	swapChain.initSurface(display, surface);
 #elif defined(__linux__)

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -227,6 +227,7 @@ public:
 	} mouseButtons;
 #elif defined(_DIRECT2DISPLAY)
 	bool quit = false;
+	uint32_t displayId = 0;
 #elif defined(__linux__)
 	struct {
 		bool left = false;


### PR DESCRIPTION
*Added macro to use default display plane, instead of query for best display plane.
"vkGetPhysicalDeviceDisplayPlanePropertiesKHR" api crashes on some target, even if vkGetPhysicalDeviceDisplayPlanePropertiesKHR is valid.
macro USE_DEFAULT_DISPLAY_PLANE_0 avoid this function call and uses default plane 0(as if display attach at least one plane need to be present with id 0)
by default macro is not enable, if your target crashes for "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" function call, can try enabling USE_DEFAULT_DISPLAY_PLANE_0 macro in VulkanSwapChain.hpp.