### PR TITLE
Add missing flush in one of the buffer creation helpers.

### DIFF
--- a/base/VulkanDevice.hpp
+++ b/base/VulkanDevice.hpp
@@ -414,6 +414,9 @@ namespace vks
 			{
 				VK_CHECK_RESULT(buffer->map());
 				memcpy(buffer->mapped, data, size);
+				if ((memoryPropertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0)
+					buffer->flush();
+
 				buffer->unmap();
 			}
 


### PR DESCRIPTION
This caused gears to break, after a driver change removed an implicit flush in our buffer copy implementation that had been hiding this issue. I could have just changed gears to use coherent memory, but it seemed sensible to fix the helper infrastructure anyway.