### PR TITLE
Fix capitalization of glslangValidator

### DIFF
--- a/data/shaders/compileshaders.py
+++ b/data/shaders/compileshaders.py
@@ -18,7 +18,7 @@ for exts in ('*.vert', '*.frag', '*.comp', '*.geom', '*.tesc', '*.tese'):
 failedshaders = []
 for shaderfile in shaderfiles:
 		print("\n-------- %s --------\n" % shaderfile)
-		if subprocess.call("glslangvalidator -V %s -o %s.spv" % (shaderfile, shaderfile), shell=True) != 0:
+		if subprocess.call("glslangValidator -V %s -o %s.spv" % (shaderfile, shaderfile), shell=True) != 0:
 			failedshaders.append(shaderfile)
 
 print("\n-------- Compilation result --------\n")


### PR DESCRIPTION
compileshaders.py didn't work for me on Linux when ``glslangvalidator`` is all lowercase.