### PR TITLE
Fix incorrect rendering of right eye on radv

### DIFF
--- a/examples/multiview/multiview.cpp
+++ b/examples/multiview/multiview.cpp
@@ -345,7 +345,7 @@ public:
 			framebufferCI.pAttachments = attachments;
 			framebufferCI.width = width;
 			framebufferCI.height = height;
-			framebufferCI.layers = 1;
+			framebufferCI.layers = 2;
 			VK_CHECK_RESULT(vkCreateFramebuffer(device, &framebufferCI, nullptr, &multiviewPass.frameBuffer));
 		}
 	}


### PR DESCRIPTION
I'm not too familiar with the spec regarding multiview, so perhaps this could be a radv bug.

Sometimes the error isn't noticeable until you tweak the eye separation.

This error occurs with both a Vega 64 and a RX 580.