### PR TITLE
texture3d checks wrong type of flag (VK_IMAGE_USAGE_TRANSFER_DST_BIT instead of VK_FORMAT_FEATURE_TRANSFER_DST_BIT)

### DIFF
--- a/examples/texture3d/texture3d.cpp
+++ b/examples/texture3d/texture3d.cpp
@@ -234,7 +234,7 @@ public:
 		VkFormatProperties formatProperties;
 		vkGetPhysicalDeviceFormatProperties(physicalDevice, texture.format, &formatProperties);
 		// Check if format supports transfer
-		if (!(formatProperties.optimalTilingFeatures & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+		if (!(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT))
 		{
 			std::cout << "Error: Device does not support flag TRANSFER_DST for selected texture format!" << std::endl;
 			return;


### PR DESCRIPTION
Test is checking that the format supports being a transfer destination
but is checking the optimalTilingFeatures against an image usage flag
(VK_IMAGE_USAGE_TRANSFER_DST_BIT) instead of a format feature flag
(VK_FORMAT_FEATURE_TRANSFER_DST_BIT) which have different values.

Otherwise the test believes the device does not support the required
format and quits.