### PR TITLE
Computecloth - fixed problem with synchronization of uniform buffer data updates

### DIFF
--- a/examples/computecloth/computecloth.cpp
+++ b/examples/computecloth/computecloth.cpp
@@ -694,6 +694,12 @@ public:
 
 	void draw()
 	{
+    VkSubmitInfo computeSubmitInfo = vks::initializers::submitInfo();
+    computeSubmitInfo.commandBufferCount = 1;
+    computeSubmitInfo.pCommandBuffers = &compute.commandBuffers[readSet];
+
+    VK_CHECK_RESULT( vkQueueSubmit( compute.queue, 1, &computeSubmitInfo, compute.fence ) );
+
 		// Submit graphics commands
 		VulkanExampleBase::prepareFrame();
 
@@ -705,12 +711,6 @@ public:
 
 		vkWaitForFences(device, 1, &compute.fence, VK_TRUE, UINT64_MAX);
 		vkResetFences(device, 1, &compute.fence);
-
-		VkSubmitInfo computeSubmitInfo = vks::initializers::submitInfo();
-		computeSubmitInfo.commandBufferCount = 1;
-		computeSubmitInfo.pCommandBuffers = &compute.commandBuffers[readSet];
-
-		VK_CHECK_RESULT(vkQueueSubmit(compute.queue, 1, &computeSubmitInfo, compute.fence));
 	}
 
 	void prepare()

--- a/examples/raytracing/raytracing.cpp
+++ b/examples/raytracing/raytracing.cpp
@@ -283,6 +283,7 @@ public:
 
 		VK_CHECK_RESULT(vkBeginCommandBuffer(compute.commandBuffer, &cmdBufInfo));
 
+		vkCmdBindPipeline(compute.commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.pipeline);
 		vkCmdBindDescriptorSets(compute.commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.pipelineLayout, 0, 1, &compute.descriptorSet, 0, 0);
 
 		vkCmdDispatch(compute.commandBuffer, textureComputeTarget.width / 16, textureComputeTarget.height / 16, 1);

--- a/examples/raytracing/raytracing.cpp
+++ b/examples/raytracing/raytracing.cpp
@@ -685,12 +685,6 @@ public:
 
 	void draw()
 	{
-    VkSubmitInfo computeSubmitInfo = vks::initializers::submitInfo();
-    computeSubmitInfo.commandBufferCount = 1;
-    computeSubmitInfo.pCommandBuffers = &compute.commandBuffer;
-
-    VK_CHECK_RESULT( vkQueueSubmit( compute.queue, 1, &computeSubmitInfo, compute.fence ) );
-
 		VulkanExampleBase::prepareFrame();
 
 		// Command buffer to be sumitted to the queue
@@ -704,6 +698,12 @@ public:
 		// Use a fence to ensure that compute command buffer has finished executing before using it again
 		vkWaitForFences(device, 1, &compute.fence, VK_TRUE, UINT64_MAX);
 		vkResetFences(device, 1, &compute.fence);
+
+		VkSubmitInfo computeSubmitInfo = vks::initializers::submitInfo();
+		computeSubmitInfo.commandBufferCount = 1;
+		computeSubmitInfo.pCommandBuffers = &compute.commandBuffer;
+
+		VK_CHECK_RESULT(vkQueueSubmit(compute.queue, 1, &computeSubmitInfo, compute.fence));
 	}
 
 	void prepare()

--- a/examples/raytracing/raytracing.cpp
+++ b/examples/raytracing/raytracing.cpp
@@ -283,23 +283,6 @@ public:
 
 		VK_CHECK_RESULT(vkBeginCommandBuffer(compute.commandBuffer, &cmdBufInfo));
 
-    VkBufferMemoryBarrier bufferMemoryBarrier = {};
-    bufferMemoryBarrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-    bufferMemoryBarrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
-    bufferMemoryBarrier.dstAccessMask = VK_ACCESS_UNIFORM_READ_BIT;
-    bufferMemoryBarrier.buffer = compute.uniformBuffer.buffer;
-    bufferMemoryBarrier.offset = 0;
-    bufferMemoryBarrier.size = VK_WHOLE_SIZE;
-    vkCmdPipelineBarrier(
-      compute.commandBuffer,
-      VK_PIPELINE_STAGE_HOST_BIT,
-      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-      VK_FLAGS_NONE,
-      0, nullptr,
-      1, &bufferMemoryBarrier,
-      0, nullptr );
-
-		vkCmdBindPipeline(compute.commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.pipeline);
 		vkCmdBindDescriptorSets(compute.commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute.pipelineLayout, 0, 1, &compute.descriptorSet, 0, 0);
 
 		vkCmdDispatch(compute.commandBuffer, textureComputeTarget.width / 16, textureComputeTarget.height / 16, 1);


### PR DESCRIPTION
Uniform buffer data updates are not properly synchronized with execution of compute shaders - they are performed at the same time. This pull request changes the order of operations so buffer updates are performed after execution of command buffer with compute shaders is finished.