### PR TITLE
multisampling, subpasses, textoverlay: Fix renderpass initial layout.

### DIFF
--- a/examples/multisampling/multisampling.cpp
+++ b/examples/multisampling/multisampling.cpp
@@ -343,6 +343,7 @@ public:
 		// Create custom overlay render pass
 		colorReference.attachment = 1;
 		attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+		attachments[1].initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 		subpass.pResolveAttachments = 0;
 		subpass.pDepthStencilAttachment = 0;
 

--- a/examples/subpasses/subpasses.cpp
+++ b/examples/subpasses/subpasses.cpp
@@ -443,6 +443,7 @@ public:
 
 		// Create custom overlay render pass
 		attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+		attachments[0].initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 		VK_CHECK_RESULT(vkCreateRenderPass(device, &renderPassInfo, nullptr, &uiRenderPass));
 	}
 

--- a/examples/textoverlay/textoverlay.cpp
+++ b/examples/textoverlay/textoverlay.cpp
@@ -470,7 +470,7 @@ public:
 		attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 		attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-		attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+		attachments[0].initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 		attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
 		// Depth attachment


### PR DESCRIPTION
Fixes #418