### PR TITLE
Don't set an object name for the wireframe pipeline when fillModeNonSolid is not supported

### DIFF
--- a/examples/debugmarker/debugmarker.cpp
+++ b/examples/debugmarker/debugmarker.cpp
@@ -864,7 +864,12 @@ public:
 		// Name pipelines for debugging
 		DebugMarker::setObjectName(device, (uint64_t)pipelines.toonshading, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, "Toon shading pipeline");
 		DebugMarker::setObjectName(device, (uint64_t)pipelines.color, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, "Color only pipeline");
-		DebugMarker::setObjectName(device, (uint64_t)pipelines.wireframe, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, "Wireframe rendering pipeline");
+
+		if (deviceFeatures.fillModeNonSolid)
+		{
+			DebugMarker::setObjectName(device, (uint64_t)pipelines.wireframe, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, "Wireframe rendering pipeline");
+		}
+
 		DebugMarker::setObjectName(device, (uint64_t)pipelines.postprocess, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, "Post processing pipeline");
 	}
 


### PR DESCRIPTION
Fixes segfault in debugmarker example on platforms where fillModeNonSolid is not supported.