### PR TITLE
Fixed pure virtual function buildCommandBuffers in VulcanExampleBase

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -1924,8 +1924,6 @@ void VulkanExampleBase::viewChanged() {}
 
 void VulkanExampleBase::keyPressed(uint32_t) {}
 
-void VulkanExampleBase::buildCommandBuffers() {}
-
 void VulkanExampleBase::createCommandPool()
 {
 	VkCommandPoolCreateInfo cmdPoolInfo = {};

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -331,7 +331,7 @@ public:
 	// Pure virtual function to be overriden by the dervice class
 	// Called in case of an event where e.g. the framebuffer has to be rebuild and thus
 	// all command buffers that may reference this
-	virtual void buildCommandBuffers();
+	virtual void buildCommandBuffers() = 0;
 
 	// Creates a new (graphics) command pool object storing command buffers
 	void createCommandPool();

--- a/multithreading/multithreading.cpp
+++ b/multithreading/multithreading.cpp
@@ -165,6 +165,9 @@ public:
 		vkDestroyFence(device, renderFence, nullptr);
 	}
 
+	virtual void buildCommandBuffers()
+	{}
+
 	float rnd(float range)
 	{
 		return range * (rand() / double(RAND_MAX));


### PR DESCRIPTION
The comment says, it is a pure virtual function, but it was not. This was it was easy to make a mistake