### PR TITLE
Fix for multisample depth resolve attachment and storeOp for the MSAA color attachment

### DIFF
--- a/examples/multisampling/multisampling.cpp
+++ b/examples/multisampling/multisampling.cpp
@@ -248,13 +248,13 @@ public:
 	{
 		// Overrides the virtual function of the base class
 
-		std::array<VkAttachmentDescription, 4> attachments = {};
+		std::array<VkAttachmentDescription, 3> attachments = {};
 
 		// Multisampled attachment that we render to
 		attachments[0].format = swapChain.colorFormat;
 		attachments[0].samples = sampleCount;
 		attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-		attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+		attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -280,16 +280,6 @@ public:
 		attachments[2].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[2].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 		attachments[2].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-		// Depth resolve attachment
-		attachments[3].format = depthFormat;
-		attachments[3].samples = VK_SAMPLE_COUNT_1_BIT;
-		attachments[3].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-		attachments[3].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-		attachments[3].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-		attachments[3].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-		attachments[3].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-		attachments[3].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
 		VkAttachmentReference colorReference = {};
 		colorReference.attachment = 0;
@@ -357,14 +347,13 @@ public:
 	{
 		// Overrides the virtual function of the base class
 
-		std::array<VkImageView, 4> attachments;
+		std::array<VkImageView, 3> attachments;
 
 		setupMultisampleTarget();
 
 		attachments[0] = multisampleTarget.color.view;
 		// attachment[1] = swapchain image
 		attachments[2] = multisampleTarget.depth.view;
-		attachments[3] = depthStencil.view;
 
 		VkFramebufferCreateInfo frameBufferCreateInfo = {};
 		frameBufferCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;


### PR DESCRIPTION
Removed the attachment intended for resolved depth, which Vulkan can't do (yet?). The storeOp for the MSAA color attachment can safely be changed to VK_ATTACHMENT_STORE_OP_DONT_CARE as it is resolved before the end of the subpass.