### PR TITLE
add datas and shaders as custom targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,64 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 add_definitions(-std=c++11)
 
-file(GLOB SOURCE *.cpp )
+# Find glslc shader compiler.
+# On Android, the NDK includes the binary, so no external dependency.
+if(ANDROID)
+    file(GLOB glslc-folders ${ANDROID_NDK}/shader-tools/*)
+else()
+    file(GLOB glslc-folders ${VULKAN_SDK}/bin "$ENV{VULKAN_SDK}/bin" "$ENV{PATH}")
+endif()
+find_program(GLSLC glslc HINTS ${glslc-folders})
+IF (GLSLC_NOTFOUND)
+	message(FATAL_ERROR "Could not find glslc compiler!")
+ELSE()
+	message(STATUS "Found spir-v compiler: " ${GLSLC})
+ENDIF()
+
+# Add data target if build outside source tree
+if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/")
+else()
+    file(GLOB_RECURSE DATAS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "data/models/*" "data/textures/*" "data/*.fnt")
+    FOREACH(DATA_FILE ${DATAS})
+        set(copy-output ${CMAKE_CURRENT_BINARY_DIR}/${DATA_FILE})
+        GET_FILENAME_COMPONENT(copy-dest-dir ${copy-output} DIRECTORY)
+        ADD_CUSTOM_COMMAND(
+           OUTPUT  "${copy-output}"
+           COMMAND ${CMAKE_COMMAND} -E make_directory ${copy-dest-dir}
+           COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/${DATA_FILE}" "${copy-output}"
+           COMMENT "Copying ${DATA_FILE} to ${copy-output}"
+           DEPENDS ${DATA_FILE}
+           VERBATIM
+        )
+        set(DATA_OUTPUTS ${DATA_OUTPUTS} ${copy-output})
+    ENDFOREACH()
+    add_custom_target(DataCopy ALL DEPENDS ${DATA_OUTPUTS} SOURCES ${DATAS})
+endif()
+
+file(GLOB SOURCE *.cpp)
+
+# Function for building shader
+function(buildShader EXAMPLE_NAME)
+	# Add shaders target
+	set(SHADER_DIR data/shaders/${EXAMPLE_NAME})
+	file(GLOB SHADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${SHADER_DIR}/*.vert" "${SHADER_DIR}/*.frag" "${SHADER_DIR}/*.geom" "${SHADER_DIR}/*.tesc" "${SHADER_DIR}/*.tese")
+	source_group("Shaders" FILES ${SHADERS})
+	foreach(SHADER ${SHADERS})
+		set(shader-input ${CMAKE_CURRENT_SOURCE_DIR}/${SHADER})
+		set(shader-output ${CMAKE_CURRENT_BINARY_DIR}/${SHADER}.spv)
+		add_custom_command (
+		  OUTPUT ${shader-output}
+		  COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/${SHADER_DIR}"
+		  COMMAND "${GLSLC}" ${shader-input} -o ${shader-output}
+		  COMMENT "Compiling ${shader-input}"
+		  DEPENDS ${shader-input}
+		  VERBATIM
+		)
+		set(SHADER_OUTPUTS ${SHADER_OUTPUTS} ${shader-output})
+	endforeach(SHADER)
+	add_custom_target("${EXAMPLE_NAME}.Shaders" ALL DEPENDS ${SHADER_OUTPUTS} SOURCES ${SHADERS})
+endfunction(buildShader)
 
 # Function for building single example
 function(buildExample EXAMPLE_NAME)
@@ -97,15 +154,12 @@ function(buildExample EXAMPLE_NAME)
 		file(GLOB ADD_SOURCE external/imgui/*.cpp)
 		SET(SOURCE ${SOURCE} ${ADD_SOURCE})
 	ENDIF()
-	# Add shaders
-	set(SHADER_DIR data/shaders/${EXAMPLE_NAME})
-	file(GLOB SHADERS "${SHADER_DIR}/*.vert" "${SHADER_DIR}/*.frag" "${SHADER_DIR}/*.geom" "${SHADER_DIR}/*.tesc" "${SHADER_DIR}/*.tese")
-	source_group("Shaders" FILES ${SHADERS})
+	buildShader(${EXAMPLE_NAME})
 	if(WIN32)
-		add_executable(${EXAMPLE_NAME} WIN32 ${MAIN_CPP} ${SOURCE} ${SHADERS})
+		add_executable(${EXAMPLE_NAME} WIN32 ${MAIN_CPP} ${SOURCE})
 		target_link_libraries(${EXAMPLE_NAME} base ${Vulkan_LIBRARY} ${ASSIMP_LIBRARIES} ${WINLIBS})
 	else(WIN32)
-		add_executable(${EXAMPLE_NAME} ${MAIN_CPP} ${SOURCE} ${SHADERS})
+		add_executable(${EXAMPLE_NAME} ${MAIN_CPP} ${SOURCE})
 		target_link_libraries(${EXAMPLE_NAME} base )
 	endif(WIN32)
 endfunction(buildExample)
@@ -127,8 +181,6 @@ IF(WIN32)
 ELSE(WIN32)
 	link_libraries(${XCB_LIBRARIES} ${Vulkan_LIBRARY} ${Vulkan_LIBRARY} ${ASSIMP_LIBRARIES} ${WAYLAND_CLIENT_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 ENDIF(WIN32)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/")
 
 add_subdirectory(base)
 
@@ -190,4 +242,5 @@ set(EXAMPLES
 	vulkanscene
 )
 
+buildShader(base)
 buildExamples()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ ENDIF()
 # Add data target if build outside source tree
 if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/")
+    add_definitions(-DBUILT_INSIDE_SRC_TREE)
 else()
     file(GLOB_RECURSE DATAS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "data/models/*" "data/textures/*" "data/*.fnt")
     FOREACH(DATA_FILE ${DATAS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ set(NAME vulkanExamples)
 
 project(${NAME})
 
+if (NOT DEFINED ${CMAKE_BUILD_TYPE})
+	message(WARNING "Build type (Debug/Release) not set in 'CMAKE_BUILD_TYPE'")
+else()
+	message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+endif()
+
 include_directories(external)
 include_directories(external/glm)
 include_directories(external/gli)
@@ -124,7 +130,7 @@ file(GLOB SOURCE *.cpp)
 function(buildShader EXAMPLE_NAME)
 	# Add shaders target
 	set(SHADER_DIR data/shaders/${EXAMPLE_NAME})
-	file(GLOB SHADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${SHADER_DIR}/*.vert" "${SHADER_DIR}/*.frag" "${SHADER_DIR}/*.geom" "${SHADER_DIR}/*.tesc" "${SHADER_DIR}/*.tese")
+	file(GLOB SHADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${SHADER_DIR}/*.vert" "${SHADER_DIR}/*.frag" "${SHADER_DIR}/*.geom"  "${SHADER_DIR}/*.comp" "${SHADER_DIR}/*.tesc" "${SHADER_DIR}/*.tese")
 	source_group("Shaders" FILES ${SHADERS})
 	foreach(SHADER ${SHADERS})
 		set(shader-input ${CMAKE_CURRENT_SOURCE_DIR}/${SHADER})

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -17,7 +17,7 @@ VkResult VulkanExampleBase::createInstance(bool enableValidation)
 	// Validation can also be forced via a define
 #if defined(_VALIDATION)
 	this->settings.validation = true;
-#endif	
+#endif
 
 	VkApplicationInfo appInfo = {};
 	appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
@@ -39,9 +39,9 @@ VkResult VulkanExampleBase::createInstance(bool enableValidation)
 #elif defined(__linux__)
 	instanceExtensions.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
 #elif defined(VK_USE_PLATFORM_IOS_MVK)
-    instanceExtensions.push_back(VK_MVK_IOS_SURFACE_EXTENSION_NAME);
+	instanceExtensions.push_back(VK_MVK_IOS_SURFACE_EXTENSION_NAME);
 #elif defined(VK_USE_PLATFORM_MACOS_MVK)
-    instanceExtensions.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+	instanceExtensions.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
 #endif
 
 	VkInstanceCreateInfo instanceCreateInfo = {};
@@ -84,7 +84,7 @@ const std::string VulkanExampleBase::getAssetPath()
 #if defined(__ANDROID__)
 	return "";
 #else
-	return "./../data/";
+	return "./data/";
 #endif
 }
 #endif
@@ -148,7 +148,7 @@ void VulkanExampleBase::flushCommandBuffer(VkCommandBuffer commandBuffer, VkQueu
 	{
 		return;
 	}
-	
+
 	VK_CHECK_RESULT(vkEndCommandBuffer(commandBuffer));
 
 	VkSubmitInfo submitInfo = {};
@@ -225,39 +225,39 @@ VkPipelineShaderStageCreateInfo VulkanExampleBase::loadShader(std::string fileNa
 void VulkanExampleBase::renderFrame()
 {
 #if (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-    auto tStart = std::chrono::high_resolution_clock::now();
-    if (viewUpdated)
-    {
-        viewUpdated = false;
-        viewChanged();
-    }
-    render();
-    frameCounter++;
-    auto tEnd = std::chrono::high_resolution_clock::now();
-    auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
-    frameTimer = tDiff / 1000.0f;
-    camera.update(frameTimer);
-    if (camera.moving())
-    {
-        viewUpdated = true;
-    }
-    // Convert to clamped timer value
-    if (!paused)
-    {
-        timer += timerSpeed * frameTimer;
-        if (timer > 1.0)
-        {
-            timer -= 1.0f;
-        }
-    }
-    fpsTimer += (float)tDiff;
-    if (fpsTimer > 1000.0f)
-    {
-        lastFPS = frameCounter;
-        updateTextOverlay();
-        fpsTimer = 0.0f;
-        frameCounter = 0;
-    }
+	auto tStart = std::chrono::high_resolution_clock::now();
+	if (viewUpdated)
+	{
+		viewUpdated = false;
+		viewChanged();
+	}
+	render();
+	frameCounter++;
+	auto tEnd = std::chrono::high_resolution_clock::now();
+	auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
+	frameTimer = tDiff / 1000.0f;
+	camera.update(frameTimer);
+	if (camera.moving())
+	{
+		viewUpdated = true;
+	}
+	// Convert to clamped timer value
+	if (!paused)
+	{
+		timer += timerSpeed * frameTimer;
+		if (timer > 1.0)
+		{
+			timer -= 1.0f;
+		}
+	}
+	fpsTimer += (float)tDiff;
+	if (fpsTimer > 1000.0f)
+	{
+		lastFPS = frameCounter;
+		updateTextOverlay();
+		fpsTimer = 0.0f;
+		frameCounter = 0;
+	}
 #endif
 }
 
@@ -570,7 +570,7 @@ void VulkanExampleBase::renderLoop()
 		}
 	}
 #endif
-	// Flush device to make sure all resources can be freed 
+	// Flush device to make sure all resources can be freed
 	vkDeviceWaitIdle(device);
 }
 
@@ -588,7 +588,7 @@ void VulkanExampleBase::updateTextOverlay()
 	textOverlay->addText(ss.str(), 5.0f, 25.0f, VulkanTextOverlay::alignLeft);
 
 	std::string deviceName(deviceProperties.deviceName);
-#if defined(__ANDROID__)	
+#if defined(__ANDROID__)
 	deviceName += " (" + androidProduct + ")";
 #endif
 	textOverlay->addText(deviceName, 5.0f, 45.0f, VulkanTextOverlay::alignLeft);
@@ -699,7 +699,7 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 			if (endptr != args[i + 1]) { height = h; };
 		}
 	}
-	
+
 #if defined(__ANDROID__)
 	// Vulkan library is loaded dynamically on Android
 	bool libLoaded = vks::android::loadVulkanLibrary();
@@ -835,7 +835,7 @@ void VulkanExampleBase::initVulkan()
 	// Defaults to the first device unless specified by command line
 	uint32_t selectedDevice = 0;
 
-#if !defined(__ANDROID__)	
+#if !defined(__ANDROID__)
 	// GPU selection via command line argument
 	for (size_t i = 0; i < args.size(); i++)
 	{
@@ -844,12 +844,12 @@ void VulkanExampleBase::initVulkan()
 		{
 			char* endptr;
 			uint32_t index = strtol(args[i + 1], &endptr, 10);
-			if (endptr != args[i + 1]) 
-			{ 
+			if (endptr != args[i + 1])
+			{
 				if (index > gpuCount - 1)
 				{
 					std::cerr << "Selected device index " << index << " is out of range, reverting to device 0 (use -listgpus to show available Vulkan devices)" << std::endl;
-				} 
+				}
 				else
 				{
 					std::cout << "Selected Vulkan device " << index << std::endl;
@@ -863,11 +863,11 @@ void VulkanExampleBase::initVulkan()
 		{
 			uint32_t gpuCount = 0;
 			VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, nullptr));
-			if (gpuCount == 0) 
+			if (gpuCount == 0)
 			{
 				std::cerr << "No Vulkan devices found!" << std::endl;
 			}
-			else 
+			else
 			{
 				// Enumerate devices
 				std::cout << "Available Vulkan devices" << std::endl;
@@ -950,7 +950,7 @@ void VulkanExampleBase::initVulkan()
 		androidProduct += std::string(prop);
 	};
 	LOGD("androidProduct = %s", androidProduct.c_str());
-#endif	
+#endif
 }
 
 #if defined(_WIN32)
@@ -1381,8 +1381,8 @@ void VulkanExampleBase::handleAppCommand(android_app * app, int32_t cmd)
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
 void* VulkanExampleBase::setupWindow(void* view)
 {
-    this->view = view;
-    return view;
+	this->view = view;
+	return view;
 }
 #elif defined(_DIRECT2DISPLAY)
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
@@ -1756,7 +1756,7 @@ xcb_window_t VulkanExampleBase::setupWindow()
 				&(atom_wm_fullscreen->atom));
 		free(atom_wm_fullscreen);
 		free(atom_wm_state);
-	}	
+	}
 
 	xcb_map_window(connection, window);
 
@@ -1869,10 +1869,10 @@ void VulkanExampleBase::handleEvent(const xcb_generic_event_t *event)
 				{
 					textOverlay->visible = !textOverlay->visible;
 				}
-				break;				
+				break;
 		}
 	}
-	break;	
+	break;
 	case XCB_KEY_RELEASE:
 	{
 		const xcb_key_release_event_t *keyEvent = (const xcb_key_release_event_t *)event;
@@ -1889,7 +1889,7 @@ void VulkanExampleBase::handleEvent(const xcb_generic_event_t *event)
 				break;
 			case KEY_D:
 				camera.keys.right = false;
-				break;			
+				break;
 			case KEY_ESCAPE:
 				quit = true;
 				break;
@@ -2107,7 +2107,7 @@ void VulkanExampleBase::windowResize()
 	vkDestroyImage(device, depthStencil.image, nullptr);
 	vkFreeMemory(device, depthStencil.mem, nullptr);
 	setupDepthStencil();
-	
+
 	for (uint32_t i = 0; i < frameBuffers.size(); i++)
 	{
 		vkDestroyFramebuffer(device, frameBuffers[i], nullptr);
@@ -2146,10 +2146,10 @@ void VulkanExampleBase::initSwapchain()
 {
 #if defined(_WIN32)
 	swapChain.initSurface(windowInstance, window);
-#elif defined(__ANDROID__)	
+#elif defined(__ANDROID__)
 	swapChain.initSurface(androidApp->window);
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-    swapChain.initSurface(view);
+	swapChain.initSurface(view);
 #elif defined(_DIRECT2DISPLAY)
 	swapChain.initSurface(width, height);
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -83,6 +83,8 @@ const std::string VulkanExampleBase::getAssetPath()
 {
 #if defined(__ANDROID__)
 	return "";
+#elif defined(BUILT_INSIDE_SRC_TREE)
+	return "./../data/";
 #else
 	return "./data/";
 #endif


### PR DESCRIPTION
This PR would add custom targets for compiling shaders and copying datas so that each time a shader or a data file is changed, it will be included in the build.

- Add custom target for data copy to the build dir but only if build is done outside source dir.
- Add custom targets for shader compilation, one per example
- glslc compiler is searched and build is canceled if not found

precompiled spir-v shaders could be removed from git.