### PR TITLE
 Fixed Android Shadowmapping crash cmake

### DIFF
--- a/android/examples/shadowmapping/build.gradle
+++ b/android/examples/shadowmapping/build.gradle
@@ -60,6 +60,11 @@ task copyTask << {
        include 'vulkanscene_shadow.dae'
     }
 
+    copy {
+       from '../../../data/models'
+       into 'assets/models'
+       include 'samplescene.dae'
+    }
 
 }
 


### PR DESCRIPTION
follow up from #478, the `samplescene.dae` wasn't getting built-in