### PR TITLE
Fix displacement sample blindly enabling BC compression feature

### DIFF
--- a/examples/displacement/displacement.cpp
+++ b/examples/displacement/displacement.cpp
@@ -122,7 +122,19 @@ public:
 		else {
 			splitScreen = false;
 		}
-		enabledFeatures.textureCompressionBC = VK_TRUE;
+		// Enable texture compression features. We already fail in loadAssets()
+		// below if none are supported, so just enable whatever exists.
+		if (deviceFeatures.textureCompressionBC) {
+			enabledFeatures.textureCompressionBC = VK_TRUE;
+		}
+
+		if (deviceFeatures.textureCompressionETC2) {
+			enabledFeatures.textureCompressionETC2 = VK_TRUE;
+		}
+
+		if (deviceFeatures.textureCompressionASTC_LDR) {
+			enabledFeatures.textureCompressionASTC_LDR = VK_TRUE;
+		}
 	}
 
 	void loadAssets()


### PR DESCRIPTION
The loadAssets() function already supported whichever compression feature was supported, but the features enabling was blindly using BC. This causes trouble on Android devices which typically do not support BC.