### PR TITLE
Request coherent memory for model staging buffer

### DIFF
--- a/base/VulkanModel.hpp
+++ b/base/VulkanModel.hpp
@@ -314,7 +314,7 @@ namespace vks
 				// Vertex buffer
 				VK_CHECK_RESULT(device->createBuffer(
 					VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
 					&vertexStaging,
 					vBufferSize,
 					vertexBuffer.data()));
@@ -322,7 +322,7 @@ namespace vks
 				// Index buffer
 				VK_CHECK_RESULT(device->createBuffer(
 					VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
 					&indexStaging,
 					iBufferSize,
 					indexBuffer.data()));


### PR DESCRIPTION
There is no guarantee in the spec on the order of the following memory types:

```
VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT,
VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
```

which means we can't assume that the first memory type that is host visible is going to be coherent.