### PR TITLE
Added VS_DEBUGGER_WORKING_DIRECTORY to examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,6 +25,8 @@ function(buildExample EXAMPLE_NAME)
 		target_link_libraries(${EXAMPLE_NAME} base )
 	endif(WIN32)
 
+	set_target_properties(${EXAMPLE_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+
 	if(RESOURCE_INSTALL_DIR)
 		install(TARGETS ${EXAMPLE_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endif()


### PR DESCRIPTION
We discussed adding a line to the CMake on the Vulkan discord that sets VS_DEBUGGER_WORKING_DIRECTORY for all the examples. So this is that PR, let me know if you want any changes.