### PR TITLE
Fix using a potentially uninitialized variable in triangle.cpp

### DIFF
--- a/examples/triangle/triangle.cpp
+++ b/examples/triangle/triangle.cpp
@@ -791,7 +791,7 @@ public:
 	VkShaderModule loadSPIRVShader(std::string filename)
 	{
 		size_t shaderSize;
-		char* shaderCode;
+		char* shaderCode = NULL;
 
 #if defined(__ANDROID__)
 		// Load shader from compressed asset


### PR DESCRIPTION
If opening of SPIR-V file fails, `shaderCode` is used in an `if` statement, but not initialized.