### PR TITLE
Support installing demos, support out-of-tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ include_directories(base)
 OPTION(USE_D2D_WSI "Build the project using Direct to Display swapchain" OFF)
 OPTION(USE_WAYLAND_WSI "Build the project using Wayland swapchain" OFF)
 
+set(RESOURCE_INSTALL_DIR "" CACHE PATH "Path to install resources to (leave empty for running uninstalled)")
+
 # Use FindVulkan module added with CMAKE 3.7
 if (NOT CMAKE_VERSION VERSION_LESS 3.7.0)
 	message(STATUS "Using module to find Vulkan")
@@ -108,6 +110,10 @@ function(buildExample EXAMPLE_NAME)
 		add_executable(${EXAMPLE_NAME} ${MAIN_CPP} ${SOURCE} ${SHADERS})
 		target_link_libraries(${EXAMPLE_NAME} ${Vulkan_LIBRARY} ${ASSIMP_LIBRARIES} ${WAYLAND_CLIENT_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 	endif(WIN32)
+
+	if(RESOURCE_INSTALL_DIR)
+		install(TARGETS ${EXAMPLE_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+	endif()
 endfunction(buildExample)
 
 # Build all examples
@@ -116,6 +122,13 @@ function(buildExamples)
 		buildExample(${EXAMPLE})
 	endforeach(EXAMPLE)
 endfunction(buildExamples)
+
+if(RESOURCE_INSTALL_DIR)
+	add_definitions(-DVK_EXAMPLE_DATA_DIR=\"${RESOURCE_INSTALL_DIR}/\")
+	install(DIRECTORY data/ DESTINATION ${RESOURCE_INSTALL_DIR}/)
+else()
+	add_definitions(-DVK_EXAMPLE_DATA_DIR=\"${CMAKE_SOURCE_DIR}/data/\")
+endif()
 
 # Compiler specific stuff
 IF(MSVC)
@@ -128,7 +141,7 @@ ELSE(WIN32)
 	link_libraries(${XCB_LIBRARIES} ${Vulkan_LIBRARY})
 ENDIF(WIN32)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
 
 set(EXAMPLES 
 	bloom

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -83,6 +83,8 @@ const std::string VulkanExampleBase::getAssetPath()
 {
 #if defined(__ANDROID__)
 	return "";
+#elif defined(VK_EXAMPLE_DATA_DIR)
+	return VK_EXAMPLE_DATA_DIR;
 #else
 	return "./../data/";
 #endif


### PR DESCRIPTION
Hi,
I'm using your demos (at least the parts without ambiguous licensing) as a Vulkan smoke testing tool in Yocto. The use-case requires installing so I cooked up this patch.

A define for install path is a bit unusual: I did because I didn't want to break the developer use case of "compile &run without installing" by default... There's no install targets at all if the define is not set: this way no-one can install binaries that would try to load data from CMAKE_SOURCE_DIR.