### PR TITLE
Fix layout transitions in renderheadless

### DIFF
--- a/examples/renderheadless/renderheadless.cpp
+++ b/examples/renderheadless/renderheadless.cpp
@@ -415,7 +415,7 @@ public:
 			attchmentDescriptions[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 			attchmentDescriptions[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 			attchmentDescriptions[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-			attchmentDescriptions[0].finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			attchmentDescriptions[0].finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 			// Depth attachment
 			attchmentDescriptions[1].format = depthFormat;
 			attchmentDescriptions[1].samples = VK_SAMPLE_COUNT_1_BIT;
@@ -706,17 +706,7 @@ public:
 				VK_PIPELINE_STAGE_TRANSFER_BIT,
 				VkImageSubresourceRange{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 });
 
-			// Transition color attachment to transfer source
-			vks::tools::insertImageMemoryBarrier(
-				copyCmd,
-				colorAttachment.image,
-				0,
-				VK_ACCESS_TRANSFER_READ_BIT,
-				VK_IMAGE_LAYOUT_UNDEFINED,
-				VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-				VK_PIPELINE_STAGE_TRANSFER_BIT,
-				VK_PIPELINE_STAGE_TRANSFER_BIT,
-				VkImageSubresourceRange{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 });
+			// colorAttachment.image is already in VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, and does not need to be transitioned
 
 			VkImageCopy imageCopyRegion{};
 			imageCopyRegion.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;


### PR DESCRIPTION
Old code had an UNDEFINED to TRANSFER_SRC_OPTIMAL transitions
causing the read-back image to also be undefined.

Fixes issue #415