### PR TITLE
Fix Android build error.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -14,6 +14,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }


### PR DESCRIPTION
The latest version of Android Studio fails with:

    Could not find com.android.tools.build:aapt2

To use AAPT2, we must now have a dependency on the `google()` repo in both places in the root build.gradle file, which is documented [here](https://developer.android.com/studio/releases/#aapt2_gmaven).