### PR TITLE
Enable DPI awareness on Windows platform

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -761,6 +761,8 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 	{
 		setupConsole("Vulkan validation output");
 	}
+
+	SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
 #endif
 }
 


### PR DESCRIPTION
Enable DPI awareness on Windows platform to prevent blurry look on UI with scale other than 100%