### PR TITLE
Fix incorrect VkDescriptorPoolSize in negativeviewportheight.

### DIFF
--- a/examples/negativeviewportheight/negativeviewportheight.cpp
+++ b/examples/negativeviewportheight/negativeviewportheight.cpp
@@ -204,7 +204,7 @@ public:
 		VkPipelineLayoutCreateInfo pipelineLayoutCI = vks::initializers::pipelineLayoutCreateInfo(&descriptorSetLayout, 1);
 		VK_CHECK_RESULT(vkCreatePipelineLayout(device, &pipelineLayoutCI, nullptr, &pipelineLayout));
 
-		VkDescriptorPoolSize poolSize = vks::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1);
+		VkDescriptorPoolSize poolSize = vks::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2);
 		VkDescriptorPoolCreateInfo descriptorPoolCI = vks::initializers::descriptorPoolCreateInfo(1, &poolSize, 2);
 		VK_CHECK_RESULT(vkCreateDescriptorPool(device, &descriptorPoolCI, nullptr, &descriptorPool));
 


### PR DESCRIPTION
There is assertion fail in negativeviewportheight (AMD GPU). The example create two VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER for descriptorSet, but descriptorCount is one in descriptorPool.

// 1, VK_SUCCESS
VK_CHECK_RESULT(vkAllocateDescriptorSets(device, &descriptorSetAI, &descriptorSets.CW));
// 2, VK_ERROR_OUT_OF_POOL_MEMORY
VK_CHECK_RESULT(vkAllocateDescriptorSets(device, &descriptorSetAI, &descriptorSets.CCW));