### PR TITLE
VulkanUIOverlay: Use the correct initial layout

### DIFF
--- a/base/VulkanUIOverlay.cpp
+++ b/base/VulkanUIOverlay.cpp
@@ -337,7 +337,7 @@ namespace vks
 		attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 		attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-		attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+		attachments[0].initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 		attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
 		// Depth attachment


### PR DESCRIPTION
Using an initial layout of VK_IMAGE_LAYOUT_UNDEFINED together with
VK_ATTACHMENT_LOAD_OP_LOAD means that the render pass starts off with
completely undefined contents.  Since we want to draw the overlay on top
of the previously rendered image, we want to use a real layout.  Since
the calling code has already transitioned to VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
that's the layout we need to use.

This was never caught by validation because VK_IMAGE_LAYOUT_UNDEFINED is
the one layout you're allowed to use as an initial layout at any time
regardless of the image's current layout.