### PR TITLE
Proper app termination after WM_QUIT

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -216,7 +216,7 @@ void VulkanExampleBase::renderLoop()
 	destHeight = height;
 #if defined(_WIN32)
 	MSG msg;
-   bool quitMessageReceived = false;
+	bool quitMessageReceived = false;
 	while (!quitMessageReceived)
 	{
 		auto tStart = std::chrono::high_resolution_clock::now();
@@ -231,11 +231,11 @@ void VulkanExampleBase::renderLoop()
 			TranslateMessage(&msg);
 			DispatchMessage(&msg);
 
-           if (msg.message == WM_QUIT)
-           {
-               quitMessageReceived = true;
-               break;
-           }
+			if (msg.message == WM_QUIT)
+			{
+				quitMessageReceived = true;
+				break;
+			}
 		}
 
 		render();

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -216,7 +216,8 @@ void VulkanExampleBase::renderLoop()
 	destHeight = height;
 #if defined(_WIN32)
 	MSG msg;
-	while (TRUE)
+   bool quitMessageReceived = false;
+	while (!quitMessageReceived)
 	{
 		auto tStart = std::chrono::high_resolution_clock::now();
 		if (viewUpdated)
@@ -229,11 +230,12 @@ void VulkanExampleBase::renderLoop()
 		{
 			TranslateMessage(&msg);
 			DispatchMessage(&msg);
-		}
 
-		if (msg.message == WM_QUIT)
-		{
-			break;
+           if (msg.message == WM_QUIT)
+           {
+               quitMessageReceived = true;
+               break;
+           }
 		}
 
 		render();


### PR DESCRIPTION
According to MSDN PeekMessage returns false only when the message queue is empty. If there is another message after WM_QUIT, the part of the code responsible for proper closing of the application would never be triggered. This change handles WM_QUIT message properly.