### PR TITLE
I changed two lines

### DIFF
--- a/multithreading/multithreading.cpp
+++ b/multithreading/multithreading.cpp
@@ -352,7 +352,6 @@ public:
 		VkCommandBufferBeginInfo cmdBufInfo = vks::initializers::commandBufferBeginInfo();
 
 		VkClearValue clearValues[2];
-		clearValues[0].color = defaultClearColor;
 		clearValues[0].color = { {0.0f, 0.0f, 0.2f, 0.0f} };
 		clearValues[1].depthStencil = { 1.0f, 0 };
 

--- a/pushconstants/pushconstants.cpp
+++ b/pushconstants/pushconstants.cpp
@@ -144,7 +144,7 @@ public:
 			pushConstants[2] = glm::vec4(r * 0.85f * sin_t, y, -sin_t * 2.5f, 1.5f);
 			pushConstants[3] = glm::vec4(0.0f, y, r * 1.25f * cos_t, 1.5f);
 			pushConstants[4] = glm::vec4(r * 2.25f * cos_t, y, 0.0f, 1.25f);
-			pushConstants[5] = glm::vec4(r * 2.5f * cos(glm::radians(timer * 360)), y, r * 2.5f * sin_t, 1.25f);
+			pushConstants[5] = glm::vec4(r * 2.5f * cos_t, y, r * 2.5f * sin_t, 1.25f);
 #undef r
 #undef y
 #undef sin_t


### PR DESCRIPTION
For the multithreading line the defaultclearcolor is immediately overwritten. For pushconstants you had cos_t as a direct replacement for that line, and so I changed it to cos_t, these are the only two nitpicks I noticed looking around so far