### PR TITLE
base: Check for swapchain blit source feature instead of destination

### DIFF
--- a/base/VulkanSwapChain.hpp
+++ b/base/VulkanSwapChain.hpp
@@ -394,7 +394,7 @@ public:
 		// Set additional usage flag for blitting from the swapchain images if supported
 		VkFormatProperties formatProps;
 		vkGetPhysicalDeviceFormatProperties(physicalDevice, colorFormat, &formatProps);
-		if (formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT) {
+		if (formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT) {
 			swapchainCI.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 		}
 


### PR DESCRIPTION
As I understand it the goal is to use the swapchain image as a transfer source (for taking screenshots), not as a transfer destination.