### PR TITLE
Use transient depth/stencil buffer

### DIFF
--- a/examples/textoverlay/textoverlay.cpp
+++ b/examples/textoverlay/textoverlay.cpp
@@ -477,7 +477,7 @@ public:
 		attachments[1].format = depthFormat;
 		attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
 		attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-		attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+		attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;


### PR DESCRIPTION
We don't need to store the d/s buffer when its load-op
is configured to clear. This can also save bandwidth and
increase performance slightly.

Flagging the depth/stencil buffer as transient and using lazy
allocation allows some implementations (tile-based renderers)
to avoid allocating the buffer at all in most cases since it
now never needs to be stored.