### PR TITLE
Pass the full count of the indirectCommands to vkCmdDrawIndexedIndirect

### DIFF
--- a/examples/computecullandlod/computecullandlod.cpp
+++ b/examples/computecullandlod/computecullandlod.cpp
@@ -200,7 +200,7 @@ public:
 
 			if (vulkanDevice->features.multiDrawIndirect)
 			{
-				vkCmdDrawIndexedIndirect(drawCmdBuffers[i], indirectCommandsBuffer.buffer, 0, indirectStats.drawCount, sizeof(VkDrawIndexedIndirectCommand));
+				vkCmdDrawIndexedIndirect(drawCmdBuffers[i], indirectCommandsBuffer.buffer, 0, indirectCommands.size(), sizeof(VkDrawIndexedIndirectCommand));
 			}
 			else
 			{


### PR DESCRIPTION
Items with zero instance count still need to be processed.

This fixes the problem reported with #526.