### PR TITLE
Cleaned up the createShaderBindingTable for the raytracing examples

### DIFF
--- a/examples/nv_ray_tracing_basic/nv_ray_tracing_basic.cpp
+++ b/examples/nv_ray_tracing_basic/nv_ray_tracing_basic.cpp
@@ -414,7 +414,6 @@ public:
 	VkDeviceSize copyShaderIdentifier(uint8_t* data, const uint8_t* shaderHandleStorage, uint32_t groupIndex) {
 		const uint32_t shaderGroupHandleSize = rayTracingProperties.shaderGroupHandleSize;
 		memcpy(data, shaderHandleStorage + groupIndex * shaderGroupHandleSize, shaderGroupHandleSize);
-		data += shaderGroupHandleSize;
 		return shaderGroupHandleSize;
 	}
 

--- a/examples/nv_ray_tracing_basic/nv_ray_tracing_basic.cpp
+++ b/examples/nv_ray_tracing_basic/nv_ray_tracing_basic.cpp
@@ -44,6 +44,8 @@ struct GeometryInstance {
 #define INDEX_MISS 1
 #define INDEX_CLOSEST_HIT 2
 
+#define NUM_SHADER_GROUPS 3
+
 class VulkanExample : public VulkanExampleBase
 {
 public:
@@ -421,7 +423,7 @@ public:
 	*/
 	void createShaderBindingTable() {
 		// Create buffer for the shader binding table
-		const uint32_t sbtSize = rayTracingProperties.shaderGroupHandleSize * 3;
+		const uint32_t sbtSize = rayTracingProperties.shaderGroupHandleSize * NUM_SHADER_GROUPS;
 		VK_CHECK_RESULT(vulkanDevice->createBuffer(
 			VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
@@ -431,10 +433,9 @@ public:
 
 		auto shaderHandleStorage = new uint8_t[sbtSize];
 		// Get shader identifiers
-		VK_CHECK_RESULT(vkGetRayTracingShaderGroupHandlesNV(device, pipeline, 0, 3, sbtSize, shaderHandleStorage));
+		VK_CHECK_RESULT(vkGetRayTracingShaderGroupHandlesNV(device, pipeline, 0, NUM_SHADER_GROUPS, sbtSize, shaderHandleStorage));
 		auto* data = static_cast<uint8_t*>(shaderBindingTable.mapped);
 		// Copy the shader identifiers to the shader binding table
-		VkDeviceSize offset = 0;
 		data += copyShaderIdentifier(data, shaderHandleStorage, INDEX_RAYGEN);
 		data += copyShaderIdentifier(data, shaderHandleStorage, INDEX_MISS);
 		data += copyShaderIdentifier(data, shaderHandleStorage, INDEX_CLOSEST_HIT);
@@ -540,7 +541,7 @@ public:
 		/*
 			Setup ray tracing shader groups
 		*/
-		std::array<VkRayTracingShaderGroupCreateInfoNV, 3> groups{};
+		std::array<VkRayTracingShaderGroupCreateInfoNV, NUM_SHADER_GROUPS> groups{};
 		for (auto& group : groups) {
 			// Init all groups with some default values
 			group.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV;

--- a/examples/nv_ray_tracing_reflections/nv_ray_tracing_reflections.cpp
+++ b/examples/nv_ray_tracing_reflections/nv_ray_tracing_reflections.cpp
@@ -423,7 +423,6 @@ public:
 		VK_CHECK_RESULT(vkGetRayTracingShaderGroupHandlesNV(device, pipeline, 0, NUM_SHADER_GROUPS, sbtSize, shaderHandleStorage));
 		auto* data = static_cast<uint8_t*>(shaderBindingTable.mapped);
 		// Copy the shader identifiers to the shader binding table
-		VkDeviceSize offset = 0;
 		data += copyShaderIdentifier(data, shaderHandleStorage, INDEX_RAYGEN);
 		data += copyShaderIdentifier(data, shaderHandleStorage, INDEX_MISS);
 		data += copyShaderIdentifier(data, shaderHandleStorage, INDEX_CLOSEST_HIT);

--- a/examples/nv_ray_tracing_reflections/nv_ray_tracing_reflections.cpp
+++ b/examples/nv_ray_tracing_reflections/nv_ray_tracing_reflections.cpp
@@ -401,7 +401,6 @@ public:
 	VkDeviceSize copyShaderIdentifier(uint8_t* data, const uint8_t* shaderHandleStorage, uint32_t groupIndex) {
 		const uint32_t shaderGroupHandleSize = rayTracingProperties.shaderGroupHandleSize;
 		memcpy(data, shaderHandleStorage + groupIndex * shaderGroupHandleSize, shaderGroupHandleSize);
-		data += shaderGroupHandleSize;
 		return shaderGroupHandleSize;
 	}
 

--- a/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
+++ b/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
@@ -432,7 +432,6 @@ public:
 		VK_CHECK_RESULT(vkGetRayTracingShaderGroupHandlesNV(device, pipeline, 0, NUM_SHADER_GROUPS, sbtSize, shaderHandleStorage));
 		auto* data = static_cast<uint8_t*>(shaderBindingTable.mapped);
 		// Copy the shader identifiers to the shader binding table
-		VkDeviceSize offset = 0;
 		data += copyShaderIdentifier(data, shaderHandleStorage, INDEX_RAYGEN);
 		data += copyShaderIdentifier(data, shaderHandleStorage, INDEX_MISS);
 		data += copyShaderIdentifier(data, shaderHandleStorage, INDEX_SHADOW_MISS);

--- a/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
+++ b/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
@@ -410,7 +410,6 @@ public:
 	VkDeviceSize copyShaderIdentifier(uint8_t* data, const uint8_t* shaderHandleStorage, uint32_t groupIndex) {
 		const uint32_t shaderGroupHandleSize = rayTracingProperties.shaderGroupHandleSize;
 		memcpy(data, shaderHandleStorage + groupIndex * shaderGroupHandleSize, shaderGroupHandleSize);
-		data += shaderGroupHandleSize;
 		return shaderGroupHandleSize;
 	}
 


### PR DESCRIPTION
Two minor changes:
* Added the `NUM_SHADER_GROUPS ` macro to the ray_tracing_basic example
* Removed the unused `VkDeviceSize offset` variable from all ray tracing examples.
* Removed unnessessary line `data += shaderGroupHandleSize;` in the `copyShaderIdentifier` function.
