### PR TITLE
Fix a couple of small errors in ray tracing examples

### DIFF
--- a/examples/nv_ray_tracing_basic/nv_ray_tracing_basic.cpp
+++ b/examples/nv_ray_tracing_basic/nv_ray_tracing_basic.cpp
@@ -246,12 +246,12 @@ public:
 	{
 		// Setup vertices for a single uv-mapped quad made from two triangles
 		struct Vertex {
-			float pos[4];
+			float pos[3];
 		};
 		std::vector<Vertex> vertices = {
-			{ {  1.0f,  1.0f, 0.0f, 1.0f } },
-			{ { -1.0f,  1.0f, 0.0f, 1.0f } },
-			{ {  0.0f, -1.0f, 0.0f, 1.0f } }
+			{ {  1.0f,  1.0f, 0.0f } },
+			{ { -1.0f,  1.0f, 0.0f } },
+			{ {  0.0f, -1.0f, 0.0f } }
 		};
 
 		// Setup indices
@@ -286,7 +286,7 @@ public:
 		geometry.geometry.triangles.vertexOffset = 0;
 		geometry.geometry.triangles.vertexCount = static_cast<uint32_t>(vertices.size());
 		geometry.geometry.triangles.vertexStride = sizeof(Vertex);
-		geometry.geometry.triangles.vertexFormat = VK_FORMAT_R32G32B32A32_SFLOAT;
+		geometry.geometry.triangles.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
 		geometry.geometry.triangles.indexData = indexBuffer.buffer;
 		geometry.geometry.triangles.indexOffset = 0;
 		geometry.geometry.triangles.indexCount = indexCount;
@@ -385,6 +385,7 @@ public:
 		/*
 			Build top-level acceleration structure
 		*/
+		buildInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV;
 		buildInfo.pGeometries = 0;
 		buildInfo.geometryCount = 0;
 		buildInfo.instanceCount = 1;

--- a/examples/nv_ray_tracing_reflections/nv_ray_tracing_reflections.cpp
+++ b/examples/nv_ray_tracing_reflections/nv_ray_tracing_reflections.cpp
@@ -374,6 +374,7 @@ public:
 		/*
 			Build top-level acceleration structure
 		*/
+		buildInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV;
 		buildInfo.pGeometries = 0;
 		buildInfo.geometryCount = 0;
 		buildInfo.instanceCount = 1;

--- a/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
+++ b/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
@@ -383,6 +383,7 @@ public:
 		/*
 			Build top-level acceleration structure
 		*/
+		buildInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV;
 		buildInfo.pGeometries = 0;
 		buildInfo.geometryCount = 0;
 		buildInfo.instanceCount = 1;


### PR DESCRIPTION
nv_ray_tracing_basic.cpp
 - update to 3 component vertex data (4 component isn't supported)
 - update type to TOP_LEVEL when building the TLAS

nv_ray_tracing_reflections.cpp
 - update AS info type to TOP_LEVEL when building the TLAS

nv_ray_tracing_shadows.cpp
 - update AS info type to TOP_LEVEL when building the TLAS

Validation layer changes which will surface these errors coming soon :)