### PR TITLE
imgui: Use TextUnformatted where appropriate

### DIFF
--- a/imgui/main.cpp
+++ b/imgui/main.cpp
@@ -343,8 +343,8 @@ public:
 
 		ImVec4 clear_color = ImColor(114, 144, 154);
 		static float f = 0.0f;
-		ImGui::Text(example->title.c_str());
-		ImGui::Text(device->properties.deviceName);
+		ImGui::TextUnformatted(example->title.c_str());
+		ImGui::TextUnformatted(device->properties.deviceName);
 
 		// Update frame time display
 		if (updateFrameGraph) {


### PR DESCRIPTION
imgui::Text takes a printf format expression, but the goal is to just print unformatted text here. Any formatting characters in the title or device name could result in crashes.
(this also shuts up a gcc warning)