### PR TITLE
added verification of submodules for android

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -20,6 +20,10 @@ Since Vulkan is not yet part of the Android OS (like OpenGL ES) the library and 
 
 ### Building the Examples
 
+### Grab Externals
+
+Make sure all submodules have been cloned using the [steps from main README](../README.md#cloning).
+
 ### Complete set
 
 **Please note that building (and deploying) all examples may take a while**

--- a/android/build.py
+++ b/android/build.py
@@ -11,6 +11,11 @@ SDK_VERSION = "android-23"
 
 PROJECT_FOLDER = ""
 
+# Check if python 3, python 2 not supported
+if sys.version_info <= (3, 0):
+    print("Sorry, requires Python 3.x, not Python 2.x")
+    sys.exit(-1)
+
 # Name/folder of the project to build
 if len(sys.argv) > 1:
     PROJECT_FOLDER = sys.argv[1]

--- a/android/build.py
+++ b/android/build.py
@@ -71,6 +71,12 @@ for arg in sys.argv[1:]:
         BUILD_ARGS = "APP_CFLAGS=-D_VALIDATION"
         break
 
+# Verify submodules are loaded in external folder
+if not os.listdir("../external/glm/") or not os.listdir("../external/gli/"):
+    print("External submodules not loaded. Clone them using:")
+    print("\tgit submodule init\n\tgit submodule update")
+    sys.exit(-1)
+
 # Build
 os.chdir(PROJECT_FOLDER)
 


### PR DESCRIPTION
The current steps for android build didn't have the new notion of needing to clone the submodules. This causes undefined references when trying to build. Added nice little check to help solve the reason faster.