### PR TITLE
Make FPS counter more accurate

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -250,7 +250,7 @@ void VulkanExampleBase::renderFrame()
 			timer -= 1.0f;
 		}
 	}
-	fpsTimer += (float)tDiff;
+	float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
 	if (fpsTimer > 1000.0f)
 	{
 		lastFPS = static_cast<uint32_t>((float)frameCounter * (1000.0f / fpsTimer));
@@ -260,8 +260,8 @@ void VulkanExampleBase::renderFrame()
 			SetWindowText(window, windowTitle.c_str());
 		}
 #endif
-		fpsTimer = 0.0f;
 		frameCounter = 0;
+		lastTimestamp = tEnd;
 	}
 	// TODO: Cap UI overlay update rates
 	updateOverlay();
@@ -280,6 +280,7 @@ void VulkanExampleBase::renderLoop()
 
 	destWidth = width;
 	destHeight = height;
+	lastTimestamp = std::chrono::high_resolution_clock::now();
 #if defined(_WIN32)
 	MSG msg;
 	bool quitMessageReceived = false;
@@ -347,12 +348,12 @@ void VulkanExampleBase::renderLoop()
 					timer -= 1.0f;
 				}
 			}
-			fpsTimer += (float)tDiff;
+			float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
 			if (fpsTimer > 1000.0f)
 			{
 				lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
-				fpsTimer = 0.0f;
 				frameCounter = 0;
+				lastTimestamp = tEnd;
 			}
 
 			// TODO: Cap UI overlay update rates/only issue when update requested
@@ -437,12 +438,12 @@ void VulkanExampleBase::renderLoop()
 				timer -= 1.0f;
 			}
 		}
-		fpsTimer += (float)tDiff;
+		float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
 		if (fpsTimer > 1000.0f)
 		{
 			lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
-			fpsTimer = 0.0f;
 			frameCounter = 0;
+			lastTimestamp = tEnd;
 		}
 		updateOverlay();
 	}
@@ -483,7 +484,7 @@ void VulkanExampleBase::renderLoop()
 				timer -= 1.0f;
 			}
 		}
-		fpsTimer += (float)tDiff;
+		float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
 		if (fpsTimer > 1000.0f)
 		{
 			if (!settings.overlay)
@@ -492,8 +493,8 @@ void VulkanExampleBase::renderLoop()
 				xdg_toplevel_set_title(xdg_toplevel, windowTitle.c_str());
 			}
 			lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
-			fpsTimer = 0.0f;
 			frameCounter = 0;
+			lastTimestamp = tEnd;
 		}
 		updateOverlay();
 	}
@@ -532,7 +533,7 @@ void VulkanExampleBase::renderLoop()
 				timer -= 1.0f;
 			}
 		}
-		fpsTimer += (float)tDiff;
+		float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
 		if (fpsTimer > 1000.0f)
 		{
 			if (!settings.overlay)
@@ -543,8 +544,8 @@ void VulkanExampleBase::renderLoop()
 					windowTitle.size(), windowTitle.c_str());
 			}
 			lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
-			fpsTimer = 0.0f;
 			frameCounter = 0;
+			lastTimestamp = tEnd;
 		}
 		updateOverlay();
 	}

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -57,8 +57,6 @@
 class VulkanExampleBase
 {
 private:	
-	// fps timer (one second interval)
-	float fpsTimer = 0.0f;
 	// Get window title with example name, device, et.
 	std::string getWindowTitle();
 	/** brief Indicates that the view (position, rotation) has changed and buffers containing camera matrices need to be updated */
@@ -74,6 +72,7 @@ protected:
 	// Frame counter to display fps
 	uint32_t frameCounter = 0;
 	uint32_t lastFPS = 0;
+	std::chrono::time_point<std::chrono::high_resolution_clock> lastTimestamp;
 	// Vulkan instance, stores all per-application states
 	VkInstance instance;
 	// Physical device (GPU) that Vulkan will ise


### PR DESCRIPTION
While trying to figure a discrepancy between the FPS counter from the
overlay we've introduced in Mesa [1] and the counter in the Vulkan
demos, I figured the demos are not accounting for part of the
rendering loop but rather just the amount of time spent rendering.

This changes accounts for the total amount of time between 2 frames. I
don't think any difference is visible until you reach high frame rates
of 100s or so.

[1]: https://gitlab.freedesktop.org/mesa/mesa/merge_requests/303