### PR TITLE
Fix occlusion query example visual glitch

### DIFF
--- a/examples/occlusionquery/occlusionquery.cpp
+++ b/examples/occlusionquery/occlusionquery.cpp
@@ -273,6 +273,7 @@ public:
 
 	void draw()
 	{
+		updateUniformBuffers();
 		VulkanExampleBase::prepareFrame();
 
 		submitInfo.commandBufferCount = 1;
@@ -592,11 +593,6 @@ public:
 		if (!prepared)
 			return;
 		draw();
-	}
-
-	virtual void viewChanged()
-	{
-		updateUniformBuffers();
 	}
 
 	virtual void OnUpdateUIOverlay(vks::UIOverlay *overlay)


### PR DESCRIPTION
In the occlusion query example, uniform buffers containing visibility
flags are only updated when the view changes, and visibility information
is calculated from occlusion queries coming from the previous frame.

This means a quick mouse movement can produce a visual glitch by which
the number of visible fragments becomes zero (and this is correctly
reflected in the UI overlay) but the color of the model remains
unchanged, or vice versa, until the view is changed again with the
mouse.

To fix this, update uniform buffers before preparing every frame as part
of the draw() method.