### PR TITLE
Call Android subprocesses with python3

### DIFF
--- a/android/build-all.py
+++ b/android/build-all.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Build all examples
 # Pass -deploy to also install on connected device
 import subprocess
@@ -75,7 +77,7 @@ print("Building all examples...")
 
 for example in EXAMPLES:
     print(COLOR_GREEN + "Building %s (%d/%d)" % (example, CURR_INDEX, len(EXAMPLES)) + COLOR_END)
-    if subprocess.call(("python build.py %s %s" % (example, BUILD_ARGUMENTS)).split(' ')) != 0:
+    if subprocess.call(("python3 build.py %s %s" % (example, BUILD_ARGUMENTS)).split(' ')) != 0:
         print("Error during build process for %s" % example)
         sys.exit(-1)
     CURR_INDEX += 1

--- a/android/build.py
+++ b/android/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Single example build and deploy script
 import os
 import subprocess

--- a/android/install-all.py
+++ b/android/install-all.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Install all examples to connected device(s)
 import subprocess
 import sys
@@ -8,6 +10,6 @@ if answer:
     for arg in sys.argv[1:]:
         if arg == "-validation":
             BUILD_ARGUMENTS += "-validation"
-    if subprocess.call(("python build-all.py -deploy %s" % BUILD_ARGUMENTS).split(' ')) != 0:
+    if subprocess.call(("python3 build-all.py -deploy %s" % BUILD_ARGUMENTS).split(' ')) != 0:
         print("Error: Not all examples may have been installed!")
         sys.exit(-1)

--- a/android/uninstall-all.py
+++ b/android/uninstall-all.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Remove all examples from connected device(s)
 import subprocess
 import sys

--- a/download_assets.py
+++ b/download_assets.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 from urllib.request import urlretrieve
 from zipfile import ZipFile


### PR DESCRIPTION
Ensure that python 3 is used on systems in which python2 is the default
python executable, but which have both pythons installed.

Tested in Ubuntu 16.04.