### PR TITLE
macOS update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,6 @@ data/models/cerberus/*.*
 *.vcxproj
 *.vcxproj.filters
 *.vcxproj.user
+
+# Ignore macOS .DS_Store
+.DS_Store

--- a/xcode/README_MoltenVK_Examples.md
+++ b/xcode/README_MoltenVK_Examples.md
@@ -7,7 +7,7 @@
 Copyright (c) 2016-2017 [The Brenwill Workshop Ltd.](http://www.brenwill.com).
 This document is licensed under the MIT license (MIT) (http://opensource.org/licenses/MIT)
 
-*This document is written in [Markdown](http://en.wikipedia.org/wiki/Markdown) format. 
+*This document is written in [Markdown](http://en.wikipedia.org/wiki/Markdown) format.
 For best results, use a Markdown reader.*
 
 
@@ -16,7 +16,7 @@ For best results, use a Markdown reader.*
 Introduction
 ------------
 
-The *Xcode* project in this folder builds and runs the *Vulkan* examples in this 
+The *Xcode* project in this folder builds and runs the *Vulkan* examples in this
 repository on *iOS* and *macOS*, using the **MoltenVK** *Vulkan* driver.
 
 
@@ -26,7 +26,7 @@ repository on *iOS* and *macOS*, using the **MoltenVK** *Vulkan* driver.
 Installing MoltenVK
 -------------------
 
-The examples in this repository can be run on *iOS* and *macOS* by using 
+The examples in this repository can be run on *iOS* and *macOS* by using
 the [**MoltenVK**](http://www.moltengl.com/moltenvk/) *Vulkan* driver.
 
 These examples require **MoltenVK 0.18.0** or greater.
@@ -34,16 +34,16 @@ These examples require **MoltenVK 0.18.0** or greater.
 Follow these instructions to install **MoltenVK**:
 
 1. [Download](https://moltengl.com/free-trial/) the **Molten** free evaluation trial.
-   This free trial includes **MoltenVK**, is full-featured, and is not time-limited. 
-   You must purchase a license if you wish to use **MoltenVK** for a production 
+   This free trial includes **MoltenVK**, is full-featured, and is not time-limited.
+   You must purchase a license if you wish to use **MoltenVK** for a production
    application or game, but you can use the evaluation version to run these examples.
-   
+
 2. Unzip the **Molten** package, and move it to a folder outside this repository.
 
 3. Open a *Terminal* session and navigate to the directory containing this document,
    remove the existing `MoltenVK` symbolic link in this directory, and create a new
    symbolic link pointing to the `MoltenVK` directory in the **Molten** package:
-   
+
    		cd path-to-this-directory
 		rm MoltenVK
 		ln -s path-to-Molten-package/MoltenVK
@@ -55,13 +55,13 @@ Follow these instructions to install **MoltenVK**:
 Installing AssImp
 -----------------
 
-The examples in this repository make use of the [*AssImp*](http://assimp.sourceforge.net) 
-library to load resource assets from files. To run the examples you must download and 
+The examples in this repository make use of the [*AssImp*](http://assimp.sourceforge.net)
+library to load resource assets from files. To run the examples you must download and
 install *AssImp* library as follows.
 
->***Note:*** Due to the way that *AssImp* makes use of the *CMake* utility, an installation 
-of *AssImp* can only be built for a single platform. To create *AssImp* libraries for both 
-*iOS* and *macOS*, download a separate copy of the *AssImp* directory for each platform 
+>***Note:*** Due to the way that *AssImp* makes use of the *CMake* utility, an installation
+of *AssImp* can only be built for a single platform. To create *AssImp* libraries for both
+*iOS* and *macOS*, download a separate copy of the *AssImp* directory for each platform
 (or create a copy of the downloaded *AssImp* directory for each platform before building).
 
 
@@ -73,7 +73,7 @@ of *AssImp* can only be built for a single platform. To create *AssImp* librarie
 
 3. Open the file `assimp-3.3.1-ios/port/iOS/IPHONEOS_ARM64_TOOLCHAIN.cmake` file and comment
    out the following lines:
-   
+
    		#SET (CC         "${DEVROOT}/usr/bin/llvm-gcc")
 		#SET (CXX        "${DEVROOT}/usr/bin/llvm-g++")
 		#CMAKE_FORCE_C_COMPILER          (${CC} LLVM)
@@ -81,13 +81,13 @@ of *AssImp* can only be built for a single platform. To create *AssImp* librarie
 
 4. Open a *Terminal* session and navigate to the `assimp-3.3.1-ios/port/iOS` directory,
    and run the following build command:
-   
+
 		cd path-to-assimp-3.3.1-ios/port/iOS
 		./build.sh --stdlib=libc++ --archs="arm64" --no-fat
 
-5. In the `assimp` directory within this directory, remove the existing `assimp-ios` 
+5. In the `assimp` directory within this directory, remove the existing `assimp-ios`
    symbolic link, and create a new symbolic link pointing to the `assimp-3.3.1-ios` directory:
-   
+
    		cd path-to-this-directory/assimp
 		rm assimp-ios
 		ln -s path-to-assimp-3.3.1-ios assimp-ios
@@ -99,16 +99,18 @@ of *AssImp* can only be built for a single platform. To create *AssImp* librarie
 
 2. Unzip and rename the directory to `assimp-3.3.1-macos`.
 
-3. Open a *Terminal* session and navigate to the `assimp-3.3.1-ios/port/macOS` directory,
+3. Open a *Terminal* session and navigate to the `assimp-3.3.1-macos` directory,
    and run the following build commands:
-   
+
 		cd path-to-assimp-3.3.1-macos
 		cmake CMakeLists.txt -G 'Unix Makefiles'
 		make
 
-4. In the `assimp` directory within this directory, remove the existing `assimp-macos` 
+	* If compilation fails, fix typo in `assimp-3.3.1-macos/code/D3MFImporter.cpp` and try `make` again
+
+4. In the `assimp` directory within this directory, remove the existing `assimp-macos`
    symbolic link, and create a new symbolic link pointing to the `assimp-3.3.1-macos` directory:
-   
+
    		cd path-to-this-directory/assimp
 		rm assimp-macos
 		ln -s path-to-assimp-3.3.1-macos assimp-macos
@@ -126,17 +128,17 @@ in this repository on either *iOS* or *macOS*. To do so, follow these instructio
 1. Open the `examples.xcodeproj` *Xcode* project.
 
 2. Specify which of the many examples within this respository you wish to run, by opening
-   the `examples.h` file within *Xcode*, and following the instructions in the comments 
+   the `examples.h` file within *Xcode*, and following the instructions in the comments
    within that file to indicate which of the examples you wish to run.
 
 3. Run either the `examples-iOS` or `examples-macOS` *Xcode Scheme* to run the example in *iOS*
    or *macOS*, repectively.
-   
+
 4. Many of the examples include an option to press keys to control the display of features
    and scene components:
-   
+
    - On *iOS*, tap on the scene to display the keyboard. Tap again on the scene to hide the keyboard.
-   - On both *iOS* and *macOS*, use the numeric keys (*1, 2, 3...*) instead of function keys (*F1, F2, F3...*). 
-   - On both *iOS* and *macOS*, use the regular keyboard *+* and *-* keys instead of the numpad *+* and *-* keys. 
-   - On both *iOS* and *macOS*, use the *delete* key instead of the *escape* key. 
+   - On both *iOS* and *macOS*, use the numeric keys (*1, 2, 3...*) instead of function keys (*F1, F2, F3...*).
+   - On both *iOS* and *macOS*, use the regular keyboard *+* and *-* keys instead of the numpad *+* and *-* keys.
+   - On both *iOS* and *macOS*, use the *delete* key instead of the *escape* key.
 

--- a/xcode/examples.h
+++ b/xcode/examples.h
@@ -7,15 +7,15 @@
  *
  * Loads the appropriate example code, as indicated by the appropriate compiler build setting below.
  *
- * To select an example to run, define one (and only one) of the macros below, either by 
- * adding a #define XXX statement at the top of this file, or more flexibily, by adding the 
+ * To select an example to run, define one (and only one) of the macros below, either by
+ * adding a #define XXX statement at the top of this file, or more flexibily, by adding the
  * macro value to the Preprocessor Macros (aka GCC_PREPROCESSOR_DEFINITIONS) compiler setting.
  *
- * To add a compiler setting, select the project in the Xcode Project Navigator panel, 
- * select the Build Settings panel, and add the value to the Preprocessor Macros 
+ * To add a compiler setting, select the project in the Xcode Project Navigator panel,
+ * select the Build Settings panel, and add the value to the Preprocessor Macros
  * (aka GCC_PREPROCESSOR_DEFINITIONS) entry.
  *
- * For example, to run the pipelines example, you would add the MVK_pipelines define macro 
+ * For example, to run the pipelines example, you would add the MVK_pipelines define macro
  * to the Preprocessor Macros (aka GCC_PREPROCESSOR_DEFINITIONS) entry of the Xcode project,
  * overwriting any otheor value there.
  *
@@ -27,129 +27,130 @@
 // In the list below, the comments indicate entries that,
 // under certain conditions, that may not run as expected.
 
+#define MVK_vulkanscene
 
 // BASICS
 
 #ifdef MVK_pipelines
-#	include "../pipelines/pipelines.cpp"
+#   include "../examples/pipelines/pipelines.cpp"
 #endif
 
 #ifdef MVK_texture
-#	include "../texture/texture.cpp"
+#   include "../examples/texture/texture.cpp"
 #endif
 
 // Does not run. Metal does not support passing matrices between shader stages.
 #ifdef MVK_texturecubemap
-#	include "../texturecubemap/texturecubemap.cpp"
+#   include "../examples/texturecubemap/texturecubemap.cpp"
 #endif
 
 // Runs in Release mode. Does not run in Debug mode, as Metal validation will
 // assert that UBO buffer length is too short for UBO size declared in shader.
 #ifdef MVK_texturearray
-#	include "../texturearray/texturearray.cpp"
+#   include "../examples/texturearray/texturearray.cpp"
 #endif
 
 #ifdef MVK_mesh
-#	include "../mesh/mesh.cpp"
+#   include "../examples/mesh/mesh.cpp"
 #endif
 
 #ifdef MVK_dynamicuniformbuffer
-#	include "../dynamicuniformbuffer/dynamicuniformbuffer.cpp"
+#   include "../examples/dynamicuniformbuffer/dynamicuniformbuffer.cpp"
 #endif
 
 // Does not run. Metal does not support passing arrays between shader stages.
 #ifdef MVK_pushconstants
-#	include "../pushconstants/pushconstants.cpp"
+#   include "../examples/pushconstants/pushconstants.cpp"
 #endif
 
 #ifdef MVK_specializationconstants
-#	include "../specializationconstants/specializationconstants.cpp"
+#   include "../examples/specializationconstants/specializationconstants.cpp"
 #endif
 
 #ifdef MVK_offscreen
-#	include "../offscreen/offscreen.cpp"
+#   include "../examples/offscreen/offscreen.cpp"
 #endif
 
 #ifdef MVK_radialblur
-#	include "../radialblur/radialblur.cpp"
+#   include "../examples/radialblur/radialblur.cpp"
 #endif
 
 #ifdef MVK_textoverlay
-#	include "../textoverlay/textoverlay.cpp"
+#   include "../examples/textoverlay/textoverlay.cpp"
 #endif
 
 #ifdef MVK_particlefire
-#	include "../particlefire/particlefire.cpp"
+#   include "../examples/particlefire/particlefire.cpp"
 #endif
 
 
 // ADVANCED
 
 #ifdef MVK_multithreading
-#	include "../multithreading/multithreading.cpp"
+#   include "../examples/multithreading/multithreading.cpp"
 #endif
 
 #ifdef MVK_scenerendering
-#	include "../scenerendering/scenerendering.cpp"
+#   include "../examples/scenerendering/scenerendering.cpp"
 #endif
 
 #ifdef MVK_instancing
-#	include "../instancing/instancing.cpp"
+#   include "../examples/instancing/instancing.cpp"
 #endif
 
 #ifdef MVK_indirectdraw
-#	include "../indirectdraw/indirectdraw.cpp"
+#   include "../examples/indirectdraw/indirectdraw.cpp"
 #endif
 
 // Does not run. Metal does not support passing matrices between shader stages.
 #ifdef MVK_hdr
-#	include "../hdr/hdr.cpp"
+#   include "../examples/hdr/hdr.cpp"
 #endif
 
 #ifdef MVK_occlusionquery
-#	include "../occlusionquery/occlusionquery.cpp"
+#   include "../examples/occlusionquery/occlusionquery.cpp"
 #endif
 
 // Does not run. Sampler arrays require Metal 2.
 #ifdef MVK_texturemipmapgen
-#	include "../texturemipmapgen/texturemipmapgen.cpp"
+#   include "../examples/texturemipmapgen/texturemipmapgen.cpp"
 #endif
 
 #ifdef MVK_multisampling
-#	include "../multisampling/multisampling.cpp"
+#   include "../examples/multisampling/multisampling.cpp"
 #endif
 
 #ifdef MVK_shadowmapping
-#	include "../shadowmapping/shadowmapping.cpp"
+#   include "../examples/shadowmapping/shadowmapping.cpp"
 #endif
 
 #ifdef MVK_shadowmappingomni
-#	include "../shadowmappingomni/shadowmappingomni.cpp"
+#   include "../examples/shadowmappingomni/shadowmappingomni.cpp"
 #endif
 
 #ifdef MVK_skeletalanimation
-#	include "../skeletalanimation/skeletalanimation.cpp"
+#   include "../examples/skeletalanimation/skeletalanimation.cpp"
 #endif
 
 #ifdef MVK_bloom
-#	include "../bloom/bloom.cpp"
+#   include "../examples/bloom/bloom.cpp"
 #endif
 
 // Runs in Release mode. Debug mode Metal validation will assert
 // UBO buffer length is too short for UBO size declared in shader.
 #ifdef MVK_deferred
-#	include "../deferred/deferred.cpp"
+#   include "../examples/deferred/deferred.cpp"
 #endif
 
 // Does not run. Metal does not support geometry shaders.
 #ifdef MVK_deferredshadows
-#	include "../deferredshadows/deferredshadows.cpp"
+#   include "../examples/deferredshadows/deferredshadows.cpp"
 #endif
 
 // Runs in Release mode, but does not display content.
 // Metal does not support the use of specialization constants to set array lengths,
 #ifdef MVK_ssao
-#	include "../ssao/ssao.cpp"
+#   include "../examples/ssao/ssao.cpp"
 #endif
 
 
@@ -168,22 +169,22 @@
 // MISC
 
 #ifdef MVK_parallaxmapping
-#	include "../parallaxmapping/parallaxmapping.cpp"
+#   include "../examples/parallaxmapping/parallaxmapping.cpp"
 #endif
 
 #ifdef MVK_sphericalenvmapping
-#	include "../sphericalenvmapping/sphericalenvmapping.cpp"
+#   include "../examples/sphericalenvmapping/sphericalenvmapping.cpp"
 #endif
 
 #ifdef MVK_gears
-#	include "../gears/gears.cpp"
+#   include "../examples/gears/gears.cpp"
 #endif
 
 #ifdef MVK_distancefieldfonts
-#	include "../distancefieldfonts/distancefieldfonts.cpp"
+#   include "../examples/distancefieldfonts/distancefieldfonts.cpp"
 #endif
 
 #ifdef MVK_vulkanscene
-#	include "../vulkanscene/vulkanscene.cpp"
+#   include "../examples/vulkanscene/vulkanscene.cpp"
 #endif
 

--- a/xcode/examples.xcodeproj/project.pbxproj
+++ b/xcode/examples.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A94C8D601EA047B400B3CE07 /* vulkangear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A94C8D5E1EA047B400B3CE07 /* vulkangear.cpp */; };
-		A94C8D611EA047B400B3CE07 /* vulkangear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A94C8D5E1EA047B400B3CE07 /* vulkangear.cpp */; };
 		A951FF171E9C349000FA9144 /* VulkanDebug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A951FF071E9C349000FA9144 /* VulkanDebug.cpp */; };
 		A951FF181E9C349000FA9144 /* VulkanDebug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A951FF071E9C349000FA9144 /* VulkanDebug.cpp */; };
 		A951FF191E9C349000FA9144 /* vulkanexamplebase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A951FF0A1E9C349000FA9144 /* vulkanexamplebase.cpp */; };
@@ -39,6 +37,19 @@
 		A9B67B911C3AAEA200373FFD /* macOS.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9B67B8B1C3AAEA200373FFD /* macOS.xcassets */; };
 		A9BC9B1C1EE8421F00384233 /* MVKExample.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9BC9B1A1EE8421F00384233 /* MVKExample.cpp */; };
 		A9BC9B1D1EE8421F00384233 /* MVKExample.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9BC9B1A1EE8421F00384233 /* MVKExample.cpp */; };
+		C9788FD52044D78D00AB0892 /* VulkanAndroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9788FD32044D78D00AB0892 /* VulkanAndroid.cpp */; };
+		C9A79EF12045045E00696219 /* stb_textedit.h in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EE82045045D00696219 /* stb_textedit.h */; };
+		C9A79EF22045045E00696219 /* imconfig.h in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EE92045045D00696219 /* imconfig.h */; };
+		C9A79EF32045045E00696219 /* imgui_demo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EEA2045045D00696219 /* imgui_demo.cpp */; };
+		C9A79EF42045045E00696219 /* imgui_draw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EEB2045045D00696219 /* imgui_draw.cpp */; };
+		C9A79EF52045045E00696219 /* imgui_internal.h in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EEC2045045E00696219 /* imgui_internal.h */; };
+		C9A79EF62045045E00696219 /* stb_rect_pack.h in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EED2045045E00696219 /* stb_rect_pack.h */; };
+		C9A79EF72045045E00696219 /* imgui.h in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EEE2045045E00696219 /* imgui.h */; };
+		C9A79EF82045045E00696219 /* stb_truetype.h in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EEF2045045E00696219 /* stb_truetype.h */; };
+		C9A79EF92045045E00696219 /* imgui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EF02045045E00696219 /* imgui.cpp */; };
+		C9A79EFC204504E000696219 /* VulkanUIOverlay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EFB204504E000696219 /* VulkanUIOverlay.cpp */; };
+		C9A79EFD2045051D00696219 /* VulkanUIOverlay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EFB204504E000696219 /* VulkanUIOverlay.cpp */; };
+		C9A79EFE2045051D00696219 /* VulkanUIOverlay.h in Sources */ = {isa = PBXBuildFile; fileRef = C9A79EFA204504E000696219 /* VulkanUIOverlay.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -73,8 +84,6 @@
 		A92F37071C7E1B2B008F8BC9 /* examples.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = examples.h; sourceTree = "<group>"; };
 		A94A67231B7BDE9B00F6D7C4 /* MetalGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalGL.framework; path = ../../MetalGL/macOS/MetalGL.framework; sourceTree = "<group>"; };
 		A94A67241B7BDE9B00F6D7C4 /* MetalGLShaderConverter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalGLShaderConverter.framework; path = ../../MetalGLShaderConverter/macOS/MetalGLShaderConverter.framework; sourceTree = "<group>"; };
-		A94C8D5E1EA047B400B3CE07 /* vulkangear.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = vulkangear.cpp; path = ../gears/vulkangear.cpp; sourceTree = "<group>"; };
-		A94C8D5F1EA047B400B3CE07 /* vulkangear.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vulkangear.h; path = ../gears/vulkangear.h; sourceTree = "<group>"; };
 		A951FF001E9C349000FA9144 /* camera.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = camera.hpp; sourceTree = "<group>"; };
 		A951FF011E9C349000FA9144 /* frustum.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = frustum.hpp; sourceTree = "<group>"; };
 		A951FF021E9C349000FA9144 /* keycodes.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keycodes.hpp; sourceTree = "<group>"; };
@@ -90,7 +99,6 @@
 		A951FF0E1E9C349000FA9144 /* VulkanInitializers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VulkanInitializers.hpp; sourceTree = "<group>"; };
 		A951FF0F1E9C349000FA9144 /* VulkanModel.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VulkanModel.hpp; sourceTree = "<group>"; };
 		A951FF101E9C349000FA9144 /* VulkanSwapChain.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VulkanSwapChain.hpp; sourceTree = "<group>"; };
-		A951FF111E9C349000FA9144 /* VulkanTextOverlay.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VulkanTextOverlay.hpp; sourceTree = "<group>"; };
 		A951FF121E9C349000FA9144 /* VulkanTexture.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VulkanTexture.hpp; sourceTree = "<group>"; };
 		A951FF131E9C349000FA9144 /* VulkanTools.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VulkanTools.cpp; sourceTree = "<group>"; };
 		A951FF141E9C349000FA9144 /* VulkanTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VulkanTools.h; sourceTree = "<group>"; };
@@ -133,6 +141,20 @@
 		A9BC9B1B1EE8421F00384233 /* MVKExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKExample.h; sourceTree = "<group>"; };
 		A9CDEA271B6A782C00F7B008 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		A9E264761B671B0A00FE691A /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/lib/libc++.dylib"; sourceTree = DEVELOPER_DIR; };
+		C9788FD02044D78D00AB0892 /* benchmark.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = benchmark.hpp; sourceTree = "<group>"; };
+		C9788FD22044D78D00AB0892 /* VulkanAndroid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VulkanAndroid.h; sourceTree = "<group>"; };
+		C9788FD32044D78D00AB0892 /* VulkanAndroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VulkanAndroid.cpp; sourceTree = "<group>"; };
+		C9A79EE82045045D00696219 /* stb_textedit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_textedit.h; path = ../external/imgui/stb_textedit.h; sourceTree = "<group>"; };
+		C9A79EE92045045D00696219 /* imconfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = imconfig.h; path = ../external/imgui/imconfig.h; sourceTree = "<group>"; };
+		C9A79EEA2045045D00696219 /* imgui_demo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imgui_demo.cpp; path = ../external/imgui/imgui_demo.cpp; sourceTree = "<group>"; };
+		C9A79EEB2045045D00696219 /* imgui_draw.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imgui_draw.cpp; path = ../external/imgui/imgui_draw.cpp; sourceTree = "<group>"; };
+		C9A79EEC2045045E00696219 /* imgui_internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = imgui_internal.h; path = ../external/imgui/imgui_internal.h; sourceTree = "<group>"; };
+		C9A79EED2045045E00696219 /* stb_rect_pack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_rect_pack.h; path = ../external/imgui/stb_rect_pack.h; sourceTree = "<group>"; };
+		C9A79EEE2045045E00696219 /* imgui.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = imgui.h; path = ../external/imgui/imgui.h; sourceTree = "<group>"; };
+		C9A79EEF2045045E00696219 /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_truetype.h; path = ../external/imgui/stb_truetype.h; sourceTree = "<group>"; };
+		C9A79EF02045045E00696219 /* imgui.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imgui.cpp; path = ../external/imgui/imgui.cpp; sourceTree = "<group>"; };
+		C9A79EFA204504E000696219 /* VulkanUIOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VulkanUIOverlay.h; sourceTree = "<group>"; };
+		C9A79EFB204504E000696219 /* VulkanUIOverlay.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VulkanUIOverlay.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,11 +192,19 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
+				C9A79EE92045045D00696219 /* imconfig.h */,
+				C9A79EEA2045045D00696219 /* imgui_demo.cpp */,
+				C9A79EEB2045045D00696219 /* imgui_draw.cpp */,
+				C9A79EEC2045045E00696219 /* imgui_internal.h */,
+				C9A79EF02045045E00696219 /* imgui.cpp */,
+				C9A79EEE2045045E00696219 /* imgui.h */,
+				C9A79EED2045045E00696219 /* stb_rect_pack.h */,
+				C9A79EE82045045D00696219 /* stb_textedit.h */,
+				C9A79EEF2045045E00696219 /* stb_truetype.h */,
 				A92F37071C7E1B2B008F8BC9 /* examples.h */,
 				A9BC9B1B1EE8421F00384233 /* MVKExample.h */,
 				A9BC9B1A1EE8421F00384233 /* MVKExample.cpp */,
 				A951FEFF1E9C349000FA9144 /* base */,
-				A94C8D5D1EA047A300B3CE07 /* extras */,
 				A98703D81E9D382A0066959C /* data */,
 				A9B67B6A1C3AAE9800373FFD /* iOS */,
 				A9B67B811C3AAEA200373FFD /* macOS */,
@@ -200,18 +230,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		A94C8D5D1EA047A300B3CE07 /* extras */ = {
-			isa = PBXGroup;
-			children = (
-				A94C8D5E1EA047B400B3CE07 /* vulkangear.cpp */,
-				A94C8D5F1EA047B400B3CE07 /* vulkangear.h */,
-			);
-			name = extras;
-			sourceTree = "<group>";
-		};
 		A951FEFF1E9C349000FA9144 /* base */ = {
 			isa = PBXGroup;
 			children = (
+				C9A79EFB204504E000696219 /* VulkanUIOverlay.cpp */,
+				C9A79EFA204504E000696219 /* VulkanUIOverlay.h */,
+				C9788FD02044D78D00AB0892 /* benchmark.hpp */,
+				C9788FD32044D78D00AB0892 /* VulkanAndroid.cpp */,
+				C9788FD22044D78D00AB0892 /* VulkanAndroid.h */,
 				A951FF001E9C349000FA9144 /* camera.hpp */,
 				A951FF011E9C349000FA9144 /* frustum.hpp */,
 				A951FF021E9C349000FA9144 /* keycodes.hpp */,
@@ -227,7 +253,6 @@
 				A951FF0E1E9C349000FA9144 /* VulkanInitializers.hpp */,
 				A951FF0F1E9C349000FA9144 /* VulkanModel.hpp */,
 				A951FF101E9C349000FA9144 /* VulkanSwapChain.hpp */,
-				A951FF111E9C349000FA9144 /* VulkanTextOverlay.hpp */,
 				A951FF121E9C349000FA9144 /* VulkanTexture.hpp */,
 				A951FF131E9C349000FA9144 /* VulkanTools.cpp */,
 				A951FF141E9C349000FA9144 /* VulkanTools.h */,
@@ -358,7 +383,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0920;
 				TargetAttributes = {
 					1D6058900D05DD3D006BFB54 = {
 						DevelopmentTeam = VU3TCKU48B;
@@ -420,10 +445,11 @@
 			files = (
 				A951FF171E9C349000FA9144 /* VulkanDebug.cpp in Sources */,
 				A9BC9B1C1EE8421F00384233 /* MVKExample.cpp in Sources */,
+				C9A79EFC204504E000696219 /* VulkanUIOverlay.cpp in Sources */,
 				A9B67B7A1C3AAE9800373FFD /* DemoViewController.mm in Sources */,
 				A9B67B781C3AAE9800373FFD /* AppDelegate.m in Sources */,
+				C9788FD52044D78D00AB0892 /* VulkanAndroid.cpp in Sources */,
 				A951FF1B1E9C349000FA9144 /* VulkanTools.cpp in Sources */,
-				A94C8D601EA047B400B3CE07 /* vulkangear.cpp in Sources */,
 				A951FF191E9C349000FA9144 /* vulkanexamplebase.cpp in Sources */,
 				A9B67B7C1C3AAE9800373FFD /* main.m in Sources */,
 			);
@@ -433,12 +459,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9A79EFD2045051D00696219 /* VulkanUIOverlay.cpp in Sources */,
+				C9A79EFE2045051D00696219 /* VulkanUIOverlay.h in Sources */,
+				C9A79EF12045045E00696219 /* stb_textedit.h in Sources */,
+				C9A79EF22045045E00696219 /* imconfig.h in Sources */,
+				C9A79EF32045045E00696219 /* imgui_demo.cpp in Sources */,
+				C9A79EF42045045E00696219 /* imgui_draw.cpp in Sources */,
+				C9A79EF52045045E00696219 /* imgui_internal.h in Sources */,
+				C9A79EF62045045E00696219 /* stb_rect_pack.h in Sources */,
+				C9A79EF72045045E00696219 /* imgui.h in Sources */,
+				C9A79EF82045045E00696219 /* stb_truetype.h in Sources */,
+				C9A79EF92045045E00696219 /* imgui.cpp in Sources */,
 				A951FF181E9C349000FA9144 /* VulkanDebug.cpp in Sources */,
 				A9BC9B1D1EE8421F00384233 /* MVKExample.cpp in Sources */,
 				A9B67B8C1C3AAEA200373FFD /* AppDelegate.m in Sources */,
 				A9B67B8F1C3AAEA200373FFD /* main.m in Sources */,
 				A951FF1C1E9C349000FA9144 /* VulkanTools.cpp in Sources */,
-				A94C8D611EA047B400B3CE07 /* vulkangear.cpp in Sources */,
 				A951FF1A1E9C349000FA9144 /* vulkanexamplebase.cpp in Sources */,
 				A9B67B8D1C3AAEA200373FFD /* DemoViewController.mm in Sources */,
 			);
@@ -502,11 +538,16 @@
 		A977BCFC1B66BB010067E5BF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/macOS/Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
+					"DEBUG=1",
+					_DEBUG,
+					VK_USE_PLATFORM_MACOS_MVK,
+				);
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = (
 					"DEBUG=1",
 					_DEBUG,
 					VK_USE_PLATFORM_MACOS_MVK,
@@ -526,13 +567,12 @@
 		A977BCFD1B66BB010067E5BF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/macOS/Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					VK_USE_PLATFORM_MACOS_MVK,
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = VK_USE_PLATFORM_MACOS_MVK;
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = VK_USE_PLATFORM_MACOS_MVK;
 				INFOPLIST_FILE = "$(SRCROOT)/macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
 				LIBRARY_SEARCH_PATHS = (
@@ -548,20 +588,43 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_BITCODE = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = MVK_vulkanscene;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/MoltenVK/include\"",
 					"\"$(SRCROOT)/../external\"/**",
@@ -575,17 +638,40 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				ENABLE_BITCODE = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = MVK_vulkanscene;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/MoltenVK/include\"",
 					"\"$(SRCROOT)/../external\"/**",

--- a/xcode/examples.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/xcode/examples.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,6494 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
+   <Group
+      location = "group:../../external"
+      name = "external">
+      <Group
+         location = "group:assimp"
+         name = "assimp">
+         <Group
+            location = "group:assimp"
+            name = "assimp">
+            <FileRef
+               location = "group:IOSystem.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:Logger.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:IOStream.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:quaternion.inl">
+            </FileRef>
+            <FileRef
+               location = "group:defs.h">
+            </FileRef>
+            <FileRef
+               location = "group:version.h">
+            </FileRef>
+            <FileRef
+               location = "group:matrix4x4.h">
+            </FileRef>
+            <FileRef
+               location = "group:Importer.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:cfileio.h">
+            </FileRef>
+            <FileRef
+               location = "group:vector2.h">
+            </FileRef>
+            <FileRef
+               location = "group:config.h">
+            </FileRef>
+            <FileRef
+               location = "group:light.h">
+            </FileRef>
+            <FileRef
+               location = "group:types.h">
+            </FileRef>
+            <FileRef
+               location = "group:cimport.h">
+            </FileRef>
+            <FileRef
+               location = "group:camera.h">
+            </FileRef>
+            <FileRef
+               location = "group:matrix3x3.h">
+            </FileRef>
+            <FileRef
+               location = "group:color4.inl">
+            </FileRef>
+            <FileRef
+               location = "group:material.h">
+            </FileRef>
+            <FileRef
+               location = "group:ai_assert.h">
+            </FileRef>
+            <FileRef
+               location = "group:NullLogger.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:quaternion.h">
+            </FileRef>
+            <FileRef
+               location = "group:DefaultLogger.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:material.inl">
+            </FileRef>
+            <FileRef
+               location = "group:metadata.h">
+            </FileRef>
+            <FileRef
+               location = "group:mesh.h">
+            </FileRef>
+            <FileRef
+               location = "group:Exporter.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:vector2.inl">
+            </FileRef>
+            <FileRef
+               location = "group:matrix4x4.inl">
+            </FileRef>
+            <FileRef
+               location = "group:vector3.inl">
+            </FileRef>
+            <FileRef
+               location = "group:ProgressHandler.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:cexport.h">
+            </FileRef>
+            <FileRef
+               location = "group:color4.h">
+            </FileRef>
+            <FileRef
+               location = "group:anim.h">
+            </FileRef>
+            <FileRef
+               location = "group:postprocess.h">
+            </FileRef>
+            <FileRef
+               location = "group:texture.h">
+            </FileRef>
+            <FileRef
+               location = "group:matrix3x3.inl">
+            </FileRef>
+            <Group
+               location = "group:port"
+               name = "port">
+               <Group
+                  location = "group:AndroidJNI"
+                  name = "AndroidJNI">
+                  <FileRef
+                     location = "group:AndroidJNIIOSystem.h">
+                  </FileRef>
+               </Group>
+            </Group>
+            <FileRef
+               location = "group:importerdesc.h">
+            </FileRef>
+            <Group
+               location = "group:Compiler"
+               name = "Compiler">
+               <FileRef
+                  location = "group:poppack1.h">
+               </FileRef>
+               <FileRef
+                  location = "group:pstdint.h">
+               </FileRef>
+               <FileRef
+                  location = "group:pushpack1.h">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:vector3.h">
+            </FileRef>
+            <FileRef
+               location = "group:scene.h">
+            </FileRef>
+            <FileRef
+               location = "group:LogStream.hpp">
+            </FileRef>
+         </Group>
+      </Group>
+      <Group
+         location = "group:imgui"
+         name = "imgui">
+         <FileRef
+            location = "group:imgui.h">
+         </FileRef>
+         <FileRef
+            location = "group:imconfig.h">
+         </FileRef>
+         <FileRef
+            location = "group:LICENSE">
+         </FileRef>
+         <FileRef
+            location = "group:stb_rect_pack.h">
+         </FileRef>
+         <FileRef
+            location = "group:README.md">
+         </FileRef>
+         <FileRef
+            location = "group:stb_truetype.h">
+         </FileRef>
+         <FileRef
+            location = "group:imgui.cpp">
+         </FileRef>
+         <FileRef
+            location = "group:imgui_internal.h">
+         </FileRef>
+         <FileRef
+            location = "group:stb_textedit.h">
+         </FileRef>
+         <FileRef
+            location = "group:imgui_demo.cpp">
+         </FileRef>
+         <FileRef
+            location = "group:imgui_draw.cpp">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:gli"
+         name = "gli">
+         <FileRef
+            location = "group:CMakeLists.txt">
+         </FileRef>
+         <Group
+            location = "group:test"
+            name = "test">
+            <FileRef
+               location = "group:bug.cpp">
+            </FileRef>
+            <FileRef
+               location = "group:CMakeLists.txt">
+            </FileRef>
+            <Group
+               location = "group:core"
+               name = "core">
+               <FileRef
+                  location = "group:core_sampler2d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_texture_1d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_convert_access.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_fetch.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_generate_mipmaps.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:convert_sampler2d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_sample.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_ktx.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_filter_1d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:generate_mipmaps_sampler2d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:CMakeLists.txt">
+               </FileRef>
+               <FileRef
+                  location = "group:core_texture.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_gen_1d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_swizzle.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:generate_mipmaps_sampler1d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_texture_cube_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:texture_lod_sampler_cube.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:convert_sampler_cube_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_storage.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_image.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:test_duplicate.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:texture_lod_sampler2d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:texture_lod_sampler2d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:convert_sampler3d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_texture_3d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gl.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_format.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_gen_1d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_texture_2d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:convert_sampler2d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:test_size.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:texture_lod_sampler3d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:test_make_texture.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_convert.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_sampler_clear.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_gen.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_gen_2d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_gen_cube.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:transform.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_texture_1d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_sampler_texel.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:convert_sampler1d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_comparison.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:test_copy.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:convert_sampler_cube.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:texture_lod_sampler1d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_flip.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:texture_lod_sampler1d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:generate_mipmaps_sampler2d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_texture_cube.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_sampler_wrap.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:generate_mipmaps_sampler1d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_filter_2d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_save.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:reduce.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_gen_2d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_dds.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:test_copy_sub.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_gen_3d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:texture_lod_sampler_cube_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_gen_cube_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_filter_3d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:generate_mipmaps_sampler_cube_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_addressing.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:convert_sampler1d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_clear.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:generate_mipmaps_sampler_cube.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_texture_2d_array.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_load_gen_rect.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:test_view.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:generate_mipmaps_sampler3d.cpp">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:core.cpp">
+            </FileRef>
+            <Group
+               location = "group:bug"
+               name = "bug">
+               <FileRef
+                  location = "group:bug.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:CMakeLists.txt">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:bug.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:main.cpp">
+            </FileRef>
+            <FileRef
+               location = "group:core.hpp">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:cmake"
+            name = "cmake">
+            <FileRef
+               location = "group:gliConfig.cmake.in">
+            </FileRef>
+            <FileRef
+               location = "group:gliBuildConfig.cmake.in">
+            </FileRef>
+            <FileRef
+               location = "group:GNUInstallDirs.cmake">
+            </FileRef>
+            <FileRef
+               location = "group:CMakePackageConfigHelpers.cmake">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:util"
+            name = "util">
+            <FileRef
+               location = "group:FindGLI.cmake">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:gli"
+            name = "gli">
+            <FileRef
+               location = "group:texture2d.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:sampler_cube_array.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:texture1d_array.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:load.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:sampler2d.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:generate_mipmaps.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:levels.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:reduce.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:CMakeLists.txt">
+            </FileRef>
+            <Group
+               location = "group:core"
+               name = "core">
+               <FileRef
+                  location = "group:dx.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:comparison.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:mipmaps_compute.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:sampler2d_array.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:load_kmg.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:save_ktx.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:storage_linear.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:load_dds.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:clear.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:sampler_cube.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:transform.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:file.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:duplicate.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:storage_linear.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:texture3d.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:file.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:clear.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:sampler3d.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:load.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:sampler2d.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:texture1d_array.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:texture2d.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:sampler_cube_array.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:filter_compute.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:reduce.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:coord.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:levels.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:generate_mipmaps.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:format.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:save.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:flip.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:texture2d_array.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:image.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:copy.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:convert.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:sampler1d.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:dummy.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:texture1d.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:texture_cube.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:convert_func.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:s3tc.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:storage.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:bc.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:filter.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:s3tc.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:sampler.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:texture_cube_array.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:sampler1d_array.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:texture.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:filter.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:view.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:workaround.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:bc.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:storage.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:save_dds.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:flip.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:make_texture.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:gl.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:load_ktx.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:save_kmg.inl">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:sampler3d.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:type.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:texture3d.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:save_ktx.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:gli.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:load_kmg.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:sampler2d_array.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:transform.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:duplicate.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:clear.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:sampler_cube.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:load_dds.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:target.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:comparison.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:dx.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:make_texture.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:save_dds.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:save_kmg.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:load_ktx.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:gl.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:sampler1d_array.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:texture.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:texture_cube_array.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:sampler.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:view.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:texture_cube.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:copy.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:image.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:texture2d_array.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:format.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:save.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:texture1d.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:convert.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:sampler1d.hpp">
+            </FileRef>
+         </Group>
+         <FileRef
+            location = "group:readme.md">
+         </FileRef>
+         <Group
+            location = "group:doc"
+            name = "doc">
+            <Group
+               location = "group:spec"
+               name = "spec">
+               <FileRef
+                  location = "group:Khronos-App.css">
+               </FileRef>
+               <FileRef
+                  location = "group:index.html">
+               </FileRef>
+               <FileRef
+                  location = "group:KhronosGroup-3D.png">
+               </FileRef>
+               <FileRef
+                  location = "group:logo-spec.png">
+               </FileRef>
+               <FileRef
+                  location = "group:logo-WD.png">
+               </FileRef>
+               <FileRef
+                  location = "group:default.css">
+               </FileRef>
+               <FileRef
+                  location = "group:generateTOC.js">
+               </FileRef>
+               <FileRef
+                  location = "group:Khronos-WD.css">
+               </FileRef>
+               <FileRef
+                  location = "group:jquery-1.3.2.min.js">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:manual"
+               name = "manual">
+               <FileRef
+                  location = "group:frontpage1.png">
+               </FileRef>
+               <FileRef
+                  location = "group:g-truc.png">
+               </FileRef>
+               <FileRef
+                  location = "group:frontpage2.png">
+               </FileRef>
+               <FileRef
+                  location = "group:logo-mini.png">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:theme"
+               name = "theme">
+               <FileRef
+                  location = "group:doxygen.css">
+               </FileRef>
+               <FileRef
+                  location = "group:tabs.css">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:api"
+               name = "api">
+               <FileRef
+                  location = "group:a00072_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00011.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00005.png">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_934f46a345653ef2b3014a1b37a162c1.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00019.html">
+               </FileRef>
+               <FileRef
+                  location = "group:splitbar.png">
+               </FileRef>
+               <FileRef
+                  location = "group:namespacemembers_enum.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00058.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00030_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00023.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00040_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00074.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00062.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00004.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00010.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00035.html">
+               </FileRef>
+               <FileRef
+                  location = "group:doxygen.css">
+               </FileRef>
+               <FileRef
+                  location = "group:a00042.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00006.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00012.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00015.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00025_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00003.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00055_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00054.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00049_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00097.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00039_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00067_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00081.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00013.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00007.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00039.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00038.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00050_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00017.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00080.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00020_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00096.html">
+               </FileRef>
+               <FileRef
+                  location = "group:arrowright.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00079.html">
+               </FileRef>
+               <FileRef
+                  location = "group:index.html">
+               </FileRef>
+               <FileRef
+                  location = "group:functions.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00055.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00002.html">
+               </FileRef>
+               <FileRef
+                  location = "group:sync_off.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00062_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00014.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00043.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00016.png">
+               </FileRef>
+               <FileRef
+                  location = "group:namespacemembers_func.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00029_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00014.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00034.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00059_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00063.html">
+               </FileRef>
+               <FileRef
+                  location = "group:sync_on.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00022.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_2c398834837487e57bd8c53ea39543b9.html">
+               </FileRef>
+               <FileRef
+                  location = "group:annotated.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00045_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00018.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00015.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00035_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:doc.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00046_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:hierarchy.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00036_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:arrowdown.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00013.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00068_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00005.html">
+               </FileRef>
+               <FileRef
+                  location = "group:bc_s.png">
+               </FileRef>
+               <FileRef
+                  location = "group:nav_g.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00052.html">
+               </FileRef>
+               <FileRef
+                  location = "group:nav_f.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00029.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tabs.css">
+               </FileRef>
+               <FileRef
+                  location = "group:a00091.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00087.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00068.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00048.html">
+               </FileRef>
+               <FileRef
+                  location = "group:closed.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00009.html">
+               </FileRef>
+               <FileRef
+                  location = "group:doxygen.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00061_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00072.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00064.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00053_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tab_s.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00033.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00023_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00064_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00065.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_98f7f9d41f9d3029bd68cf237526a774.html">
+               </FileRef>
+               <FileRef
+                  location = "group:files.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00026_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00008.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00056_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tab_a.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00049.html">
+               </FileRef>
+               <FileRef
+                  location = "group:functions_func.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00086.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00069.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00090.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00033_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00028.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00043_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00053.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00004.html">
+               </FileRef>
+               <FileRef
+                  location = "group:namespaces.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00012.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tab_b.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00071_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:bdwn.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00085.html">
+               </FileRef>
+               <Group
+                  location = "group:search"
+                  name = "search">
+                  <FileRef
+                     location = "group:enums_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:searchdata.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_6.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_6.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_4.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_9.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_d.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_a.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search_r.png">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_7.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_a.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_8.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_c.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:enums_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_e.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_6.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:enums_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_a.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_b.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_9.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_d.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:enums_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_7.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_8.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search.css">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_5.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_7.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_7.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_e.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_9.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_8.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_7.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:namespaces_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_4.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_9.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_a.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_a.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_6.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_8.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_d.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_6.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_5.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_5.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_9.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_8.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_4.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_d.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_4.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_4.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:namespaces_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_5.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_b.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_6.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_4.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:enums_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search_l.png">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:pages_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:enums_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_4.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_a.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_c.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_c.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_8.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search_m.png">
+                  </FileRef>
+                  <FileRef
+                     location = "group:enums_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_9.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_b.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_5.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:pages_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:mag_sel.png">
+                  </FileRef>
+                  <FileRef
+                     location = "group:enums_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_b.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:nomatches.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_4.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_5.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_7.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:classes_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_c.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:close.png">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:a00093.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00034_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00044_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00050.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00058_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_b73546165ac7e018753d96ca90d34595.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00007.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00028_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00011.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00046.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00063_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00066.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00089.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00070.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00027.html">
+               </FileRef>
+               <FileRef
+                  location = "group:namespacemembers.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00021_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00051_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_5dc556008ba3b473ea5d66774d4b1dbc.html">
+               </FileRef>
+               <FileRef
+                  location = "group:logo-mini.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00038_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00048_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:nav_h.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00066_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00026.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00071.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00067.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00088.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00054_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tab_h.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00030.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00024_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00041_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00047.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00010.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00031_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00006.html">
+               </FileRef>
+               <FileRef
+                  location = "group:classes.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00051.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00092.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00073_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00084.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_9344afb825aed5e2f5be1d2015dde43c.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00018.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00037.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00070_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:open.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00042_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00032_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00019.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00057_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00027_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00083.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00095.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00056.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00065_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_ae6bff3f3cf3c65a1db429f9020bb7b3.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00001.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00017.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00040.html">
+               </FileRef>
+               <FileRef
+                  location = "group:folderclosed.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00041.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dynsections.js">
+               </FileRef>
+               <FileRef
+                  location = "group:a00016.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00022_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00052_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:folderopen.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00057.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00094.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00060_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00082.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00009.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00020.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00037_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00047_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00061.html">
+               </FileRef>
+               <FileRef
+                  location = "group:jquery.js">
+               </FileRef>
+               <FileRef
+                  location = "group:a00008.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00036.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00069_source.html">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:man.doxy">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:external"
+            name = "external">
+            <Group
+               location = "group:glm"
+               name = "glm">
+               <FileRef
+                  location = "group:vec4.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:integer.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:vector_relational.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:mat2x3.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:mat4x4.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:mat2x2.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:exponential.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:vec2.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:CMakeLists.txt">
+               </FileRef>
+               <FileRef
+                  location = "group:vec3.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:fwd.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:mat4x3.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:mat4x2.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:mat2x4.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:packing.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:mat3x3.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:mat3x2.hpp">
+               </FileRef>
+               <Group
+                  location = "group:simd"
+                  name = "simd">
+                  <FileRef
+                     location = "group:vector_relational.h">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix.h">
+                  </FileRef>
+                  <FileRef
+                     location = "group:packing.h">
+                  </FileRef>
+                  <FileRef
+                     location = "group:common.h">
+                  </FileRef>
+                  <FileRef
+                     location = "group:trigonometric.h">
+                  </FileRef>
+                  <FileRef
+                     location = "group:geometric.h">
+                  </FileRef>
+                  <FileRef
+                     location = "group:integer.h">
+                  </FileRef>
+                  <FileRef
+                     location = "group:platform.h">
+                  </FileRef>
+                  <FileRef
+                     location = "group:exponential.h">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:mat3x4.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:glm.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:trigonometric.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:geometric.hpp">
+               </FileRef>
+               <Group
+                  location = "group:detail"
+                  name = "detail">
+                  <FileRef
+                     location = "group:type_vec.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_geometric.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_exponential.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_trigonometric.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_integer_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_vector_relational.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_packing.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_common.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:_fixes.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_half.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_integer.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_vector_relational_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_matrix_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_int.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:_noise.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_half.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:_features.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_integer.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:_vectorize.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_exponential.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_geometric.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_common.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_packing.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_vector_relational.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_trigonometric.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat2x4.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat4x2.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:_swizzle.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat4x3.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_packing_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec4.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_trigonometric_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:precision.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat3x3.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat3x2.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:dummy.cpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:setup.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat2x2.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec1.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_common_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_matrix.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat4x4.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_geometric_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat2x3.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec2.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:glm.cpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_gentype.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat3x4.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec3.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat4x4_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat2x3.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat4x4.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_matrix.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat2x2.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec1.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:_swizzle_func.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec3.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec4_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat3x4.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:func_exponential_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_gentype.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec2.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat4x3.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat4x2.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_float.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat2x4.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat3x2.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_mat3x3.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_vec4.hpp">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:ext.hpp">
+               </FileRef>
+               <Group
+                  location = "group:gtc"
+                  name = "gtc">
+                  <FileRef
+                     location = "group:integer.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_integer.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_inverse.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:quaternion.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:packing.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_transform.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:vec1.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_precision.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:bitfield.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ulp.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:round.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:packing.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:quaternion_simd.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ulp.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:round.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_transform.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_precision.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:bitfield.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:vec1.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:integer.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:quaternion.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_inverse.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:epsilon.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:random.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_access.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_ptr.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:reciprocal.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:constants.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:color_space.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:noise.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:color_space.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:noise.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_access.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:random.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:epsilon.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:constants.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:reciprocal.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_ptr.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_aligned.hpp">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:common.hpp">
+               </FileRef>
+               <Group
+                  location = "group:gtx"
+                  name = "gtx">
+                  <FileRef
+                     location = "group:vector_angle.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:log_base.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_query.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:extend.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:integer.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:associated_min_max.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_transform_2d.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:hash.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:rotate_vector.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_interpolation.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:quaternion.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:gradient_paint.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:string_cast.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:color_space_YCoCg.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_trait.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:extended_min_max.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:euler_angles.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:fast_square_root.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:raw_data.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_cross_product.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:spline.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:fast_trigonometry.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:optimum_pow.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:dual_quaternion.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:closest_point.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:number_precision.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:mixed_product.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:transform.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:bit.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:io.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:fast_trigonometry.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:optimum_pow.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:spline.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:raw_data.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_cross_product.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:euler_angles.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:fast_square_root.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:color_space_YCoCg.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_trait.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:extended_min_max.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:io.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:float_notmalize.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:transform.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:bit.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:number_precision.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:mixed_product.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:closest_point.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:dual_quaternion.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:associated_min_max.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_transform_2d.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:integer.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:log_base.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_query.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:vector_angle.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:extend.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:gradient_paint.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:quaternion.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:string_cast.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:rotate_vector.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_interpolation.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:hash.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:vector_query.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:polar_coordinates.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:orthonormalize.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:component_wise.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:normalize_dot.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:std_based_type.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_aligned.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:vec_swizzle.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:projection.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:compatibility.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:scalar_relational.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:wrap.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:rotate_normalized_axis.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:color_encoding.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:norm.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_major_storage.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_operation.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:color_space.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:normal.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:intersect.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:perpendicular.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:transform2.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_decompose.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:fast_exponential.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:common.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:handed_coordinate_space.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:intersect.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:perpendicular.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_operation.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:color_space.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:normal.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:color_encoding.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_major_storage.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:norm.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:handed_coordinate_space.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:common.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:range.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:fast_exponential.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:transform2.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:matrix_decompose.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:scalar_multiplication.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:std_based_type.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:orthonormalize.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:normalize_dot.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:component_wise.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:polar_coordinates.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:vector_query.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:scalar_relational.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:wrap.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:compatibility.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:rotate_normalized_axis.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:projection.inl">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type_aligned.hpp">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+         <FileRef
+            location = "group:manual.md">
+         </FileRef>
+         <Group
+            location = "group:data"
+            name = "data">
+            <FileRef
+               location = "group:cube_rgba8_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_etc2_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_r_eac_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt5_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_r8_sint.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba16_sfloat.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_pvrtc2_4bpp_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba8_snorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_astc12x12_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_bgra8_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken8_rgba_dxt1_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:test.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_astc4x4_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_astc8x8_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba8_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_pvrtc2_2bpp_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_pvrtc2_2bpp_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_bgra8_srgb.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_dxt1_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_r_ati1n_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt1_srgb.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_r16_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_r5g6b5_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba8_srgb.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_r8_uint.dds">
+            </FileRef>
+            <FileRef
+               location = "group:array_r8_uint.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rg11b10_ufloat.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt1_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken8_bgr8_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rg_ati2n_unorm_decompressed.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb9e5_ufloat.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_bgr8_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken8_rgba8_srgb.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken8_srgb8.jpg">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_dxt1_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rg_ati2n_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_bgrx8_srgb.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb10a2u.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb5a1_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_bgrx8_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt5_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_pvrtc2_4bpp_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba4_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rg_eac_snorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_etc1_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_bgra8_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb8_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_atc_interpolate_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_pvrtc2_4bpp_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_atc_explicit_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_atc_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba16_sfloat.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt5_unorm_decompressed.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_a8_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt5_unorm1.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt5_srgb.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_astc8x5_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt5_unorm2.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_etc2_srgb.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_l8_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:cube_rgba8_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_bgr8_srgb.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_r_eac_snorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_bgra8_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb10a2_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt1_unorm_decompressed.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_etc2_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba8_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb8_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_astc4x4_srgb.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb5a1_unorm_.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_pvrtc_4bpp_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt3_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_etc2_a1_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_srgb8.png">
+            </FileRef>
+            <FileRef
+               location = "group:kueken8_rgba8_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_srgb8.jpg">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb9e5_ufloat.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rg_eac_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_pvrtc_4bpp_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:array_r8_uint.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rg11b10_ufloat.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_r5g6b5_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba8_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:npot.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_etc1_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt3_unorm_decompressed.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_etc2_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba4_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgba_dxt5_unorm.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_r_ati1n_unorm_decompressed.dds">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb5a1_unorm.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb8.jpg">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_pvrtc_2bpp_srgb.ktx">
+            </FileRef>
+            <FileRef
+               location = "group:kueken7_rgb_pvrtc_2bpp_unorm.dds">
+            </FileRef>
+         </Group>
+      </Group>
+      <Group
+         location = "group:stb"
+         name = "stb">
+         <FileRef
+            location = "group:stb_font_consolas_24_latin1.inl">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:vulkan"
+         name = "vulkan">
+         <FileRef
+            location = "group:vk_layer.h">
+         </FileRef>
+         <FileRef
+            location = "group:vk_icd.h">
+         </FileRef>
+         <FileRef
+            location = "group:vk_layer_dispatch_table.h">
+         </FileRef>
+         <FileRef
+            location = "group:vulkan.h">
+         </FileRef>
+         <FileRef
+            location = "group:vk_platform.h">
+         </FileRef>
+         <FileRef
+            location = "group:spirv.py">
+         </FileRef>
+         <FileRef
+            location = "group:spirv.lua">
+         </FileRef>
+         <FileRef
+            location = "group:spirv.hpp11">
+         </FileRef>
+         <FileRef
+            location = "group:spirv.hpp">
+         </FileRef>
+         <FileRef
+            location = "group:spirv.h">
+         </FileRef>
+         <FileRef
+            location = "group:GLSL.std.450.h">
+         </FileRef>
+         <FileRef
+            location = "group:vk_sdk_platform.h">
+         </FileRef>
+         <FileRef
+            location = "group:spirv.json">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:glm"
+         name = "glm">
+         <FileRef
+            location = "group:CMakeLists.txt">
+         </FileRef>
+         <Group
+            location = "group:test"
+            name = "test">
+            <FileRef
+               location = "group:glm.cppcheck">
+            </FileRef>
+            <FileRef
+               location = "group:CMakeLists.txt">
+            </FileRef>
+            <Group
+               location = "group:core"
+               name = "core">
+               <FileRef
+                  location = "group:core_func_integer_bit_count.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:CMakeLists.txt">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_float.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_integer.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_setup_force_cxx98.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_setup_message.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_common.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_length.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_setup_precision.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_exponential.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_setup_force_size_t_length.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_packing.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_geometric.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_ctor.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_trigonometric.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_integer_find_msb.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_swizzle.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_mat2x2.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_mat4x4.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_vector_relational.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_mat2x3.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_mat2x4.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_mat4x2.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_mat4x3.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_noise.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_int.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_vec1.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_mat3x2.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_mat3x3.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_force_unrestricted_gentype.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_integer_find_lsb.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_vec2.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_force_pure.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_vec3.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_mat3x4.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_aligned.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_vec4.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_func_matrix.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:core_type_cast.cpp">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:bug"
+               name = "bug">
+               <FileRef
+                  location = "group:CMakeLists.txt">
+               </FileRef>
+               <FileRef
+                  location = "group:bug_ms_vec_static.cpp">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:external"
+               name = "external">
+               <Group
+                  location = "group:gli"
+                  name = "gli">
+                  <FileRef
+                     location = "group:texture2d.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:sampler_cube_array.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:texture1d_array.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:load.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:sampler2d.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:generate_mipmaps.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:levels.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:reduce.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CMakeLists.txt">
+                  </FileRef>
+                  <Group
+                     location = "group:core"
+                     name = "core">
+                     <FileRef
+                        location = "group:dx.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:comparison.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:mipmaps_compute.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:sampler2d_array.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:load_kmg.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:save_ktx.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:storage_linear.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:load_dds.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:clear.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:sampler_cube.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:transform.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:file.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:duplicate.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:storage_linear.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:texture3d.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:file.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:clear.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:sampler3d.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:load.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:sampler2d.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:texture1d_array.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:texture2d.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:sampler_cube_array.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:filter_compute.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:reduce.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:coord.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:levels.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:generate_mipmaps.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:format.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:save.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:flip.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:texture2d_array.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:image.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:copy.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:convert.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:sampler1d.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:dummy.cpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:texture1d.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:texture_cube.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:convert_func.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:storage.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:filter.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:sampler.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:texture_cube_array.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:sampler1d_array.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:texture.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:filter.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:view.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:workaround.hpp">
+                     </FileRef>
+                     <FileRef
+                        location = "group:storage.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:save_dds.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:flip.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:make_texture.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:gl.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:load_ktx.inl">
+                     </FileRef>
+                     <FileRef
+                        location = "group:save_kmg.inl">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:sampler3d.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:type.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:texture3d.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:save_ktx.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:gli.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:load_kmg.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:sampler2d_array.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:transform.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:duplicate.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:clear.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:sampler_cube.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:load_dds.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:target.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:comparison.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:dx.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:make_texture.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:save_dds.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:save_kmg.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:load_ktx.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:gl.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:sampler1d_array.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:texture.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:texture_cube_array.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:sampler.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:view.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:texture_cube.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:copy.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:image.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:texture2d_array.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:format.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:save.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:texture1d.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:convert.hpp">
+                  </FileRef>
+                  <FileRef
+                     location = "group:sampler1d.hpp">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:gtc"
+               name = "gtc">
+               <FileRef
+                  location = "group:gtc_packing.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_matrix_inverse.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:CMakeLists.txt">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_type_ptr.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_matrix_transform.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_type_precision.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_reciprocal.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_integer.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_noise.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_color_space.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_matrix_integer.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_user_defined_types.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_constants.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_type_aligned.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_random.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_epsilon.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_round.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_quaternion.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_matrix_access.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_bitfield.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_ulp.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_vec1.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtc_functions.cpp">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:gtx"
+               name = "gtx">
+               <FileRef
+                  location = "group:gtx_closest_point.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_number_precision.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_log_base.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_io.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_color_space.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_spline.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_scalar_multiplication.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_int_10_10_10_2.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:CMakeLists.txt">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_rotate_vector.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_vec_swizzle.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_exterior_product.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_matrix_query.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_intersect.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_color_encoding.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_matrix_factorisation.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_extend.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_euler_angle.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_quaternion.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_vector_angle.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_component_wise.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_orthonormalize.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_rotate_normalized_axis.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_type_trait.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_mixed_product.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_color_space_YCoCg.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_matrix_major_storage.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_fast_square_root.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_extended_min_max.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_fast_trigonometry.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_extented_min_max.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_simd_vec4.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_normal.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_matrix_operation.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_norm.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_handed_coordinate_space.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_type_aligned.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_matrix_interpolation.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_string_cast.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_wrap.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_projection.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_vector_query.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_random.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_compatibility.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_matrix_transform_2d.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_scalar_relational.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_polar_coordinates.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_normalize_dot.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_integer.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_simd_mat4.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_fast_exponential.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_dual_quaternion.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_matrix_decompose.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_range.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_common.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_perpendicular.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_gradient_paint.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_associated_min_max.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_matrix_cross_product.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gtx_optimum_pow.cpp">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:cmake"
+            name = "cmake">
+            <FileRef
+               location = "group:glmConfig.cmake.in">
+            </FileRef>
+            <FileRef
+               location = "group:glmBuildConfig.cmake.in">
+            </FileRef>
+            <FileRef
+               location = "group:GNUInstallDirs.cmake">
+            </FileRef>
+            <FileRef
+               location = "group:CMakePackageConfigHelpers.cmake">
+            </FileRef>
+            <FileRef
+               location = "group:glm.pc.in">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:util"
+            name = "util">
+            <FileRef
+               location = "group:autoexp.vc2010.dat">
+            </FileRef>
+            <FileRef
+               location = "group:usertype.dat">
+            </FileRef>
+            <FileRef
+               location = "group:autoexp.txt">
+            </FileRef>
+            <FileRef
+               location = "group:glm.natvis">
+            </FileRef>
+            <Group
+               location = "group:conan-package"
+               name = "conan-package">
+               <Group
+                  location = "group:lib_licenses"
+                  name = "lib_licenses">
+                  <FileRef
+                     location = "group:LICENSE2.txt">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LICENSE1.txt">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:conanfile.py">
+               </FileRef>
+               <FileRef
+                  location = "group:README.md">
+               </FileRef>
+               <Group
+                  location = "group:test_package"
+                  name = "test_package">
+                  <FileRef
+                     location = "group:CMakeLists.txt">
+                  </FileRef>
+                  <FileRef
+                     location = "group:conanfile.py">
+                  </FileRef>
+                  <FileRef
+                     location = "group:main.cpp">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+         <FileRef
+            location = "group:readme.md">
+         </FileRef>
+         <Group
+            location = "group:doc"
+            name = "doc">
+            <Group
+               location = "group:manual"
+               name = "manual">
+               <FileRef
+                  location = "group:references-leosfortune2.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:frontpage1.png">
+               </FileRef>
+               <FileRef
+                  location = "group:g-truc.png">
+               </FileRef>
+               <FileRef
+                  location = "group:frontpage2.png">
+               </FileRef>
+               <FileRef
+                  location = "group:references-cinder.png">
+               </FileRef>
+               <FileRef
+                  location = "group:references-leosfortune.jpeg">
+               </FileRef>
+               <FileRef
+                  location = "group:random-ballrand.png">
+               </FileRef>
+               <FileRef
+                  location = "group:random-circularrand.png">
+               </FileRef>
+               <FileRef
+                  location = "group:random-linearrand.png">
+               </FileRef>
+               <FileRef
+                  location = "group:noise-perlin2.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:noise-perlin3.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:references-opencloth1.png">
+               </FileRef>
+               <FileRef
+                  location = "group:references-outerra1.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:references-outerra3.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:references-opencloth3.png">
+               </FileRef>
+               <FileRef
+                  location = "group:noise-perlin1.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:references-outerra2.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:random-sphericalrand.png">
+               </FileRef>
+               <FileRef
+                  location = "group:logo-mini.png">
+               </FileRef>
+               <FileRef
+                  location = "group:noise-simplex2.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:noise-perlin4.png">
+               </FileRef>
+               <FileRef
+                  location = "group:random-gaussrand.png">
+               </FileRef>
+               <FileRef
+                  location = "group:noise-perlin5.png">
+               </FileRef>
+               <FileRef
+                  location = "group:noise-simplex3.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:noise-simplex1.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:noise-perlin6.png">
+               </FileRef>
+               <FileRef
+                  location = "group:references-outerra4.jpg">
+               </FileRef>
+               <FileRef
+                  location = "group:random-diskrand.png">
+               </FileRef>
+               <FileRef
+                  location = "group:references-glsl4book.jpg">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:theme"
+               name = "theme">
+               <FileRef
+                  location = "group:doxygen.css">
+               </FileRef>
+               <FileRef
+                  location = "group:tabs.css">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:pages.doxy">
+            </FileRef>
+            <Group
+               location = "group:api"
+               name = "api">
+               <FileRef
+                  location = "group:a00072_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00222.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00110_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_934f46a345653ef2b3014a1b37a162c1.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00002_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00019.html">
+               </FileRef>
+               <FileRef
+                  location = "group:splitbar.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00058.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00234.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00166.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00030_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00189.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00023.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00040_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00131.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00074.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00122_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00218.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00127.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00062.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00170.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00093_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00035.html">
+               </FileRef>
+               <FileRef
+                  location = "group:doxygen.css">
+               </FileRef>
+               <FileRef
+                  location = "group:a00042.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00107.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00086_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00119_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00015.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00150.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00025_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00003.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00146.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00055_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00054.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00111.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00137_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00185.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00049_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00214.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00097.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00039_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00078.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00067_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00202.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00081.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00105_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00017_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00193.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00039.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00192.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00132_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00038.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00050_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00080.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00020_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00203.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00096.html">
+               </FileRef>
+               <FileRef
+                  location = "group:arrowright.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00079.html">
+               </FileRef>
+               <FileRef
+                  location = "group:index.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00083_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00215.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00184.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00055.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00110.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00012_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00002.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00147.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00100_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:sync_off.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00062_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00014.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00151.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00043.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00106.html">
+               </FileRef>
+               <FileRef
+                  location = "group:modules.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00029_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00171.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00034.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00059_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00126.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00063.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00219.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_48eca2e6cf73effdec262031e861eeb0.html">
+               </FileRef>
+               <FileRef
+                  location = "group:sync_on.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00007_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00130.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00075.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00115_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00077_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00167.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00188.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00022.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00235.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_da256b9dd32ba43e2eaa8a2832c37f1b.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00109_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00096_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00059.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00127_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00045_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00018.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00223.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00035_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:doc.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00228.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00046_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00124_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00044.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00101.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00036_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:arrowdown.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00013.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00156.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00095_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00068_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00005.html">
+               </FileRef>
+               <FileRef
+                  location = "group:bc_s.png">
+               </FileRef>
+               <FileRef
+                  location = "group:nav_g.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00018_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00052.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00117.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00004_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:nav_f.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00029.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00183.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tabs.css">
+               </FileRef>
+               <FileRef
+                  location = "group:a00074_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00212.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00116_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00091.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00089_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00204.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00087.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00068.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00138_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00195.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00048.html">
+               </FileRef>
+               <FileRef
+                  location = "group:closed.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00224.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00009.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00011_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:doxygen.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00061_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00232.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00103_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00160.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00080_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00025.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00137.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00072.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00121.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00064.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00053_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tab_s.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00131_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00208.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00176.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00033.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00023_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00199.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00099_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00106_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00177.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00032.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00064_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00198.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00209.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00120.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00065.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00014_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00136.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00073.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00128_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00161.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00024.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_98f7f9d41f9d3029bd68cf237526a774.html">
+               </FileRef>
+               <FileRef
+                  location = "group:files.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00233.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00026_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00134_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00008.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00056_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00008_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tab_a.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00225.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00078_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00049.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00085_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00194.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00086.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00069.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00205.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00090_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00090.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00033_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00213.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00121_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00028.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00182.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00043_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00053.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00116.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00004.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00113_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00012.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00157.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tab_b.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00071_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00045.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00100.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00229.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00001_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00197.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00178.html">
+               </FileRef>
+               <FileRef
+                  location = "group:bdwn.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00097_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00108_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00085.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00206.html">
+               </FileRef>
+               <Group
+                  location = "group:search"
+                  name = "search">
+                  <FileRef
+                     location = "group:functions_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:searchdata.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_6.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_f.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_6.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_11.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_4.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_9.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_14.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_d.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_17.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_a.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search_r.png">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_7.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_9.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_a.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_8.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_c.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_15.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_10.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_8.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_e.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_6.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_8.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_14.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_a.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_b.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_9.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_11.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_9.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_d.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_16.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_7.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_10.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_8.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search.css">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_5.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_e.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_7.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_16.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_d.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_7.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_e.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_17.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_7.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_9.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_6.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_6.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_11.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_11.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_8.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_13.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_a.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_7.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_11.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_7.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_6.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_9.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_10.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_12.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_a.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_3.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_a.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_10.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_10.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_6.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_e.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_16.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_6.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_7.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_8.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_d.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_7.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_6.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_f.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_2.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_a.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_9.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_11.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_b.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_4.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_5.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_e.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_5.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_13.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_5.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_f.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_8.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_c.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_5.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_15.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_9.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_4.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_b.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_13.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_b.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_13.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_12.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_12.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_c.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_8.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_1.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_4.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_14.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_b.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_9.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_5.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_12.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_4.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_c.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_d.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_4.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_10.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_f.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_c.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_5.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_8.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_4.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_5.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_15.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_b.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_12.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_6.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_d.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_4.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_15.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search_l.png">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:pages_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_13.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_4.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_a.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_f.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_c.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_c.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_8.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search_m.png">
+                  </FileRef>
+                  <FileRef
+                     location = "group:search.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_9.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_0.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_b.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_12.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_5.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:pages_0.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:typedefs_3.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:mag_sel.png">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_b.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:nomatches.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_4.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_14.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_14.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_5.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_e.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_7.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_1.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_16.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:functions_c.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:files_13.js">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_14.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:groups_2.html">
+                  </FileRef>
+                  <FileRef
+                     location = "group:close.png">
+                  </FileRef>
+                  <FileRef
+                     location = "group:all_f.js">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:a00093.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00139.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00034_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00210.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00181.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00044_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00126_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00115.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00050.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00058_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00007.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00028_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00154.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00011.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00076_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00114_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00103.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_45973f864e07b2505003ae343b7c8af7.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00046.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00006_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00063_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00031.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00101_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00174.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00013_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00066.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00089.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00123.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00070.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00135.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00027.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00162.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00230.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00021_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00119.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00051_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00133_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00158.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_e8f3c1046ba4b357711397765359cd18.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00082_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00226.html">
+               </FileRef>
+               <FileRef
+                  location = "group:logo-mini.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00038_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00227.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00159.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00048_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00016_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00104_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00118.html">
+               </FileRef>
+               <FileRef
+                  location = "group:nav_h.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00231.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00066_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00026.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00163.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00118_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00087_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00071.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00134.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00136_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00067.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00088.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00122.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00054_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:tab_h.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00030.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00175.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00024_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00123_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00102.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00041_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00047.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00155.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00010.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00031_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00092_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00006.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00114.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00180.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00003_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00211.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00111_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00092.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00138.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00073_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00207.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00084.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00196.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00179.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_9344afb825aed5e2f5be1d2015dde43c.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00037.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00172.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00060.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00125.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00076.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00133.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00099.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00070_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00021.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00112_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00164.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00091_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00236.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00148.html">
+               </FileRef>
+               <FileRef
+                  location = "group:open.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00042_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00120_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00032_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00220.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_304be5dfae1339a7705426c0b536faf2.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00109.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00191.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00057_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00135_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00027_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00129.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00200.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00084_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00095.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00216.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00079_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00187.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00168.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00009_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00113.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00015_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00056.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00065_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00001.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00107_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00098_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00152.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00017.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00129_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00105.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00040.html">
+               </FileRef>
+               <FileRef
+                  location = "group:folderclosed.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00104.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00041.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dynsections.js">
+               </FileRef>
+               <FileRef
+                  location = "group:a00153.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00081_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00016.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00022_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00145.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00130_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00112.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00052_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:folderopen.png">
+               </FileRef>
+               <FileRef
+                  location = "group:a00057.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00186.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00169.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00217.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00094.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00201.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00102_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00060_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00128.html">
+               </FileRef>
+               <FileRef
+                  location = "group:dir_7997edb062bdde9a99cb6835d42b0d9d.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00082.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00010_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00190.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00108.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00088_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00117_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00075_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00221.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00005_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00149.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00139_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00020.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00165.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00037_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00077.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00132.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00098.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00125_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00047_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00061.html">
+               </FileRef>
+               <FileRef
+                  location = "group:jquery.js">
+               </FileRef>
+               <FileRef
+                  location = "group:a00124.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00019_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00036.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00173.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00069_source.html">
+               </FileRef>
+               <FileRef
+                  location = "group:a00094_source.html">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:man.doxy">
+            </FileRef>
+         </Group>
+         <FileRef
+            location = "group:manual.md">
+         </FileRef>
+         <Group
+            location = "group:glm"
+            name = "glm">
+            <FileRef
+               location = "group:vec4.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:integer.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:vector_relational.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:mat2x3.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:mat4x4.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:mat2x2.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:exponential.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:vec2.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:CMakeLists.txt">
+            </FileRef>
+            <FileRef
+               location = "group:vec3.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:fwd.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:mat4x3.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:mat4x2.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:mat2x4.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:packing.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:mat3x3.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:mat3x2.hpp">
+            </FileRef>
+            <Group
+               location = "group:simd"
+               name = "simd">
+               <FileRef
+                  location = "group:vector_relational.h">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix.h">
+               </FileRef>
+               <FileRef
+                  location = "group:packing.h">
+               </FileRef>
+               <FileRef
+                  location = "group:common.h">
+               </FileRef>
+               <FileRef
+                  location = "group:trigonometric.h">
+               </FileRef>
+               <FileRef
+                  location = "group:geometric.h">
+               </FileRef>
+               <FileRef
+                  location = "group:integer.h">
+               </FileRef>
+               <FileRef
+                  location = "group:platform.h">
+               </FileRef>
+               <FileRef
+                  location = "group:exponential.h">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:mat3x4.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:matrix.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:glm.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:trigonometric.hpp">
+            </FileRef>
+            <FileRef
+               location = "group:geometric.hpp">
+            </FileRef>
+            <Group
+               location = "group:detail"
+               name = "detail">
+               <FileRef
+                  location = "group:type_vec.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_geometric.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_exponential.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_trigonometric.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_integer_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_vector_relational.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_packing.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_common.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:_fixes.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_half.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_integer.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_vector_relational_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_matrix_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_int.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:_noise.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_half.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:_features.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_integer.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:_vectorize.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_exponential.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_geometric.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_common.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_packing.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_vector_relational.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_trigonometric.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat2x4.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat4x2.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:_swizzle.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat4x3.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_packing_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec4.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_trigonometric_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:precision.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat3x3.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat3x2.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:dummy.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:setup.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat2x2.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec1.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_common_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_matrix.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat4x4.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_geometric_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat2x3.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec2.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:glm.cpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_gentype.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat3x4.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec3.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat4x4_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat2x3.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat4x4.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:func_matrix.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat2x2.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec1.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:_swizzle_func.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec3.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec4_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat3x4.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:func_exponential_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_gentype.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec2.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat4x3.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat4x2.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_float.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat2x4.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat3x2.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_mat3x3.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_vec4.hpp">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:ext.hpp">
+            </FileRef>
+            <Group
+               location = "group:gtc"
+               name = "gtc">
+               <FileRef
+                  location = "group:integer.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_integer.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:functions.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_inverse.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:quaternion.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:packing.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_transform.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:vec1.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_precision.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:bitfield.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:ulp.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:round.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:packing.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:quaternion_simd.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:ulp.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:round.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_transform.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_precision.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:bitfield.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:vec1.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:integer.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:quaternion.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:functions.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_inverse.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:epsilon.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:random.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_access.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_ptr.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:reciprocal.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:constants.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:color_space.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:noise.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:color_space.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:noise.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_access.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:random.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:epsilon.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:constants.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:reciprocal.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_ptr.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_aligned.hpp">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:common.hpp">
+            </FileRef>
+            <Group
+               location = "group:gtx"
+               name = "gtx">
+               <FileRef
+                  location = "group:vector_angle.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:log_base.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_query.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:extend.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:integer.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:associated_min_max.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_transform_2d.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:hash.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:rotate_vector.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_interpolation.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:quaternion.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:exterior_product.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:gradient_paint.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:string_cast.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:color_space_YCoCg.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:type_trait.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:extended_min_max.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:euler_angles.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:fast_square_root.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:raw_data.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_cross_product.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:spline.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:fast_trigonometry.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:optimum_pow.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:dual_quaternion.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:closest_point.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:number_precision.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:mixed_product.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:transform.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:bit.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:io.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:fast_trigonometry.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:optimum_pow.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:spline.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:raw_data.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_cross_product.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:euler_angles.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:fast_square_root.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:color_space_YCoCg.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_trait.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:extended_min_max.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:io.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:float_notmalize.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:transform.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:bit.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:number_precision.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:mixed_product.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:closest_point.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:dual_quaternion.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:associated_min_max.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_transform_2d.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:integer.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:log_base.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_query.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:vector_angle.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:extend.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:gradient_paint.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:quaternion.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:exterior_product.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:string_cast.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:rotate_vector.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_interpolation.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:hash.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:vector_query.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:polar_coordinates.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:orthonormalize.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:component_wise.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:normalize_dot.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:std_based_type.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_factorisation.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_aligned.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:vec_swizzle.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:projection.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:compatibility.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:scalar_relational.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:wrap.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:rotate_normalized_axis.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:color_encoding.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:norm.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_major_storage.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_operation.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:color_space.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:normal.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:intersect.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:perpendicular.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:transform2.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_decompose.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:fast_exponential.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:common.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:handed_coordinate_space.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:intersect.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:perpendicular.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_operation.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:color_space.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:normal.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:color_encoding.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_major_storage.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:norm.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:handed_coordinate_space.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:common.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:range.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:fast_exponential.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:transform2.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_decompose.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:scalar_multiplication.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:std_based_type.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:matrix_factorisation.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:orthonormalize.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:normalize_dot.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:component_wise.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:polar_coordinates.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:vector_query.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:scalar_relational.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:wrap.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:compatibility.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:rotate_normalized_axis.hpp">
+               </FileRef>
+               <FileRef
+                  location = "group:projection.inl">
+               </FileRef>
+               <FileRef
+                  location = "group:type_aligned.hpp">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+   </Group>
+   <Group
+      location = "group:../../external/imgui"
+      name = "imgui">
+      <FileRef
+         location = "group:imgui.h">
+      </FileRef>
+      <FileRef
+         location = "group:imconfig.h">
+      </FileRef>
+      <FileRef
+         location = "group:LICENSE">
+      </FileRef>
+      <FileRef
+         location = "group:stb_rect_pack.h">
+      </FileRef>
+      <FileRef
+         location = "group:README.md">
+      </FileRef>
+      <FileRef
+         location = "group:stb_truetype.h">
+      </FileRef>
+      <FileRef
+         location = "group:imgui.cpp">
+      </FileRef>
+      <FileRef
+         location = "group:imgui_internal.h">
+      </FileRef>
+      <FileRef
+         location = "group:stb_textedit.h">
+      </FileRef>
+      <FileRef
+         location = "group:imgui_demo.cpp">
+      </FileRef>
+      <FileRef
+         location = "group:imgui_draw.cpp">
+      </FileRef>
+   </Group>
    <FileRef
-      location = "self:/Users/bill/Documents/Dev/iOSProjects/Molten/Testing/MoltenVK/SaschaWillems/Vulkan-bw/xcode/examples.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/xcode/examples.xcodeproj/xcshareddata/xcschemes/examples-ios.xcscheme
+++ b/xcode/examples.xcodeproj/xcshareddata/xcschemes/examples-ios.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0920"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -45,6 +46,7 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/xcode/examples.xcodeproj/xcshareddata/xcschemes/examples-macos.xcscheme
+++ b/xcode/examples.xcodeproj/xcshareddata/xcschemes/examples-macos.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0920"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -45,6 +46,7 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
This updates include paths in `examples.h`, README for molten, and xcode project files so that the examples can be run on macOS.

Particulary in the xcode files, I am not sure if I did the right thing, so I would appreciate someone checking that.

Some of the examples do not run, but that is documented in `examples.h`, and is because of vulkan/metal mismatch.
