### PR TITLE
Add clang-format configuration, reformat common files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,39 @@
+Language: Cpp
+Standard: Cpp11
+BasedOnStyle: "Chromium" 
+ColumnLimit: 160
+IndentWidth: 4
+UseTab: Never
+
+BreakBeforeBraces: Custom
+BraceWrapping:   
+  AfterEnum: false
+  AfterClass: true
+  AfterControlStatement: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: true
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: true
+
+NamespaceIndentation: All
+AccessModifierOffset: -4
+AllowShortFunctionsOnASingleLine: None  
+BreakConstructorInitializers: BeforeColon 
+BreakConstructorInitializersBeforeComma: true
+IndentCaseLabels: true
+ReflowComments: false 
+Cpp11BracedListStyle: false
+ContinuationIndentWidth: 4
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+CompactNamespaces: true
+SortIncludes: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+
+PenaltyReturnTypeOnItsOwnLine: 1000
+PenaltyBreakBeforeFirstCallParameter: 1000
+

--- a/base/VulkanAndroid.cpp
+++ b/base/VulkanAndroid.cpp
@@ -9,9 +9,9 @@
 #include "VulkanAndroid.h"
 
 #if defined(__ANDROID__)
-	#include <android/log.h>
-	#include <dlfcn.h>
-	#include <android/native_window_jni.h>
+#include <android/log.h>
+#include <dlfcn.h>
+#include <android/native_window_jni.h>
 
 android_app* androidApp;
 
@@ -122,195 +122,211 @@ PFN_vkDestroySurfaceKHR vkDestroySurfaceKHR;
 
 int32_t vks::android::screenDensity;
 
-void *libVulkan;
+void* libVulkan;
 
 namespace vks
 {
-	namespace android
-	{
-		// Dynamically load Vulkan library and base function pointers
-		bool loadVulkanLibrary()
-		{
-			__android_log_print(ANDROID_LOG_INFO, "vulkanandroid", "Loading libvulkan.so...\n");
+    namespace android
+    {
+        // Dynamically load Vulkan library and base function pointers
+        bool loadVulkanLibrary()
+        {
+            __android_log_print(ANDROID_LOG_INFO, "vulkanandroid", "Loading libvulkan.so...\n");
 
-			// Load vulkan library
-			libVulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
-			if (!libVulkan)
-			{
-				__android_log_print(ANDROID_LOG_INFO, "vulkanandroid", "Could not load vulkan library : %s!\n", dlerror());
-				return false;
-			}
+            // Load vulkan library
+            libVulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+            if (!libVulkan)
+            {
+                __android_log_print(ANDROID_LOG_INFO, "vulkanandroid", "Could not load vulkan library : %s!\n", dlerror());
+                return false;
+            }
 
-			// Load base function pointers
-			vkEnumerateInstanceExtensionProperties = reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(dlsym(libVulkan, "vkEnumerateInstanceExtensionProperties"));
-			vkEnumerateInstanceLayerProperties = reinterpret_cast<PFN_vkEnumerateInstanceLayerProperties>(dlsym(libVulkan, "vkEnumerateInstanceLayerProperties"));
-			vkCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(dlsym(libVulkan, "vkCreateInstance"));
-			vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(dlsym(libVulkan, "vkGetInstanceProcAddr"));
-			vkGetDeviceProcAddr = reinterpret_cast<PFN_vkGetDeviceProcAddr>(dlsym(libVulkan, "vkGetDeviceProcAddr"));
+            // Load base function pointers
+            vkEnumerateInstanceExtensionProperties =
+                reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(dlsym(libVulkan, "vkEnumerateInstanceExtensionProperties"));
+            vkEnumerateInstanceLayerProperties =
+                reinterpret_cast<PFN_vkEnumerateInstanceLayerProperties>(dlsym(libVulkan, "vkEnumerateInstanceLayerProperties"));
+            vkCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(dlsym(libVulkan, "vkCreateInstance"));
+            vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(dlsym(libVulkan, "vkGetInstanceProcAddr"));
+            vkGetDeviceProcAddr = reinterpret_cast<PFN_vkGetDeviceProcAddr>(dlsym(libVulkan, "vkGetDeviceProcAddr"));
 
-			return true;
-		}
+            return true;
+        }
 
-		// Load instance based Vulkan function pointers
-		void loadVulkanFunctions(VkInstance instance)
-		{
-			__android_log_print(ANDROID_LOG_INFO, "vulkanandroid", "Loading instance based function pointers...\n");
+        // Load instance based Vulkan function pointers
+        void loadVulkanFunctions(VkInstance instance)
+        {
+            __android_log_print(ANDROID_LOG_INFO, "vulkanandroid", "Loading instance based function pointers...\n");
 
-			vkEnumeratePhysicalDevices = reinterpret_cast<PFN_vkEnumeratePhysicalDevices>(vkGetInstanceProcAddr(instance, "vkEnumeratePhysicalDevices"));
-			vkGetPhysicalDeviceProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties"));
-			vkEnumerateDeviceLayerProperties = reinterpret_cast<PFN_vkEnumerateDeviceLayerProperties>(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceLayerProperties"));
-			vkEnumerateDeviceExtensionProperties = reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceExtensionProperties"));
-			vkGetPhysicalDeviceQueueFamilyProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceQueueFamilyProperties"));
-			vkGetPhysicalDeviceFeatures = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures"));
-			vkCreateDevice = reinterpret_cast<PFN_vkCreateDevice>(vkGetInstanceProcAddr(instance, "vkCreateDevice"));
-			vkGetPhysicalDeviceFormatProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFormatProperties"));
-			vkGetPhysicalDeviceMemoryProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceMemoryProperties"));
+            vkEnumeratePhysicalDevices = reinterpret_cast<PFN_vkEnumeratePhysicalDevices>(vkGetInstanceProcAddr(instance, "vkEnumeratePhysicalDevices"));
+            vkGetPhysicalDeviceProperties =
+                reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties"));
+            vkEnumerateDeviceLayerProperties =
+                reinterpret_cast<PFN_vkEnumerateDeviceLayerProperties>(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceLayerProperties"));
+            vkEnumerateDeviceExtensionProperties =
+                reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceExtensionProperties"));
+            vkGetPhysicalDeviceQueueFamilyProperties =
+                reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceQueueFamilyProperties"));
+            vkGetPhysicalDeviceFeatures = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures"));
+            vkCreateDevice = reinterpret_cast<PFN_vkCreateDevice>(vkGetInstanceProcAddr(instance, "vkCreateDevice"));
+            vkGetPhysicalDeviceFormatProperties =
+                reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFormatProperties"));
+            vkGetPhysicalDeviceMemoryProperties =
+                reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceMemoryProperties"));
 
-			vkCmdPipelineBarrier = reinterpret_cast<PFN_vkCmdPipelineBarrier>(vkGetInstanceProcAddr(instance, "vkCmdPipelineBarrier"));
-			vkCreateShaderModule = reinterpret_cast<PFN_vkCreateShaderModule>(vkGetInstanceProcAddr(instance, "vkCreateShaderModule"));
+            vkCmdPipelineBarrier = reinterpret_cast<PFN_vkCmdPipelineBarrier>(vkGetInstanceProcAddr(instance, "vkCmdPipelineBarrier"));
+            vkCreateShaderModule = reinterpret_cast<PFN_vkCreateShaderModule>(vkGetInstanceProcAddr(instance, "vkCreateShaderModule"));
 
-			vkCreateBuffer = reinterpret_cast<PFN_vkCreateBuffer>(vkGetInstanceProcAddr(instance, "vkCreateBuffer"));
-			vkGetBufferMemoryRequirements = reinterpret_cast<PFN_vkGetBufferMemoryRequirements>(vkGetInstanceProcAddr(instance, "vkGetBufferMemoryRequirements"));
-			vkMapMemory = reinterpret_cast<PFN_vkMapMemory>(vkGetInstanceProcAddr(instance, "vkMapMemory"));
-			vkUnmapMemory = reinterpret_cast<PFN_vkUnmapMemory>(vkGetInstanceProcAddr(instance, "vkUnmapMemory"));
-			vkFlushMappedMemoryRanges = reinterpret_cast<PFN_vkFlushMappedMemoryRanges>(vkGetInstanceProcAddr(instance, "vkFlushMappedMemoryRanges"));
-			vkInvalidateMappedMemoryRanges = reinterpret_cast<PFN_vkInvalidateMappedMemoryRanges>(vkGetInstanceProcAddr(instance, "vkInvalidateMappedMemoryRanges"));
-			vkBindBufferMemory = reinterpret_cast<PFN_vkBindBufferMemory>(vkGetInstanceProcAddr(instance, "vkBindBufferMemory"));
-			vkDestroyBuffer = reinterpret_cast<PFN_vkDestroyBuffer>(vkGetInstanceProcAddr(instance, "vkDestroyBuffer"));
+            vkCreateBuffer = reinterpret_cast<PFN_vkCreateBuffer>(vkGetInstanceProcAddr(instance, "vkCreateBuffer"));
+            vkGetBufferMemoryRequirements =
+                reinterpret_cast<PFN_vkGetBufferMemoryRequirements>(vkGetInstanceProcAddr(instance, "vkGetBufferMemoryRequirements"));
+            vkMapMemory = reinterpret_cast<PFN_vkMapMemory>(vkGetInstanceProcAddr(instance, "vkMapMemory"));
+            vkUnmapMemory = reinterpret_cast<PFN_vkUnmapMemory>(vkGetInstanceProcAddr(instance, "vkUnmapMemory"));
+            vkFlushMappedMemoryRanges = reinterpret_cast<PFN_vkFlushMappedMemoryRanges>(vkGetInstanceProcAddr(instance, "vkFlushMappedMemoryRanges"));
+            vkInvalidateMappedMemoryRanges =
+                reinterpret_cast<PFN_vkInvalidateMappedMemoryRanges>(vkGetInstanceProcAddr(instance, "vkInvalidateMappedMemoryRanges"));
+            vkBindBufferMemory = reinterpret_cast<PFN_vkBindBufferMemory>(vkGetInstanceProcAddr(instance, "vkBindBufferMemory"));
+            vkDestroyBuffer = reinterpret_cast<PFN_vkDestroyBuffer>(vkGetInstanceProcAddr(instance, "vkDestroyBuffer"));
 
-			vkAllocateMemory = reinterpret_cast<PFN_vkAllocateMemory>(vkGetInstanceProcAddr(instance, "vkAllocateMemory"));
-			vkFreeMemory = reinterpret_cast<PFN_vkFreeMemory>(vkGetInstanceProcAddr(instance, "vkFreeMemory"));
-			vkCreateRenderPass = reinterpret_cast<PFN_vkCreateRenderPass>(vkGetInstanceProcAddr(instance, "vkCreateRenderPass"));
-			vkCmdBeginRenderPass = reinterpret_cast<PFN_vkCmdBeginRenderPass>(vkGetInstanceProcAddr(instance, "vkCmdBeginRenderPass"));
-			vkCmdEndRenderPass = reinterpret_cast<PFN_vkCmdEndRenderPass>(vkGetInstanceProcAddr(instance, "vkCmdEndRenderPass"));
-			vkCmdNextSubpass = reinterpret_cast<PFN_vkCmdNextSubpass>(vkGetInstanceProcAddr(instance, "vkCmdNextSubpass"));
-			vkCmdExecuteCommands = reinterpret_cast<PFN_vkCmdExecuteCommands>(vkGetInstanceProcAddr(instance, "vkCmdExecuteCommands"));
+            vkAllocateMemory = reinterpret_cast<PFN_vkAllocateMemory>(vkGetInstanceProcAddr(instance, "vkAllocateMemory"));
+            vkFreeMemory = reinterpret_cast<PFN_vkFreeMemory>(vkGetInstanceProcAddr(instance, "vkFreeMemory"));
+            vkCreateRenderPass = reinterpret_cast<PFN_vkCreateRenderPass>(vkGetInstanceProcAddr(instance, "vkCreateRenderPass"));
+            vkCmdBeginRenderPass = reinterpret_cast<PFN_vkCmdBeginRenderPass>(vkGetInstanceProcAddr(instance, "vkCmdBeginRenderPass"));
+            vkCmdEndRenderPass = reinterpret_cast<PFN_vkCmdEndRenderPass>(vkGetInstanceProcAddr(instance, "vkCmdEndRenderPass"));
+            vkCmdNextSubpass = reinterpret_cast<PFN_vkCmdNextSubpass>(vkGetInstanceProcAddr(instance, "vkCmdNextSubpass"));
+            vkCmdExecuteCommands = reinterpret_cast<PFN_vkCmdExecuteCommands>(vkGetInstanceProcAddr(instance, "vkCmdExecuteCommands"));
 
-			vkCreateImage = reinterpret_cast<PFN_vkCreateImage>(vkGetInstanceProcAddr(instance, "vkCreateImage"));
-			vkGetImageMemoryRequirements = reinterpret_cast<PFN_vkGetImageMemoryRequirements>(vkGetInstanceProcAddr(instance, "vkGetImageMemoryRequirements"));
-			vkCreateImageView = reinterpret_cast<PFN_vkCreateImageView>(vkGetInstanceProcAddr(instance, "vkCreateImageView"));
-			vkDestroyImageView = reinterpret_cast<PFN_vkDestroyImageView>(vkGetInstanceProcAddr(instance, "vkDestroyImageView"));
-			vkBindImageMemory = reinterpret_cast<PFN_vkBindImageMemory>(vkGetInstanceProcAddr(instance, "vkBindImageMemory"));
-			vkGetImageSubresourceLayout = reinterpret_cast<PFN_vkGetImageSubresourceLayout>(vkGetInstanceProcAddr(instance, "vkGetImageSubresourceLayout"));
-			vkCmdCopyImage = reinterpret_cast<PFN_vkCmdCopyImage>(vkGetInstanceProcAddr(instance, "vkCmdCopyImage"));
-			vkCmdBlitImage = reinterpret_cast<PFN_vkCmdBlitImage>(vkGetInstanceProcAddr(instance, "vkCmdBlitImage"));
-			vkDestroyImage = reinterpret_cast<PFN_vkDestroyImage>(vkGetInstanceProcAddr(instance, "vkDestroyImage"));
+            vkCreateImage = reinterpret_cast<PFN_vkCreateImage>(vkGetInstanceProcAddr(instance, "vkCreateImage"));
+            vkGetImageMemoryRequirements = reinterpret_cast<PFN_vkGetImageMemoryRequirements>(vkGetInstanceProcAddr(instance, "vkGetImageMemoryRequirements"));
+            vkCreateImageView = reinterpret_cast<PFN_vkCreateImageView>(vkGetInstanceProcAddr(instance, "vkCreateImageView"));
+            vkDestroyImageView = reinterpret_cast<PFN_vkDestroyImageView>(vkGetInstanceProcAddr(instance, "vkDestroyImageView"));
+            vkBindImageMemory = reinterpret_cast<PFN_vkBindImageMemory>(vkGetInstanceProcAddr(instance, "vkBindImageMemory"));
+            vkGetImageSubresourceLayout = reinterpret_cast<PFN_vkGetImageSubresourceLayout>(vkGetInstanceProcAddr(instance, "vkGetImageSubresourceLayout"));
+            vkCmdCopyImage = reinterpret_cast<PFN_vkCmdCopyImage>(vkGetInstanceProcAddr(instance, "vkCmdCopyImage"));
+            vkCmdBlitImage = reinterpret_cast<PFN_vkCmdBlitImage>(vkGetInstanceProcAddr(instance, "vkCmdBlitImage"));
+            vkDestroyImage = reinterpret_cast<PFN_vkDestroyImage>(vkGetInstanceProcAddr(instance, "vkDestroyImage"));
 
-			vkCmdClearAttachments = reinterpret_cast<PFN_vkCmdClearAttachments>(vkGetInstanceProcAddr(instance, "vkCmdClearAttachments"));
+            vkCmdClearAttachments = reinterpret_cast<PFN_vkCmdClearAttachments>(vkGetInstanceProcAddr(instance, "vkCmdClearAttachments"));
 
-			vkCmdCopyBuffer = reinterpret_cast<PFN_vkCmdCopyBuffer>(vkGetInstanceProcAddr(instance, "vkCmdCopyBuffer"));
-			vkCmdCopyBufferToImage = reinterpret_cast<PFN_vkCmdCopyBufferToImage>(vkGetInstanceProcAddr(instance, "vkCmdCopyBufferToImage"));
+            vkCmdCopyBuffer = reinterpret_cast<PFN_vkCmdCopyBuffer>(vkGetInstanceProcAddr(instance, "vkCmdCopyBuffer"));
+            vkCmdCopyBufferToImage = reinterpret_cast<PFN_vkCmdCopyBufferToImage>(vkGetInstanceProcAddr(instance, "vkCmdCopyBufferToImage"));
 
-			vkCreateSampler = reinterpret_cast<PFN_vkCreateSampler>(vkGetInstanceProcAddr(instance, "vkCreateSampler"));
-			vkDestroySampler = reinterpret_cast<PFN_vkDestroySampler>(vkGetInstanceProcAddr(instance, "vkDestroySampler"));;
+            vkCreateSampler = reinterpret_cast<PFN_vkCreateSampler>(vkGetInstanceProcAddr(instance, "vkCreateSampler"));
+            vkDestroySampler = reinterpret_cast<PFN_vkDestroySampler>(vkGetInstanceProcAddr(instance, "vkDestroySampler"));
+            ;
 
-			vkCreateSemaphore = reinterpret_cast<PFN_vkCreateSemaphore>(vkGetInstanceProcAddr(instance, "vkCreateSemaphore"));
-			vkDestroySemaphore = reinterpret_cast<PFN_vkDestroySemaphore>(vkGetInstanceProcAddr(instance, "vkDestroySemaphore"));
+            vkCreateSemaphore = reinterpret_cast<PFN_vkCreateSemaphore>(vkGetInstanceProcAddr(instance, "vkCreateSemaphore"));
+            vkDestroySemaphore = reinterpret_cast<PFN_vkDestroySemaphore>(vkGetInstanceProcAddr(instance, "vkDestroySemaphore"));
 
-			vkCreateFence = reinterpret_cast<PFN_vkCreateFence>(vkGetInstanceProcAddr(instance, "vkCreateFence"));
-			vkDestroyFence = reinterpret_cast<PFN_vkDestroyFence>(vkGetInstanceProcAddr(instance, "vkDestroyFence"));
-			vkWaitForFences = reinterpret_cast<PFN_vkWaitForFences>(vkGetInstanceProcAddr(instance, "vkWaitForFences"));
-			vkResetFences = reinterpret_cast<PFN_vkResetFences>(vkGetInstanceProcAddr(instance, "vkResetFences"));;
+            vkCreateFence = reinterpret_cast<PFN_vkCreateFence>(vkGetInstanceProcAddr(instance, "vkCreateFence"));
+            vkDestroyFence = reinterpret_cast<PFN_vkDestroyFence>(vkGetInstanceProcAddr(instance, "vkDestroyFence"));
+            vkWaitForFences = reinterpret_cast<PFN_vkWaitForFences>(vkGetInstanceProcAddr(instance, "vkWaitForFences"));
+            vkResetFences = reinterpret_cast<PFN_vkResetFences>(vkGetInstanceProcAddr(instance, "vkResetFences"));
+            ;
 
-			vkCreateCommandPool = reinterpret_cast<PFN_vkCreateCommandPool>(vkGetInstanceProcAddr(instance, "vkCreateCommandPool"));
-			vkDestroyCommandPool = reinterpret_cast<PFN_vkDestroyCommandPool>(vkGetInstanceProcAddr(instance, "vkDestroyCommandPool"));;
+            vkCreateCommandPool = reinterpret_cast<PFN_vkCreateCommandPool>(vkGetInstanceProcAddr(instance, "vkCreateCommandPool"));
+            vkDestroyCommandPool = reinterpret_cast<PFN_vkDestroyCommandPool>(vkGetInstanceProcAddr(instance, "vkDestroyCommandPool"));
+            ;
 
-			vkAllocateCommandBuffers = reinterpret_cast<PFN_vkAllocateCommandBuffers>(vkGetInstanceProcAddr(instance, "vkAllocateCommandBuffers"));
-			vkBeginCommandBuffer = reinterpret_cast<PFN_vkBeginCommandBuffer>(vkGetInstanceProcAddr(instance, "vkBeginCommandBuffer"));
-			vkEndCommandBuffer = reinterpret_cast<PFN_vkEndCommandBuffer>(vkGetInstanceProcAddr(instance, "vkEndCommandBuffer"));
+            vkAllocateCommandBuffers = reinterpret_cast<PFN_vkAllocateCommandBuffers>(vkGetInstanceProcAddr(instance, "vkAllocateCommandBuffers"));
+            vkBeginCommandBuffer = reinterpret_cast<PFN_vkBeginCommandBuffer>(vkGetInstanceProcAddr(instance, "vkBeginCommandBuffer"));
+            vkEndCommandBuffer = reinterpret_cast<PFN_vkEndCommandBuffer>(vkGetInstanceProcAddr(instance, "vkEndCommandBuffer"));
 
-			vkGetDeviceQueue = reinterpret_cast<PFN_vkGetDeviceQueue>(vkGetInstanceProcAddr(instance, "vkGetDeviceQueue"));
-			vkQueueSubmit = reinterpret_cast<PFN_vkQueueSubmit>(vkGetInstanceProcAddr(instance, "vkQueueSubmit"));
-			vkQueueWaitIdle = reinterpret_cast<PFN_vkQueueWaitIdle>(vkGetInstanceProcAddr(instance, "vkQueueWaitIdle"));
+            vkGetDeviceQueue = reinterpret_cast<PFN_vkGetDeviceQueue>(vkGetInstanceProcAddr(instance, "vkGetDeviceQueue"));
+            vkQueueSubmit = reinterpret_cast<PFN_vkQueueSubmit>(vkGetInstanceProcAddr(instance, "vkQueueSubmit"));
+            vkQueueWaitIdle = reinterpret_cast<PFN_vkQueueWaitIdle>(vkGetInstanceProcAddr(instance, "vkQueueWaitIdle"));
 
-			vkDeviceWaitIdle = reinterpret_cast<PFN_vkDeviceWaitIdle>(vkGetInstanceProcAddr(instance, "vkDeviceWaitIdle"));
+            vkDeviceWaitIdle = reinterpret_cast<PFN_vkDeviceWaitIdle>(vkGetInstanceProcAddr(instance, "vkDeviceWaitIdle"));
 
-			vkCreateFramebuffer = reinterpret_cast<PFN_vkCreateFramebuffer>(vkGetInstanceProcAddr(instance, "vkCreateFramebuffer"));
+            vkCreateFramebuffer = reinterpret_cast<PFN_vkCreateFramebuffer>(vkGetInstanceProcAddr(instance, "vkCreateFramebuffer"));
 
-			vkCreatePipelineCache = reinterpret_cast<PFN_vkCreatePipelineCache>(vkGetInstanceProcAddr(instance, "vkCreatePipelineCache"));
-			vkCreatePipelineLayout = reinterpret_cast<PFN_vkCreatePipelineLayout>(vkGetInstanceProcAddr(instance, "vkCreatePipelineLayout"));
-			vkCreateGraphicsPipelines = reinterpret_cast<PFN_vkCreateGraphicsPipelines>(vkGetInstanceProcAddr(instance, "vkCreateGraphicsPipelines"));
-			vkCreateComputePipelines = reinterpret_cast<PFN_vkCreateComputePipelines>(vkGetInstanceProcAddr(instance, "vkCreateComputePipelines"));
+            vkCreatePipelineCache = reinterpret_cast<PFN_vkCreatePipelineCache>(vkGetInstanceProcAddr(instance, "vkCreatePipelineCache"));
+            vkCreatePipelineLayout = reinterpret_cast<PFN_vkCreatePipelineLayout>(vkGetInstanceProcAddr(instance, "vkCreatePipelineLayout"));
+            vkCreateGraphicsPipelines = reinterpret_cast<PFN_vkCreateGraphicsPipelines>(vkGetInstanceProcAddr(instance, "vkCreateGraphicsPipelines"));
+            vkCreateComputePipelines = reinterpret_cast<PFN_vkCreateComputePipelines>(vkGetInstanceProcAddr(instance, "vkCreateComputePipelines"));
 
-			vkCreateDescriptorPool = reinterpret_cast<PFN_vkCreateDescriptorPool>(vkGetInstanceProcAddr(instance, "vkCreateDescriptorPool"));
-			vkCreateDescriptorSetLayout = reinterpret_cast<PFN_vkCreateDescriptorSetLayout>(vkGetInstanceProcAddr(instance, "vkCreateDescriptorSetLayout"));
+            vkCreateDescriptorPool = reinterpret_cast<PFN_vkCreateDescriptorPool>(vkGetInstanceProcAddr(instance, "vkCreateDescriptorPool"));
+            vkCreateDescriptorSetLayout = reinterpret_cast<PFN_vkCreateDescriptorSetLayout>(vkGetInstanceProcAddr(instance, "vkCreateDescriptorSetLayout"));
 
-			vkAllocateDescriptorSets = reinterpret_cast<PFN_vkAllocateDescriptorSets>(vkGetInstanceProcAddr(instance, "vkAllocateDescriptorSets"));
-			vkUpdateDescriptorSets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(vkGetInstanceProcAddr(instance, "vkUpdateDescriptorSets"));
+            vkAllocateDescriptorSets = reinterpret_cast<PFN_vkAllocateDescriptorSets>(vkGetInstanceProcAddr(instance, "vkAllocateDescriptorSets"));
+            vkUpdateDescriptorSets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(vkGetInstanceProcAddr(instance, "vkUpdateDescriptorSets"));
 
-			vkCmdBindDescriptorSets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(vkGetInstanceProcAddr(instance, "vkCmdBindDescriptorSets"));
-			vkCmdBindPipeline = reinterpret_cast<PFN_vkCmdBindPipeline>(vkGetInstanceProcAddr(instance, "vkCmdBindPipeline"));
-			vkCmdBindVertexBuffers = reinterpret_cast<PFN_vkCmdBindVertexBuffers>(vkGetInstanceProcAddr(instance, "vkCmdBindVertexBuffers"));
-			vkCmdBindIndexBuffer = reinterpret_cast<PFN_vkCmdBindIndexBuffer>(vkGetInstanceProcAddr(instance, "vkCmdBindIndexBuffer"));
+            vkCmdBindDescriptorSets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(vkGetInstanceProcAddr(instance, "vkCmdBindDescriptorSets"));
+            vkCmdBindPipeline = reinterpret_cast<PFN_vkCmdBindPipeline>(vkGetInstanceProcAddr(instance, "vkCmdBindPipeline"));
+            vkCmdBindVertexBuffers = reinterpret_cast<PFN_vkCmdBindVertexBuffers>(vkGetInstanceProcAddr(instance, "vkCmdBindVertexBuffers"));
+            vkCmdBindIndexBuffer = reinterpret_cast<PFN_vkCmdBindIndexBuffer>(vkGetInstanceProcAddr(instance, "vkCmdBindIndexBuffer"));
 
-			vkCmdSetViewport = reinterpret_cast<PFN_vkCmdSetViewport>(vkGetInstanceProcAddr(instance, "vkCmdSetViewport"));
-			vkCmdSetScissor = reinterpret_cast<PFN_vkCmdSetScissor>(vkGetInstanceProcAddr(instance, "vkCmdSetScissor"));
-			vkCmdSetLineWidth = reinterpret_cast<PFN_vkCmdSetLineWidth>(vkGetInstanceProcAddr(instance, "vkCmdSetLineWidth"));
-			vkCmdSetDepthBias = reinterpret_cast<PFN_vkCmdSetDepthBias>(vkGetInstanceProcAddr(instance, "vkCmdSetDepthBias"));
-			vkCmdPushConstants = reinterpret_cast<PFN_vkCmdPushConstants>(vkGetInstanceProcAddr(instance, "vkCmdPushConstants"));;
+            vkCmdSetViewport = reinterpret_cast<PFN_vkCmdSetViewport>(vkGetInstanceProcAddr(instance, "vkCmdSetViewport"));
+            vkCmdSetScissor = reinterpret_cast<PFN_vkCmdSetScissor>(vkGetInstanceProcAddr(instance, "vkCmdSetScissor"));
+            vkCmdSetLineWidth = reinterpret_cast<PFN_vkCmdSetLineWidth>(vkGetInstanceProcAddr(instance, "vkCmdSetLineWidth"));
+            vkCmdSetDepthBias = reinterpret_cast<PFN_vkCmdSetDepthBias>(vkGetInstanceProcAddr(instance, "vkCmdSetDepthBias"));
+            vkCmdPushConstants = reinterpret_cast<PFN_vkCmdPushConstants>(vkGetInstanceProcAddr(instance, "vkCmdPushConstants"));
+            ;
 
-			vkCmdDrawIndexed = reinterpret_cast<PFN_vkCmdDrawIndexed>(vkGetInstanceProcAddr(instance, "vkCmdDrawIndexed"));
-			vkCmdDraw = reinterpret_cast<PFN_vkCmdDraw>(vkGetInstanceProcAddr(instance, "vkCmdDraw"));
-			vkCmdDrawIndexedIndirect = reinterpret_cast<PFN_vkCmdDrawIndexedIndirect>(vkGetInstanceProcAddr(instance, "vkCmdDrawIndexedIndirect"));
-			vkCmdDrawIndirect = reinterpret_cast<PFN_vkCmdDrawIndirect>(vkGetInstanceProcAddr(instance, "vkCmdDrawIndirect"));
-			vkCmdDispatch = reinterpret_cast<PFN_vkCmdDispatch>(vkGetInstanceProcAddr(instance, "vkCmdDispatch"));
+            vkCmdDrawIndexed = reinterpret_cast<PFN_vkCmdDrawIndexed>(vkGetInstanceProcAddr(instance, "vkCmdDrawIndexed"));
+            vkCmdDraw = reinterpret_cast<PFN_vkCmdDraw>(vkGetInstanceProcAddr(instance, "vkCmdDraw"));
+            vkCmdDrawIndexedIndirect = reinterpret_cast<PFN_vkCmdDrawIndexedIndirect>(vkGetInstanceProcAddr(instance, "vkCmdDrawIndexedIndirect"));
+            vkCmdDrawIndirect = reinterpret_cast<PFN_vkCmdDrawIndirect>(vkGetInstanceProcAddr(instance, "vkCmdDrawIndirect"));
+            vkCmdDispatch = reinterpret_cast<PFN_vkCmdDispatch>(vkGetInstanceProcAddr(instance, "vkCmdDispatch"));
 
-			vkDestroyPipeline = reinterpret_cast<PFN_vkDestroyPipeline>(vkGetInstanceProcAddr(instance, "vkDestroyPipeline"));
-			vkDestroyPipelineLayout = reinterpret_cast<PFN_vkDestroyPipelineLayout>(vkGetInstanceProcAddr(instance, "vkDestroyPipelineLayout"));;
-			vkDestroyDescriptorSetLayout = reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(vkGetInstanceProcAddr(instance, "vkDestroyDescriptorSetLayout"));
-			vkDestroyDevice = reinterpret_cast<PFN_vkDestroyDevice>(vkGetInstanceProcAddr(instance, "vkDestroyDevice"));
-			vkDestroyInstance = reinterpret_cast<PFN_vkDestroyInstance>(vkGetInstanceProcAddr(instance, "vkDestroyInstance"));
-			vkDestroyDescriptorPool = reinterpret_cast<PFN_vkDestroyDescriptorPool>(vkGetInstanceProcAddr(instance, "vkDestroyDescriptorPool"));
-			vkFreeCommandBuffers = reinterpret_cast<PFN_vkFreeCommandBuffers>(vkGetInstanceProcAddr(instance, "vkFreeCommandBuffers"));
-			vkDestroyRenderPass = reinterpret_cast<PFN_vkDestroyRenderPass>(vkGetInstanceProcAddr(instance, "vkDestroyRenderPass"));
-			vkDestroyFramebuffer = reinterpret_cast<PFN_vkDestroyFramebuffer>(vkGetInstanceProcAddr(instance, "vkDestroyFramebuffer"));
-			vkDestroyShaderModule = reinterpret_cast<PFN_vkDestroyShaderModule>(vkGetInstanceProcAddr(instance, "vkDestroyShaderModule"));
-			vkDestroyPipelineCache = reinterpret_cast<PFN_vkDestroyPipelineCache>(vkGetInstanceProcAddr(instance, "vkDestroyPipelineCache"));
+            vkDestroyPipeline = reinterpret_cast<PFN_vkDestroyPipeline>(vkGetInstanceProcAddr(instance, "vkDestroyPipeline"));
+            vkDestroyPipelineLayout = reinterpret_cast<PFN_vkDestroyPipelineLayout>(vkGetInstanceProcAddr(instance, "vkDestroyPipelineLayout"));
+            ;
+            vkDestroyDescriptorSetLayout = reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(vkGetInstanceProcAddr(instance, "vkDestroyDescriptorSetLayout"));
+            vkDestroyDevice = reinterpret_cast<PFN_vkDestroyDevice>(vkGetInstanceProcAddr(instance, "vkDestroyDevice"));
+            vkDestroyInstance = reinterpret_cast<PFN_vkDestroyInstance>(vkGetInstanceProcAddr(instance, "vkDestroyInstance"));
+            vkDestroyDescriptorPool = reinterpret_cast<PFN_vkDestroyDescriptorPool>(vkGetInstanceProcAddr(instance, "vkDestroyDescriptorPool"));
+            vkFreeCommandBuffers = reinterpret_cast<PFN_vkFreeCommandBuffers>(vkGetInstanceProcAddr(instance, "vkFreeCommandBuffers"));
+            vkDestroyRenderPass = reinterpret_cast<PFN_vkDestroyRenderPass>(vkGetInstanceProcAddr(instance, "vkDestroyRenderPass"));
+            vkDestroyFramebuffer = reinterpret_cast<PFN_vkDestroyFramebuffer>(vkGetInstanceProcAddr(instance, "vkDestroyFramebuffer"));
+            vkDestroyShaderModule = reinterpret_cast<PFN_vkDestroyShaderModule>(vkGetInstanceProcAddr(instance, "vkDestroyShaderModule"));
+            vkDestroyPipelineCache = reinterpret_cast<PFN_vkDestroyPipelineCache>(vkGetInstanceProcAddr(instance, "vkDestroyPipelineCache"));
 
-			vkCreateQueryPool = reinterpret_cast<PFN_vkCreateQueryPool>(vkGetInstanceProcAddr(instance, "vkCreateQueryPool"));
-			vkDestroyQueryPool = reinterpret_cast<PFN_vkDestroyQueryPool>(vkGetInstanceProcAddr(instance, "vkDestroyQueryPool"));
-			vkGetQueryPoolResults = reinterpret_cast<PFN_vkGetQueryPoolResults>(vkGetInstanceProcAddr(instance, "vkGetQueryPoolResults"));
+            vkCreateQueryPool = reinterpret_cast<PFN_vkCreateQueryPool>(vkGetInstanceProcAddr(instance, "vkCreateQueryPool"));
+            vkDestroyQueryPool = reinterpret_cast<PFN_vkDestroyQueryPool>(vkGetInstanceProcAddr(instance, "vkDestroyQueryPool"));
+            vkGetQueryPoolResults = reinterpret_cast<PFN_vkGetQueryPoolResults>(vkGetInstanceProcAddr(instance, "vkGetQueryPoolResults"));
 
-			vkCmdBeginQuery = reinterpret_cast<PFN_vkCmdBeginQuery>(vkGetInstanceProcAddr(instance, "vkCmdBeginQuery"));
-			vkCmdEndQuery = reinterpret_cast<PFN_vkCmdEndQuery>(vkGetInstanceProcAddr(instance, "vkCmdEndQuery"));
-			vkCmdResetQueryPool = reinterpret_cast<PFN_vkCmdResetQueryPool>(vkGetInstanceProcAddr(instance, "vkCmdResetQueryPool"));
-			vkCmdCopyQueryPoolResults = reinterpret_cast<PFN_vkCmdCopyQueryPoolResults>(vkGetInstanceProcAddr(instance, "vkCmdCopyQueryPoolResults"));
+            vkCmdBeginQuery = reinterpret_cast<PFN_vkCmdBeginQuery>(vkGetInstanceProcAddr(instance, "vkCmdBeginQuery"));
+            vkCmdEndQuery = reinterpret_cast<PFN_vkCmdEndQuery>(vkGetInstanceProcAddr(instance, "vkCmdEndQuery"));
+            vkCmdResetQueryPool = reinterpret_cast<PFN_vkCmdResetQueryPool>(vkGetInstanceProcAddr(instance, "vkCmdResetQueryPool"));
+            vkCmdCopyQueryPoolResults = reinterpret_cast<PFN_vkCmdCopyQueryPoolResults>(vkGetInstanceProcAddr(instance, "vkCmdCopyQueryPoolResults"));
 
-			vkCreateAndroidSurfaceKHR = reinterpret_cast<PFN_vkCreateAndroidSurfaceKHR>(vkGetInstanceProcAddr(instance, "vkCreateAndroidSurfaceKHR"));
-			vkDestroySurfaceKHR = reinterpret_cast<PFN_vkDestroySurfaceKHR>(vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
-		}
+            vkCreateAndroidSurfaceKHR = reinterpret_cast<PFN_vkCreateAndroidSurfaceKHR>(vkGetInstanceProcAddr(instance, "vkCreateAndroidSurfaceKHR"));
+            vkDestroySurfaceKHR = reinterpret_cast<PFN_vkDestroySurfaceKHR>(vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        }
 
-		void freeVulkanLibrary()
-		{
-			dlclose(libVulkan);
-		}
+        void freeVulkanLibrary()
+        {
+            dlclose(libVulkan);
+        }
 
-		void getDeviceConfig()
-		{
-			// Screen density
-			AConfiguration* config = AConfiguration_new();
-			AConfiguration_fromAssetManager(config, androidApp->activity->assetManager);
-			vks::android::screenDensity = AConfiguration_getDensity(config);
-			AConfiguration_delete(config);
-		}
+        void getDeviceConfig()
+        {
+            // Screen density
+            AConfiguration* config = AConfiguration_new();
+            AConfiguration_fromAssetManager(config, androidApp->activity->assetManager);
+            vks::android::screenDensity = AConfiguration_getDensity(config);
+            AConfiguration_delete(config);
+        }
 
-		// Displays a native alert dialog using JNI
-		void showAlert(const char* message) {
-			JNIEnv* jni;
-			androidApp->activity->vm->AttachCurrentThread(&jni, NULL);
+        // Displays a native alert dialog using JNI
+        void showAlert(const char* message)
+        {
+            JNIEnv* jni;
+            androidApp->activity->vm->AttachCurrentThread(&jni, NULL);
 
-			jstring jmessage = jni->NewStringUTF(message);
+            jstring jmessage = jni->NewStringUTF(message);
 
-			jclass clazz = jni->GetObjectClass(androidApp->activity->clazz);
-			// Signature has to match java implementation (arguments)
-			jmethodID methodID = jni->GetMethodID(clazz, "showAlert", "(Ljava/lang/String;)V");
-			jni->CallVoidMethod(androidApp->activity->clazz, methodID, jmessage);
-			jni->DeleteLocalRef(jmessage);
+            jclass clazz = jni->GetObjectClass(androidApp->activity->clazz);
+            // Signature has to match java implementation (arguments)
+            jmethodID methodID = jni->GetMethodID(clazz, "showAlert", "(Ljava/lang/String;)V");
+            jni->CallVoidMethod(androidApp->activity->clazz, methodID, jmessage);
+            jni->DeleteLocalRef(jmessage);
 
-			androidApp->activity->vm->DetachCurrentThread();
-			return;
-		}
-	}
-}
+            androidApp->activity->vm->DetachCurrentThread();
+            return;
+        }
+    }  // namespace android
+}  // namespace vks
 
 #endif

--- a/base/VulkanAndroid.h
+++ b/base/VulkanAndroid.h
@@ -31,12 +31,12 @@
 // Missing from the NDK
 namespace std
 {
-	template<typename T, typename... Args>
-	std::unique_ptr<T> make_unique(Args&&... args)
-	{
-		return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-	}
-}
+    template <typename T, typename... Args>
+    std::unique_ptr<T> make_unique(Args&&... args)
+    {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
+}  // namespace std
 
 // Global reference to android application object
 extern android_app* androidApp;
@@ -155,29 +155,27 @@ extern PFN_vkDestroySurfaceKHR vkDestroySurfaceKHR;
 
 namespace vks
 {
-	namespace android
-	{
-		/* @brief Touch control thresholds from Android NDK samples */
-		const int32_t DOUBLE_TAP_TIMEOUT = 300 * 1000000;
-		const int32_t TAP_TIMEOUT = 180 * 1000000;
-		const int32_t DOUBLE_TAP_SLOP = 100;
-		const int32_t TAP_SLOP = 8;
+    namespace android
+    {
+        /* @brief Touch control thresholds from Android NDK samples */
+        const int32_t DOUBLE_TAP_TIMEOUT = 300 * 1000000;
+        const int32_t TAP_TIMEOUT = 180 * 1000000;
+        const int32_t DOUBLE_TAP_SLOP = 100;
+        const int32_t TAP_SLOP = 8;
 
-		/** @brief Density of the device screen (in DPI) */
-		extern int32_t screenDensity;
+        /** @brief Density of the device screen (in DPI) */
+        extern int32_t screenDensity;
 
-		bool loadVulkanLibrary();
-		void loadVulkanFunctions(VkInstance instance);
-		void freeVulkanLibrary();
-		void getDeviceConfig();
-		void showAlert(const char* message);
-	}
-}
+        bool loadVulkanLibrary();
+        void loadVulkanFunctions(VkInstance instance);
+        void freeVulkanLibrary();
+        void getDeviceConfig();
+        void showAlert(const char* message);
+    }  // namespace android
+}  // namespace vks
 
 #endif
 
-#endif // VULKANANDROID_HPP
+#endif  // VULKANANDROID_HPP
 
-
-#endif // VULKANANDROID_H
- 
+#endif  // VULKANANDROID_H

--- a/base/VulkanBuffer.hpp
+++ b/base/VulkanBuffer.hpp
@@ -16,27 +16,27 @@
 #include "VulkanTools.h"
 
 namespace vks
-{	
-	/**
+{
+    /**
 	* @brief Encapsulates access to a Vulkan buffer backed up by device memory
 	* @note To be filled by an external source like the VulkanDevice
 	*/
-	struct Buffer
-	{
-		VkDevice device;
-		VkBuffer buffer = VK_NULL_HANDLE;
-		VkDeviceMemory memory = VK_NULL_HANDLE;
-		VkDescriptorBufferInfo descriptor;
-		VkDeviceSize size = 0;
-		VkDeviceSize alignment = 0;
-		void* mapped = nullptr;
+    struct Buffer
+    {
+        VkDevice device;
+        VkBuffer buffer = VK_NULL_HANDLE;
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+        VkDescriptorBufferInfo descriptor;
+        VkDeviceSize size = 0;
+        VkDeviceSize alignment = 0;
+        void* mapped = nullptr;
 
-		/** @brief Usage flags to be filled by external source at buffer creation (to query at some later point) */
-		VkBufferUsageFlags usageFlags;
-		/** @brief Memory propertys flags to be filled by external source at buffer creation (to query at some later point) */
-		VkMemoryPropertyFlags memoryPropertyFlags;
+        /** @brief Usage flags to be filled by external source at buffer creation (to query at some later point) */
+        VkBufferUsageFlags usageFlags;
+        /** @brief Memory propertys flags to be filled by external source at buffer creation (to query at some later point) */
+        VkMemoryPropertyFlags memoryPropertyFlags;
 
-		/** 
+        /** 
 		* Map a memory range of this buffer. If successful, mapped points to the specified buffer range.
 		* 
 		* @param size (Optional) Size of the memory range to map. Pass VK_WHOLE_SIZE to map the complete buffer range.
@@ -44,65 +44,65 @@ namespace vks
 		* 
 		* @return VkResult of the buffer mapping call
 		*/
-		VkResult map(VkDeviceSize size = VK_WHOLE_SIZE, VkDeviceSize offset = 0)
-		{
-			return vkMapMemory(device, memory, offset, size, 0, &mapped);
-		}
+        VkResult map(VkDeviceSize size = VK_WHOLE_SIZE, VkDeviceSize offset = 0)
+        {
+            return vkMapMemory(device, memory, offset, size, 0, &mapped);
+        }
 
-		/**
+        /**
 		* Unmap a mapped memory range
 		*
 		* @note Does not return a result as vkUnmapMemory can't fail
 		*/
-		void unmap()
-		{
-			if (mapped)
-			{
-				vkUnmapMemory(device, memory);
-				mapped = nullptr;
-			}
-		}
+        void unmap()
+        {
+            if (mapped)
+            {
+                vkUnmapMemory(device, memory);
+                mapped = nullptr;
+            }
+        }
 
-		/** 
+        /** 
 		* Attach the allocated memory block to the buffer
 		* 
 		* @param offset (Optional) Byte offset (from the beginning) for the memory region to bind
 		* 
 		* @return VkResult of the bindBufferMemory call
 		*/
-		VkResult bind(VkDeviceSize offset = 0)
-		{
-			return vkBindBufferMemory(device, buffer, memory, offset);
-		}
+        VkResult bind(VkDeviceSize offset = 0)
+        {
+            return vkBindBufferMemory(device, buffer, memory, offset);
+        }
 
-		/**
+        /**
 		* Setup the default descriptor for this buffer
 		*
 		* @param size (Optional) Size of the memory range of the descriptor
 		* @param offset (Optional) Byte offset from beginning
 		*
 		*/
-		void setupDescriptor(VkDeviceSize size = VK_WHOLE_SIZE, VkDeviceSize offset = 0)
-		{
-			descriptor.offset = offset;
-			descriptor.buffer = buffer;
-			descriptor.range = size;
-		}
+        void setupDescriptor(VkDeviceSize size = VK_WHOLE_SIZE, VkDeviceSize offset = 0)
+        {
+            descriptor.offset = offset;
+            descriptor.buffer = buffer;
+            descriptor.range = size;
+        }
 
-		/**
+        /**
 		* Copies the specified data to the mapped buffer
 		* 
 		* @param data Pointer to the data to copy
 		* @param size Size of the data to copy in machine units
 		*
 		*/
-		void copyTo(void* data, VkDeviceSize size)
-		{
-			assert(mapped);
-			memcpy(mapped, data, size);
-		}
+        void copyTo(void* data, VkDeviceSize size)
+        {
+            assert(mapped);
+            memcpy(mapped, data, size);
+        }
 
-		/** 
+        /** 
 		* Flush a memory range of the buffer to make it visible to the device
 		*
 		* @note Only required for non-coherent memory
@@ -112,17 +112,17 @@ namespace vks
 		*
 		* @return VkResult of the flush call
 		*/
-		VkResult flush(VkDeviceSize size = VK_WHOLE_SIZE, VkDeviceSize offset = 0)
-		{
-			VkMappedMemoryRange mappedRange = {};
-			mappedRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
-			mappedRange.memory = memory;
-			mappedRange.offset = offset;
-			mappedRange.size = size;
-			return vkFlushMappedMemoryRanges(device, 1, &mappedRange);
-		}
+        VkResult flush(VkDeviceSize size = VK_WHOLE_SIZE, VkDeviceSize offset = 0)
+        {
+            VkMappedMemoryRange mappedRange = {};
+            mappedRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+            mappedRange.memory = memory;
+            mappedRange.offset = offset;
+            mappedRange.size = size;
+            return vkFlushMappedMemoryRanges(device, 1, &mappedRange);
+        }
 
-		/**
+        /**
 		* Invalidate a memory range of the buffer to make it visible to the host
 		*
 		* @note Only required for non-coherent memory
@@ -132,30 +132,29 @@ namespace vks
 		*
 		* @return VkResult of the invalidate call
 		*/
-		VkResult invalidate(VkDeviceSize size = VK_WHOLE_SIZE, VkDeviceSize offset = 0)
-		{
-			VkMappedMemoryRange mappedRange = {};
-			mappedRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
-			mappedRange.memory = memory;
-			mappedRange.offset = offset;
-			mappedRange.size = size;
-			return vkInvalidateMappedMemoryRanges(device, 1, &mappedRange);
-		}
+        VkResult invalidate(VkDeviceSize size = VK_WHOLE_SIZE, VkDeviceSize offset = 0)
+        {
+            VkMappedMemoryRange mappedRange = {};
+            mappedRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+            mappedRange.memory = memory;
+            mappedRange.offset = offset;
+            mappedRange.size = size;
+            return vkInvalidateMappedMemoryRanges(device, 1, &mappedRange);
+        }
 
-		/** 
+        /** 
 		* Release all Vulkan resources held by this buffer
 		*/
-		void destroy()
-		{
-			if (buffer)
-			{
-				vkDestroyBuffer(device, buffer, nullptr);
-			}
-			if (memory)
-			{
-				vkFreeMemory(device, memory, nullptr);
-			}
-		}
-
-	};
-}
+        void destroy()
+        {
+            if (buffer)
+            {
+                vkDestroyBuffer(device, buffer, nullptr);
+            }
+            if (memory)
+            {
+                vkFreeMemory(device, memory, nullptr);
+            }
+        }
+    };
+}  // namespace vks

--- a/base/VulkanDebug.cpp
+++ b/base/VulkanDebug.cpp
@@ -11,251 +11,258 @@
 
 namespace vks
 {
-	namespace debug
-	{
-		PFN_vkCreateDebugUtilsMessengerEXT vkCreateDebugUtilsMessengerEXT;
-		PFN_vkDestroyDebugUtilsMessengerEXT vkDestroyDebugUtilsMessengerEXT;
-		VkDebugUtilsMessengerEXT debugUtilsMessenger;
+    namespace debug
+    {
+        PFN_vkCreateDebugUtilsMessengerEXT vkCreateDebugUtilsMessengerEXT;
+        PFN_vkDestroyDebugUtilsMessengerEXT vkDestroyDebugUtilsMessengerEXT;
+        VkDebugUtilsMessengerEXT debugUtilsMessenger;
 
-		VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsMessengerCallback(
-			VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-			VkDebugUtilsMessageTypeFlagsEXT messageType,
-			const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
-			void* pUserData)
-		{
-			// Select prefix depending on flags passed to the callback
-			std::string prefix("");
+        VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsMessengerCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+                                                                   VkDebugUtilsMessageTypeFlagsEXT messageType,
+                                                                   const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
+                                                                   void* pUserData)
+        {
+            // Select prefix depending on flags passed to the callback
+            std::string prefix("");
 
-			if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) {
-				prefix = "VERBOSE: ";
-			}
-			else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) {
-				prefix = "INFO: ";
-			}
-			else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
-				prefix = "WARNING: ";
-			}
-			else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
-				prefix = "ERROR: ";
-			}
+            if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT)
+            {
+                prefix = "VERBOSE: ";
+            }
+            else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)
+            {
+                prefix = "INFO: ";
+            }
+            else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+            {
+                prefix = "WARNING: ";
+            }
+            else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+            {
+                prefix = "ERROR: ";
+            }
 
-
-			// Display message to default output (console/logcat)
-			std::stringstream debugMessage;
-			debugMessage << prefix << "[" << pCallbackData->messageIdNumber << "][" << pCallbackData->pMessageIdName << "] : " << pCallbackData->pMessage;
+            // Display message to default output (console/logcat)
+            std::stringstream debugMessage;
+            debugMessage << prefix << "[" << pCallbackData->messageIdNumber << "][" << pCallbackData->pMessageIdName << "] : " << pCallbackData->pMessage;
 
 #if defined(__ANDROID__)
-			if (messageSeverity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
-				LOGE("%s", debugMessage.str().c_str());
-			} else {
-				LOGD("%s", debugMessage.str().c_str());
-			}
+            if (messageSeverity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+            {
+                LOGE("%s", debugMessage.str().c_str());
+            }
+            else
+            {
+                LOGD("%s", debugMessage.str().c_str());
+            }
 #else
-			if (messageSeverity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
-				std::cerr << debugMessage.str() << "\n";
-			} else {
-				std::cout << debugMessage.str() << "\n";
-			}
-			fflush(stdout);
+            if (messageSeverity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+            {
+                std::cerr << debugMessage.str() << "\n";
+            }
+            else
+            {
+                std::cout << debugMessage.str() << "\n";
+            }
+            fflush(stdout);
 #endif
 
+            // The return value of this callback controls wether the Vulkan call that caused the validation message will be aborted or not
+            // We return VK_FALSE as we DON'T want Vulkan calls that cause a validation message to abort
+            // If you instead want to have calls abort, pass in VK_TRUE and the function will return VK_ERROR_VALIDATION_FAILED_EXT
+            return VK_FALSE;
+        }
 
-			// The return value of this callback controls wether the Vulkan call that caused the validation message will be aborted or not
-			// We return VK_FALSE as we DON'T want Vulkan calls that cause a validation message to abort
-			// If you instead want to have calls abort, pass in VK_TRUE and the function will return VK_ERROR_VALIDATION_FAILED_EXT 
-			return VK_FALSE;
-		}
+        void setupDebugging(VkInstance instance, VkDebugReportFlagsEXT flags, VkDebugReportCallbackEXT callBack)
+        {
+            vkCreateDebugUtilsMessengerEXT =
+                reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT"));
+            vkDestroyDebugUtilsMessengerEXT =
+                reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(vkGetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT"));
 
-		void setupDebugging(VkInstance instance, VkDebugReportFlagsEXT flags, VkDebugReportCallbackEXT callBack)
-		{
+            VkDebugUtilsMessengerCreateInfoEXT debugUtilsMessengerCI{};
+            debugUtilsMessengerCI.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+            debugUtilsMessengerCI.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+            debugUtilsMessengerCI.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+            debugUtilsMessengerCI.pfnUserCallback = debugUtilsMessengerCallback;
+            VkResult result = vkCreateDebugUtilsMessengerEXT(instance, &debugUtilsMessengerCI, nullptr, &debugUtilsMessenger);
+            assert(result == VK_SUCCESS);
+        }
 
-			vkCreateDebugUtilsMessengerEXT = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT"));
-			vkDestroyDebugUtilsMessengerEXT = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(vkGetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT"));
+        void freeDebugCallback(VkInstance instance)
+        {
+            if (debugUtilsMessenger != VK_NULL_HANDLE)
+            {
+                vkDestroyDebugUtilsMessengerEXT(instance, debugUtilsMessenger, nullptr);
+            }
+        }
+    }  // namespace debug
 
-			VkDebugUtilsMessengerCreateInfoEXT debugUtilsMessengerCI{};
-			debugUtilsMessengerCI.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
-			debugUtilsMessengerCI.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-			debugUtilsMessengerCI.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-			debugUtilsMessengerCI.pfnUserCallback = debugUtilsMessengerCallback;
-			VkResult result = vkCreateDebugUtilsMessengerEXT(instance, &debugUtilsMessengerCI, nullptr, &debugUtilsMessenger);
-			assert(result == VK_SUCCESS);
-		}
+    namespace debugmarker
+    {
+        bool active = false;
 
-		void freeDebugCallback(VkInstance instance)
-		{
-			if (debugUtilsMessenger != VK_NULL_HANDLE)
-			{
-				vkDestroyDebugUtilsMessengerEXT(instance, debugUtilsMessenger, nullptr);
-			}
-		}
-	}
+        PFN_vkDebugMarkerSetObjectTagEXT pfnDebugMarkerSetObjectTag = VK_NULL_HANDLE;
+        PFN_vkDebugMarkerSetObjectNameEXT pfnDebugMarkerSetObjectName = VK_NULL_HANDLE;
+        PFN_vkCmdDebugMarkerBeginEXT pfnCmdDebugMarkerBegin = VK_NULL_HANDLE;
+        PFN_vkCmdDebugMarkerEndEXT pfnCmdDebugMarkerEnd = VK_NULL_HANDLE;
+        PFN_vkCmdDebugMarkerInsertEXT pfnCmdDebugMarkerInsert = VK_NULL_HANDLE;
 
-	namespace debugmarker
-	{
-		bool active = false;
+        void setup(VkDevice device)
+        {
+            pfnDebugMarkerSetObjectTag = reinterpret_cast<PFN_vkDebugMarkerSetObjectTagEXT>(vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectTagEXT"));
+            pfnDebugMarkerSetObjectName = reinterpret_cast<PFN_vkDebugMarkerSetObjectNameEXT>(vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT"));
+            pfnCmdDebugMarkerBegin = reinterpret_cast<PFN_vkCmdDebugMarkerBeginEXT>(vkGetDeviceProcAddr(device, "vkCmdDebugMarkerBeginEXT"));
+            pfnCmdDebugMarkerEnd = reinterpret_cast<PFN_vkCmdDebugMarkerEndEXT>(vkGetDeviceProcAddr(device, "vkCmdDebugMarkerEndEXT"));
+            pfnCmdDebugMarkerInsert = reinterpret_cast<PFN_vkCmdDebugMarkerInsertEXT>(vkGetDeviceProcAddr(device, "vkCmdDebugMarkerInsertEXT"));
 
-		PFN_vkDebugMarkerSetObjectTagEXT pfnDebugMarkerSetObjectTag = VK_NULL_HANDLE;
-		PFN_vkDebugMarkerSetObjectNameEXT pfnDebugMarkerSetObjectName = VK_NULL_HANDLE;
-		PFN_vkCmdDebugMarkerBeginEXT pfnCmdDebugMarkerBegin = VK_NULL_HANDLE;
-		PFN_vkCmdDebugMarkerEndEXT pfnCmdDebugMarkerEnd = VK_NULL_HANDLE;
-		PFN_vkCmdDebugMarkerInsertEXT pfnCmdDebugMarkerInsert = VK_NULL_HANDLE;
+            // Set flag if at least one function pointer is present
+            active = (pfnDebugMarkerSetObjectName != VK_NULL_HANDLE);
+        }
 
-		void setup(VkDevice device)
-		{
-			pfnDebugMarkerSetObjectTag = reinterpret_cast<PFN_vkDebugMarkerSetObjectTagEXT>(vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectTagEXT"));
-			pfnDebugMarkerSetObjectName = reinterpret_cast<PFN_vkDebugMarkerSetObjectNameEXT>(vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT"));
-			pfnCmdDebugMarkerBegin = reinterpret_cast<PFN_vkCmdDebugMarkerBeginEXT>(vkGetDeviceProcAddr(device, "vkCmdDebugMarkerBeginEXT"));
-			pfnCmdDebugMarkerEnd = reinterpret_cast<PFN_vkCmdDebugMarkerEndEXT>(vkGetDeviceProcAddr(device, "vkCmdDebugMarkerEndEXT"));
-			pfnCmdDebugMarkerInsert = reinterpret_cast<PFN_vkCmdDebugMarkerInsertEXT>(vkGetDeviceProcAddr(device, "vkCmdDebugMarkerInsertEXT"));
+        void setObjectName(VkDevice device, uint64_t object, VkDebugReportObjectTypeEXT objectType, const char* name)
+        {
+            // Check for valid function pointer (may not be present if not running in a debugging application)
+            if (pfnDebugMarkerSetObjectName)
+            {
+                VkDebugMarkerObjectNameInfoEXT nameInfo = {};
+                nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
+                nameInfo.objectType = objectType;
+                nameInfo.object = object;
+                nameInfo.pObjectName = name;
+                pfnDebugMarkerSetObjectName(device, &nameInfo);
+            }
+        }
 
-			// Set flag if at least one function pointer is present
-			active = (pfnDebugMarkerSetObjectName != VK_NULL_HANDLE);
-		}
+        void setObjectTag(VkDevice device, uint64_t object, VkDebugReportObjectTypeEXT objectType, uint64_t name, size_t tagSize, const void* tag)
+        {
+            // Check for valid function pointer (may not be present if not running in a debugging application)
+            if (pfnDebugMarkerSetObjectTag)
+            {
+                VkDebugMarkerObjectTagInfoEXT tagInfo = {};
+                tagInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT;
+                tagInfo.objectType = objectType;
+                tagInfo.object = object;
+                tagInfo.tagName = name;
+                tagInfo.tagSize = tagSize;
+                tagInfo.pTag = tag;
+                pfnDebugMarkerSetObjectTag(device, &tagInfo);
+            }
+        }
 
-		void setObjectName(VkDevice device, uint64_t object, VkDebugReportObjectTypeEXT objectType, const char *name)
-		{
-			// Check for valid function pointer (may not be present if not running in a debugging application)
-			if (pfnDebugMarkerSetObjectName)
-			{
-				VkDebugMarkerObjectNameInfoEXT nameInfo = {};
-				nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
-				nameInfo.objectType = objectType;
-				nameInfo.object = object;
-				nameInfo.pObjectName = name;
-				pfnDebugMarkerSetObjectName(device, &nameInfo);
-			}
-		}
+        void beginRegion(VkCommandBuffer cmdbuffer, const char* pMarkerName, glm::vec4 color)
+        {
+            // Check for valid function pointer (may not be present if not running in a debugging application)
+            if (pfnCmdDebugMarkerBegin)
+            {
+                VkDebugMarkerMarkerInfoEXT markerInfo = {};
+                markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
+                memcpy(markerInfo.color, &color[0], sizeof(float) * 4);
+                markerInfo.pMarkerName = pMarkerName;
+                pfnCmdDebugMarkerBegin(cmdbuffer, &markerInfo);
+            }
+        }
 
-		void setObjectTag(VkDevice device, uint64_t object, VkDebugReportObjectTypeEXT objectType, uint64_t name, size_t tagSize, const void* tag)
-		{
-			// Check for valid function pointer (may not be present if not running in a debugging application)
-			if (pfnDebugMarkerSetObjectTag)
-			{
-				VkDebugMarkerObjectTagInfoEXT tagInfo = {};
-				tagInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT;
-				tagInfo.objectType = objectType;
-				tagInfo.object = object;
-				tagInfo.tagName = name;
-				tagInfo.tagSize = tagSize;
-				tagInfo.pTag = tag;
-				pfnDebugMarkerSetObjectTag(device, &tagInfo);
-			}
-		}
+        void insert(VkCommandBuffer cmdbuffer, std::string markerName, glm::vec4 color)
+        {
+            // Check for valid function pointer (may not be present if not running in a debugging application)
+            if (pfnCmdDebugMarkerInsert)
+            {
+                VkDebugMarkerMarkerInfoEXT markerInfo = {};
+                markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
+                memcpy(markerInfo.color, &color[0], sizeof(float) * 4);
+                markerInfo.pMarkerName = markerName.c_str();
+                pfnCmdDebugMarkerInsert(cmdbuffer, &markerInfo);
+            }
+        }
 
-		void beginRegion(VkCommandBuffer cmdbuffer, const char* pMarkerName, glm::vec4 color)
-		{
-			// Check for valid function pointer (may not be present if not running in a debugging application)
-			if (pfnCmdDebugMarkerBegin)
-			{
-				VkDebugMarkerMarkerInfoEXT markerInfo = {};
-				markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
-				memcpy(markerInfo.color, &color[0], sizeof(float) * 4);
-				markerInfo.pMarkerName = pMarkerName;
-				pfnCmdDebugMarkerBegin(cmdbuffer, &markerInfo);
-			}
-		}
+        void endRegion(VkCommandBuffer cmdBuffer)
+        {
+            // Check for valid function (may not be present if not runnin in a debugging application)
+            if (pfnCmdDebugMarkerEnd)
+            {
+                pfnCmdDebugMarkerEnd(cmdBuffer);
+            }
+        }
 
-		void insert(VkCommandBuffer cmdbuffer, std::string markerName, glm::vec4 color)
-		{
-			// Check for valid function pointer (may not be present if not running in a debugging application)
-			if (pfnCmdDebugMarkerInsert)
-			{
-				VkDebugMarkerMarkerInfoEXT markerInfo = {};
-				markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
-				memcpy(markerInfo.color, &color[0], sizeof(float) * 4);
-				markerInfo.pMarkerName = markerName.c_str();
-				pfnCmdDebugMarkerInsert(cmdbuffer, &markerInfo);
-			}
-		}
+        void setCommandBufferName(VkDevice device, VkCommandBuffer cmdBuffer, const char* name)
+        {
+            setObjectName(device, (uint64_t)cmdBuffer, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, name);
+        }
 
-		void endRegion(VkCommandBuffer cmdBuffer)
-		{
-			// Check for valid function (may not be present if not runnin in a debugging application)
-			if (pfnCmdDebugMarkerEnd)
-			{
-				pfnCmdDebugMarkerEnd(cmdBuffer);
-			}
-		}
+        void setQueueName(VkDevice device, VkQueue queue, const char* name)
+        {
+            setObjectName(device, (uint64_t)queue, VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT, name);
+        }
 
-		void setCommandBufferName(VkDevice device, VkCommandBuffer cmdBuffer, const char * name)
-		{
-			setObjectName(device, (uint64_t)cmdBuffer, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, name);
-		}
+        void setImageName(VkDevice device, VkImage image, const char* name)
+        {
+            setObjectName(device, (uint64_t)image, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, name);
+        }
 
-		void setQueueName(VkDevice device, VkQueue queue, const char * name)
-		{
-			setObjectName(device, (uint64_t)queue, VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT, name);
-		}
+        void setSamplerName(VkDevice device, VkSampler sampler, const char* name)
+        {
+            setObjectName(device, (uint64_t)sampler, VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT, name);
+        }
 
-		void setImageName(VkDevice device, VkImage image, const char * name)
-		{
-			setObjectName(device, (uint64_t)image, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, name);
-		}
+        void setBufferName(VkDevice device, VkBuffer buffer, const char* name)
+        {
+            setObjectName(device, (uint64_t)buffer, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, name);
+        }
 
-		void setSamplerName(VkDevice device, VkSampler sampler, const char * name)
-		{
-			setObjectName(device, (uint64_t)sampler, VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT, name);
-		}
+        void setDeviceMemoryName(VkDevice device, VkDeviceMemory memory, const char* name)
+        {
+            setObjectName(device, (uint64_t)memory, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT, name);
+        }
 
-		void setBufferName(VkDevice device, VkBuffer buffer, const char * name)
-		{
-			setObjectName(device, (uint64_t)buffer, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, name);
-		}
+        void setShaderModuleName(VkDevice device, VkShaderModule shaderModule, const char* name)
+        {
+            setObjectName(device, (uint64_t)shaderModule, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
+        }
 
-		void setDeviceMemoryName(VkDevice device, VkDeviceMemory memory, const char * name)
-		{
-			setObjectName(device, (uint64_t)memory, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT, name);
-		}
+        void setPipelineName(VkDevice device, VkPipeline pipeline, const char* name)
+        {
+            setObjectName(device, (uint64_t)pipeline, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, name);
+        }
 
-		void setShaderModuleName(VkDevice device, VkShaderModule shaderModule, const char * name)
-		{
-			setObjectName(device, (uint64_t)shaderModule, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
-		}
+        void setPipelineLayoutName(VkDevice device, VkPipelineLayout pipelineLayout, const char* name)
+        {
+            setObjectName(device, (uint64_t)pipelineLayout, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT, name);
+        }
 
-		void setPipelineName(VkDevice device, VkPipeline pipeline, const char * name)
-		{
-			setObjectName(device, (uint64_t)pipeline, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, name);
-		}
+        void setRenderPassName(VkDevice device, VkRenderPass renderPass, const char* name)
+        {
+            setObjectName(device, (uint64_t)renderPass, VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT, name);
+        }
 
-		void setPipelineLayoutName(VkDevice device, VkPipelineLayout pipelineLayout, const char * name)
-		{
-			setObjectName(device, (uint64_t)pipelineLayout, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT, name);
-		}
+        void setFramebufferName(VkDevice device, VkFramebuffer framebuffer, const char* name)
+        {
+            setObjectName(device, (uint64_t)framebuffer, VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT, name);
+        }
 
-		void setRenderPassName(VkDevice device, VkRenderPass renderPass, const char * name)
-		{
-			setObjectName(device, (uint64_t)renderPass, VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT, name);
-		}
+        void setDescriptorSetLayoutName(VkDevice device, VkDescriptorSetLayout descriptorSetLayout, const char* name)
+        {
+            setObjectName(device, (uint64_t)descriptorSetLayout, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT, name);
+        }
 
-		void setFramebufferName(VkDevice device, VkFramebuffer framebuffer, const char * name)
-		{
-			setObjectName(device, (uint64_t)framebuffer, VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT, name);
-		}
+        void setDescriptorSetName(VkDevice device, VkDescriptorSet descriptorSet, const char* name)
+        {
+            setObjectName(device, (uint64_t)descriptorSet, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT, name);
+        }
 
-		void setDescriptorSetLayoutName(VkDevice device, VkDescriptorSetLayout descriptorSetLayout, const char * name)
-		{
-			setObjectName(device, (uint64_t)descriptorSetLayout, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT, name);
-		}
+        void setSemaphoreName(VkDevice device, VkSemaphore semaphore, const char* name)
+        {
+            setObjectName(device, (uint64_t)semaphore, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, name);
+        }
 
-		void setDescriptorSetName(VkDevice device, VkDescriptorSet descriptorSet, const char * name)
-		{
-			setObjectName(device, (uint64_t)descriptorSet, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT, name);
-		}
+        void setFenceName(VkDevice device, VkFence fence, const char* name)
+        {
+            setObjectName(device, (uint64_t)fence, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, name);
+        }
 
-		void setSemaphoreName(VkDevice device, VkSemaphore semaphore, const char * name)
-		{
-			setObjectName(device, (uint64_t)semaphore, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, name);
-		}
-
-		void setFenceName(VkDevice device, VkFence fence, const char * name)
-		{
-			setObjectName(device, (uint64_t)fence, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, name);
-		}
-
-		void setEventName(VkDevice device, VkEvent _event, const char * name)
-		{
-			setObjectName(device, (uint64_t)_event, VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT, name);
-		}
-	};
-}
-
+        void setEventName(VkDevice device, VkEvent _event, const char* name)
+        {
+            setObjectName(device, (uint64_t)_event, VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT, name);
+        }
+    };  // namespace debugmarker
+}  // namespace vks

--- a/base/VulkanDebug.h
+++ b/base/VulkanDebug.h
@@ -24,79 +24,75 @@
 
 namespace vks
 {
-	namespace debug
-	{
-		// Default validation layers
-		extern int validationLayerCount;
-		extern const char *validationLayerNames[];
+    namespace debug
+    {
+        // Default validation layers
+        extern int validationLayerCount;
+        extern const char* validationLayerNames[];
 
-		// Default debug callback
-		VKAPI_ATTR VkBool32 VKAPI_CALL messageCallback(
-			VkDebugReportFlagsEXT flags,
-			VkDebugReportObjectTypeEXT objType,
-			uint64_t srcObject,
-			size_t location,
-			int32_t msgCode,
-			const char* pLayerPrefix,
-			const char* pMsg,
-			void* pUserData);
+        // Default debug callback
+        VKAPI_ATTR VkBool32 VKAPI_CALL messageCallback(VkDebugReportFlagsEXT flags,
+                                                       VkDebugReportObjectTypeEXT objType,
+                                                       uint64_t srcObject,
+                                                       size_t location,
+                                                       int32_t msgCode,
+                                                       const char* pLayerPrefix,
+                                                       const char* pMsg,
+                                                       void* pUserData);
 
-		// Load debug function pointers and set debug callback
-		// if callBack is NULL, default message callback will be used
-		void setupDebugging(
-			VkInstance instance,
-			VkDebugReportFlagsEXT flags,
-			VkDebugReportCallbackEXT callBack);
-		// Clear debug callback
-		void freeDebugCallback(VkInstance instance);
-	}
+        // Load debug function pointers and set debug callback
+        // if callBack is NULL, default message callback will be used
+        void setupDebugging(VkInstance instance, VkDebugReportFlagsEXT flags, VkDebugReportCallbackEXT callBack);
+        // Clear debug callback
+        void freeDebugCallback(VkInstance instance);
+    }  // namespace debug
 
-	// Setup and functions for the VK_EXT_debug_marker_extension
-	// Extension spec can be found at https://github.com/KhronosGroup/Vulkan-Docs/blob/1.0-VK_EXT_debug_marker/doc/specs/vulkan/appendices/VK_EXT_debug_marker.txt
-	// Note that the extension will only be present if run from an offline debugging application
-	// The actual check for extension presence and enabling it on the device is done in the example base class
-	// See VulkanExampleBase::createInstance and VulkanExampleBase::createDevice (base/vulkanexamplebase.cpp)
-	namespace debugmarker
-	{
-		// Set to true if function pointer for the debug marker are available
-		extern bool active;
+    // Setup and functions for the VK_EXT_debug_marker_extension
+    // Extension spec can be found at https://github.com/KhronosGroup/Vulkan-Docs/blob/1.0-VK_EXT_debug_marker/doc/specs/vulkan/appendices/VK_EXT_debug_marker.txt
+    // Note that the extension will only be present if run from an offline debugging application
+    // The actual check for extension presence and enabling it on the device is done in the example base class
+    // See VulkanExampleBase::createInstance and VulkanExampleBase::createDevice (base/vulkanexamplebase.cpp)
+    namespace debugmarker
+    {
+        // Set to true if function pointer for the debug marker are available
+        extern bool active;
 
-		// Get function pointers for the debug report extensions from the device
-		void setup(VkDevice device);
+        // Get function pointers for the debug report extensions from the device
+        void setup(VkDevice device);
 
-		// Sets the debug name of an object
-		// All Objects in Vulkan are represented by their 64-bit handles which are passed into this function
-		// along with the object type
-		void setObjectName(VkDevice device, uint64_t object, VkDebugReportObjectTypeEXT objectType, const char *name);
+        // Sets the debug name of an object
+        // All Objects in Vulkan are represented by their 64-bit handles which are passed into this function
+        // along with the object type
+        void setObjectName(VkDevice device, uint64_t object, VkDebugReportObjectTypeEXT objectType, const char* name);
 
-		// Set the tag for an object
-		void setObjectTag(VkDevice device, uint64_t object, VkDebugReportObjectTypeEXT objectType, uint64_t name, size_t tagSize, const void* tag);
+        // Set the tag for an object
+        void setObjectTag(VkDevice device, uint64_t object, VkDebugReportObjectTypeEXT objectType, uint64_t name, size_t tagSize, const void* tag);
 
-		// Start a new debug marker region
-		void beginRegion(VkCommandBuffer cmdbuffer, const char* pMarkerName, glm::vec4 color);
+        // Start a new debug marker region
+        void beginRegion(VkCommandBuffer cmdbuffer, const char* pMarkerName, glm::vec4 color);
 
-		// Insert a new debug marker into the command buffer
-		void insert(VkCommandBuffer cmdbuffer, std::string markerName, glm::vec4 color);
+        // Insert a new debug marker into the command buffer
+        void insert(VkCommandBuffer cmdbuffer, std::string markerName, glm::vec4 color);
 
-		// End the current debug marker region
-		void endRegion(VkCommandBuffer cmdBuffer);
+        // End the current debug marker region
+        void endRegion(VkCommandBuffer cmdBuffer);
 
-		// Object specific naming functions
-		void setCommandBufferName(VkDevice device, VkCommandBuffer cmdBuffer, const char * name);
-		void setQueueName(VkDevice device, VkQueue queue, const char * name);
-		void setImageName(VkDevice device, VkImage image, const char * name);
-		void setSamplerName(VkDevice device, VkSampler sampler, const char * name);
-		void setBufferName(VkDevice device, VkBuffer buffer, const char * name);
-		void setDeviceMemoryName(VkDevice device, VkDeviceMemory memory, const char * name);
-		void setShaderModuleName(VkDevice device, VkShaderModule shaderModule, const char * name);
-		void setPipelineName(VkDevice device, VkPipeline pipeline, const char * name);
-		void setPipelineLayoutName(VkDevice device, VkPipelineLayout pipelineLayout, const char * name);
-		void setRenderPassName(VkDevice device, VkRenderPass renderPass, const char * name);
-		void setFramebufferName(VkDevice device, VkFramebuffer framebuffer, const char * name);
-		void setDescriptorSetLayoutName(VkDevice device, VkDescriptorSetLayout descriptorSetLayout, const char * name);
-		void setDescriptorSetName(VkDevice device, VkDescriptorSet descriptorSet, const char * name);
-		void setSemaphoreName(VkDevice device, VkSemaphore semaphore, const char * name);
-		void setFenceName(VkDevice device, VkFence fence, const char * name);
-		void setEventName(VkDevice device, VkEvent _event, const char * name);
-	};
-}
+        // Object specific naming functions
+        void setCommandBufferName(VkDevice device, VkCommandBuffer cmdBuffer, const char* name);
+        void setQueueName(VkDevice device, VkQueue queue, const char* name);
+        void setImageName(VkDevice device, VkImage image, const char* name);
+        void setSamplerName(VkDevice device, VkSampler sampler, const char* name);
+        void setBufferName(VkDevice device, VkBuffer buffer, const char* name);
+        void setDeviceMemoryName(VkDevice device, VkDeviceMemory memory, const char* name);
+        void setShaderModuleName(VkDevice device, VkShaderModule shaderModule, const char* name);
+        void setPipelineName(VkDevice device, VkPipeline pipeline, const char* name);
+        void setPipelineLayoutName(VkDevice device, VkPipelineLayout pipelineLayout, const char* name);
+        void setRenderPassName(VkDevice device, VkRenderPass renderPass, const char* name);
+        void setFramebufferName(VkDevice device, VkFramebuffer framebuffer, const char* name);
+        void setDescriptorSetLayoutName(VkDevice device, VkDescriptorSetLayout descriptorSetLayout, const char* name);
+        void setDescriptorSetName(VkDevice device, VkDescriptorSet descriptorSet, const char* name);
+        void setSemaphoreName(VkDevice device, VkSemaphore semaphore, const char* name);
+        void setFenceName(VkDevice device, VkFence fence, const char* name);
+        void setEventName(VkDevice device, VkEvent _event, const char* name);
+    };  // namespace debugmarker
+}  // namespace vks

--- a/base/VulkanDevice.hpp
+++ b/base/VulkanDevice.hpp
@@ -18,101 +18,104 @@
 #include "VulkanBuffer.hpp"
 
 namespace vks
-{	
-	struct VulkanDevice
-	{
-		/** @brief Physical device representation */
-		VkPhysicalDevice physicalDevice;
-		/** @brief Logical device representation (application's view of the device) */
-		VkDevice logicalDevice;
-		/** @brief Properties of the physical device including limits that the application can check against */
-		VkPhysicalDeviceProperties properties;
-		/** @brief Features of the physical device that an application can use to check if a feature is supported */
-		VkPhysicalDeviceFeatures features;
-		/** @brief Features that have been enabled for use on the physical device */
-		VkPhysicalDeviceFeatures enabledFeatures;
-		/** @brief Memory types and heaps of the physical device */
-		VkPhysicalDeviceMemoryProperties memoryProperties;
-		/** @brief Queue family properties of the physical device */
-		std::vector<VkQueueFamilyProperties> queueFamilyProperties;
-		/** @brief List of extensions supported by the device */
-		std::vector<std::string> supportedExtensions;
+{
+    struct VulkanDevice
+    {
+        /** @brief Physical device representation */
+        VkPhysicalDevice physicalDevice;
+        /** @brief Logical device representation (application's view of the device) */
+        VkDevice logicalDevice;
+        /** @brief Properties of the physical device including limits that the application can check against */
+        VkPhysicalDeviceProperties properties;
+        /** @brief Features of the physical device that an application can use to check if a feature is supported */
+        VkPhysicalDeviceFeatures features;
+        /** @brief Features that have been enabled for use on the physical device */
+        VkPhysicalDeviceFeatures enabledFeatures;
+        /** @brief Memory types and heaps of the physical device */
+        VkPhysicalDeviceMemoryProperties memoryProperties;
+        /** @brief Queue family properties of the physical device */
+        std::vector<VkQueueFamilyProperties> queueFamilyProperties;
+        /** @brief List of extensions supported by the device */
+        std::vector<std::string> supportedExtensions;
 
-		/** @brief Default command pool for the graphics queue family index */
-		VkCommandPool commandPool = VK_NULL_HANDLE;
+        /** @brief Default command pool for the graphics queue family index */
+        VkCommandPool commandPool = VK_NULL_HANDLE;
 
-		/** @brief Set to true when the debug marker extension is detected */
-		bool enableDebugMarkers = false;
+        /** @brief Set to true when the debug marker extension is detected */
+        bool enableDebugMarkers = false;
 
-		/** @brief Contains queue family indices */
-		struct
-		{
-			uint32_t graphics;
-			uint32_t compute;
-			uint32_t transfer;
-		} queueFamilyIndices;
+        /** @brief Contains queue family indices */
+        struct
+        {
+            uint32_t graphics;
+            uint32_t compute;
+            uint32_t transfer;
+        } queueFamilyIndices;
 
-		/**  @brief Typecast to VkDevice */
-		operator VkDevice() { return logicalDevice; };
+        /**  @brief Typecast to VkDevice */
+        operator VkDevice()
+        {
+            return logicalDevice;
+        };
 
-		/**
+        /**
 		* Default constructor
 		*
 		* @param physicalDevice Physical device that is to be used
 		*/
-		VulkanDevice(VkPhysicalDevice physicalDevice)
-		{
-			assert(physicalDevice);
-			this->physicalDevice = physicalDevice;
+        VulkanDevice(VkPhysicalDevice physicalDevice)
+        {
+            assert(physicalDevice);
+            this->physicalDevice = physicalDevice;
 
-			// Store Properties features, limits and properties of the physical device for later use
-			// Device properties also contain limits and sparse properties
-			vkGetPhysicalDeviceProperties(physicalDevice, &properties);
-			// Features should be checked by the examples before using them
-			vkGetPhysicalDeviceFeatures(physicalDevice, &features);
-			// Memory properties are used regularly for creating all kinds of buffers
-			vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memoryProperties);
-			// Queue family properties, used for setting up requested queues upon device creation
-			uint32_t queueFamilyCount;
-			vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, nullptr);
-			assert(queueFamilyCount > 0);
-			queueFamilyProperties.resize(queueFamilyCount);
-			vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, queueFamilyProperties.data());
+            // Store Properties features, limits and properties of the physical device for later use
+            // Device properties also contain limits and sparse properties
+            vkGetPhysicalDeviceProperties(physicalDevice, &properties);
+            // Features should be checked by the examples before using them
+            vkGetPhysicalDeviceFeatures(physicalDevice, &features);
+            // Memory properties are used regularly for creating all kinds of buffers
+            vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memoryProperties);
+            // Queue family properties, used for setting up requested queues upon device creation
+            uint32_t queueFamilyCount;
+            vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, nullptr);
+            assert(queueFamilyCount > 0);
+            queueFamilyProperties.resize(queueFamilyCount);
+            vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, queueFamilyProperties.data());
 
-			// Get list of supported extensions
-			uint32_t extCount = 0;
-			vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, nullptr);
-			if (extCount > 0)
-			{
-				std::vector<VkExtensionProperties> extensions(extCount);
-				if (vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, &extensions.front()) == VK_SUCCESS)
-				{
-					for (auto ext : extensions)
-					{
-						supportedExtensions.push_back(ext.extensionName);
-					}
-				}
-			}
-		}
+            // Get list of supported extensions
+            uint32_t extCount = 0;
+            vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, nullptr);
+            if (extCount > 0)
+            {
+                std::vector<VkExtensionProperties> extensions(extCount);
+                if (vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, &extensions.front()) == VK_SUCCESS)
+                {
+                    for (auto ext : extensions)
+                    {
+                        supportedExtensions.push_back(ext.extensionName);
+                    }
+                }
+            }
+        }
 
-		/** 
+        /** 
 		* Default destructor
 		*
 		* @note Frees the logical device
 		*/
-		~VulkanDevice()
-		{
-			if (commandPool)
-			{
-				vkDestroyCommandPool(logicalDevice, commandPool, nullptr);
-			}
-			if (logicalDevice)
-			{
-				vkDestroyDevice(logicalDevice, nullptr);
-			}
-		}
+        ~VulkanDevice()
+        {
+            if (commandPool)
+            {
+                vkDestroyCommandPool(logicalDevice, commandPool, nullptr);
+            }
+            if (logicalDevice)
+            {
+                vkDestroyDevice(logicalDevice, nullptr);
+            }
+        }
 
-		/**
+        /**
 		* Get the index of a memory type that has all the requested property bits set
 		*
 		* @param typeBits Bitmask with bits set for each memory type supported by the resource to request for (from VkMemoryRequirements)
@@ -123,36 +126,36 @@ namespace vks
 		*
 		* @throw Throws an exception if memTypeFound is null and no memory type could be found that supports the requested properties
 		*/
-		uint32_t getMemoryType(uint32_t typeBits, VkMemoryPropertyFlags properties, VkBool32 *memTypeFound = nullptr)
-		{
-			for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; i++)
-			{
-				if ((typeBits & 1) == 1)
-				{
-					if ((memoryProperties.memoryTypes[i].propertyFlags & properties) == properties)
-					{
-						if (memTypeFound)
-						{
-							*memTypeFound = true;
-						}
-						return i;
-					}
-				}
-				typeBits >>= 1;
-			}
+        uint32_t getMemoryType(uint32_t typeBits, VkMemoryPropertyFlags properties, VkBool32* memTypeFound = nullptr)
+        {
+            for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; i++)
+            {
+                if ((typeBits & 1) == 1)
+                {
+                    if ((memoryProperties.memoryTypes[i].propertyFlags & properties) == properties)
+                    {
+                        if (memTypeFound)
+                        {
+                            *memTypeFound = true;
+                        }
+                        return i;
+                    }
+                }
+                typeBits >>= 1;
+            }
 
-			if (memTypeFound)
-			{
-				*memTypeFound = false;
-				return 0;
-			}
-			else
-			{
-				throw std::runtime_error("Could not find a matching memory type");
-			}
-		}
+            if (memTypeFound)
+            {
+                *memTypeFound = false;
+                return 0;
+            }
+            else
+            {
+                throw std::runtime_error("Could not find a matching memory type");
+            }
+        }
 
-		/**
+        /**
 		* Get the index of a queue family that supports the requested queue flags
 		*
 		* @param queueFlags Queue flags to find a queue family index for
@@ -161,50 +164,51 @@ namespace vks
 		*
 		* @throw Throws an exception if no queue family index could be found that supports the requested flags
 		*/
-		uint32_t getQueueFamilyIndex(VkQueueFlagBits queueFlags)
-		{
-			// Dedicated queue for compute
-			// Try to find a queue family index that supports compute but not graphics
-			if (queueFlags & VK_QUEUE_COMPUTE_BIT)
-			{
-				for (uint32_t i = 0; i < static_cast<uint32_t>(queueFamilyProperties.size()); i++)
-				{
-					if ((queueFamilyProperties[i].queueFlags & queueFlags) && ((queueFamilyProperties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0))
-					{
-						return i;
-						break;
-					}
-				}
-			}
+        uint32_t getQueueFamilyIndex(VkQueueFlagBits queueFlags)
+        {
+            // Dedicated queue for compute
+            // Try to find a queue family index that supports compute but not graphics
+            if (queueFlags & VK_QUEUE_COMPUTE_BIT)
+            {
+                for (uint32_t i = 0; i < static_cast<uint32_t>(queueFamilyProperties.size()); i++)
+                {
+                    if ((queueFamilyProperties[i].queueFlags & queueFlags) && ((queueFamilyProperties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0))
+                    {
+                        return i;
+                        break;
+                    }
+                }
+            }
 
-			// Dedicated queue for transfer
-			// Try to find a queue family index that supports transfer but not graphics and compute
-			if (queueFlags & VK_QUEUE_TRANSFER_BIT)
-			{
-				for (uint32_t i = 0; i < static_cast<uint32_t>(queueFamilyProperties.size()); i++)
-				{
-					if ((queueFamilyProperties[i].queueFlags & queueFlags) && ((queueFamilyProperties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0) && ((queueFamilyProperties[i].queueFlags & VK_QUEUE_COMPUTE_BIT) == 0))
-					{
-						return i;
-						break;
-					}
-				}
-			}
+            // Dedicated queue for transfer
+            // Try to find a queue family index that supports transfer but not graphics and compute
+            if (queueFlags & VK_QUEUE_TRANSFER_BIT)
+            {
+                for (uint32_t i = 0; i < static_cast<uint32_t>(queueFamilyProperties.size()); i++)
+                {
+                    if ((queueFamilyProperties[i].queueFlags & queueFlags) && ((queueFamilyProperties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0) &&
+                        ((queueFamilyProperties[i].queueFlags & VK_QUEUE_COMPUTE_BIT) == 0))
+                    {
+                        return i;
+                        break;
+                    }
+                }
+            }
 
-			// For other queue types or if no separate compute queue is present, return the first one to support the requested flags
-			for (uint32_t i = 0; i < static_cast<uint32_t>(queueFamilyProperties.size()); i++)
-			{
-				if (queueFamilyProperties[i].queueFlags & queueFlags)
-				{
-					return i;
-					break;
-				}
-			}
+            // For other queue types or if no separate compute queue is present, return the first one to support the requested flags
+            for (uint32_t i = 0; i < static_cast<uint32_t>(queueFamilyProperties.size()); i++)
+            {
+                if (queueFamilyProperties[i].queueFlags & queueFlags)
+                {
+                    return i;
+                    break;
+                }
+            }
 
-			throw std::runtime_error("Could not find a matching queue family index");
-		}
+            throw std::runtime_error("Could not find a matching queue family index");
+        }
 
-		/**
+        /**
 		* Create the logical device based on the assigned physical device, also gets default queue family indices
 		*
 		* @param enabledFeatures Can be used to enable certain features upon device creation
@@ -214,128 +218,134 @@ namespace vks
 		*
 		* @return VkResult of the device creation call
 		*/
-		VkResult createLogicalDevice(VkPhysicalDeviceFeatures enabledFeatures, std::vector<const char*> enabledExtensions, void* pNextChain, bool useSwapChain = true, VkQueueFlags requestedQueueTypes = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)
-		{			
-			// Desired queues need to be requested upon logical device creation
-			// Due to differing queue family configurations of Vulkan implementations this can be a bit tricky, especially if the application
-			// requests different queue types
+        VkResult createLogicalDevice(VkPhysicalDeviceFeatures enabledFeatures,
+                                     std::vector<const char*> enabledExtensions,
+                                     void* pNextChain,
+                                     bool useSwapChain = true,
+                                     VkQueueFlags requestedQueueTypes = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)
+        {
+            // Desired queues need to be requested upon logical device creation
+            // Due to differing queue family configurations of Vulkan implementations this can be a bit tricky, especially if the application
+            // requests different queue types
 
-			std::vector<VkDeviceQueueCreateInfo> queueCreateInfos{};
+            std::vector<VkDeviceQueueCreateInfo> queueCreateInfos{};
 
-			// Get queue family indices for the requested queue family types
-			// Note that the indices may overlap depending on the implementation
+            // Get queue family indices for the requested queue family types
+            // Note that the indices may overlap depending on the implementation
 
-			const float defaultQueuePriority(0.0f);
+            const float defaultQueuePriority(0.0f);
 
-			// Graphics queue
-			if (requestedQueueTypes & VK_QUEUE_GRAPHICS_BIT)
-			{
-				queueFamilyIndices.graphics = getQueueFamilyIndex(VK_QUEUE_GRAPHICS_BIT);
-				VkDeviceQueueCreateInfo queueInfo{};
-				queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-				queueInfo.queueFamilyIndex = queueFamilyIndices.graphics;
-				queueInfo.queueCount = 1;
-				queueInfo.pQueuePriorities = &defaultQueuePriority;
-				queueCreateInfos.push_back(queueInfo);
-			}
-			else
-			{
-				queueFamilyIndices.graphics = VK_NULL_HANDLE;
-			}
+            // Graphics queue
+            if (requestedQueueTypes & VK_QUEUE_GRAPHICS_BIT)
+            {
+                queueFamilyIndices.graphics = getQueueFamilyIndex(VK_QUEUE_GRAPHICS_BIT);
+                VkDeviceQueueCreateInfo queueInfo{};
+                queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+                queueInfo.queueFamilyIndex = queueFamilyIndices.graphics;
+                queueInfo.queueCount = 1;
+                queueInfo.pQueuePriorities = &defaultQueuePriority;
+                queueCreateInfos.push_back(queueInfo);
+            }
+            else
+            {
+                queueFamilyIndices.graphics = VK_NULL_HANDLE;
+            }
 
-			// Dedicated compute queue
-			if (requestedQueueTypes & VK_QUEUE_COMPUTE_BIT)
-			{
-				queueFamilyIndices.compute = getQueueFamilyIndex(VK_QUEUE_COMPUTE_BIT);
-				if (queueFamilyIndices.compute != queueFamilyIndices.graphics)
-				{
-					// If compute family index differs, we need an additional queue create info for the compute queue
-					VkDeviceQueueCreateInfo queueInfo{};
-					queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-					queueInfo.queueFamilyIndex = queueFamilyIndices.compute;
-					queueInfo.queueCount = 1;
-					queueInfo.pQueuePriorities = &defaultQueuePriority;
-					queueCreateInfos.push_back(queueInfo);
-				}
-			}
-			else
-			{
-				// Else we use the same queue
-				queueFamilyIndices.compute = queueFamilyIndices.graphics;
-			}
+            // Dedicated compute queue
+            if (requestedQueueTypes & VK_QUEUE_COMPUTE_BIT)
+            {
+                queueFamilyIndices.compute = getQueueFamilyIndex(VK_QUEUE_COMPUTE_BIT);
+                if (queueFamilyIndices.compute != queueFamilyIndices.graphics)
+                {
+                    // If compute family index differs, we need an additional queue create info for the compute queue
+                    VkDeviceQueueCreateInfo queueInfo{};
+                    queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+                    queueInfo.queueFamilyIndex = queueFamilyIndices.compute;
+                    queueInfo.queueCount = 1;
+                    queueInfo.pQueuePriorities = &defaultQueuePriority;
+                    queueCreateInfos.push_back(queueInfo);
+                }
+            }
+            else
+            {
+                // Else we use the same queue
+                queueFamilyIndices.compute = queueFamilyIndices.graphics;
+            }
 
-			// Dedicated transfer queue
-			if (requestedQueueTypes & VK_QUEUE_TRANSFER_BIT)
-			{
-				queueFamilyIndices.transfer = getQueueFamilyIndex(VK_QUEUE_TRANSFER_BIT);
-				if ((queueFamilyIndices.transfer != queueFamilyIndices.graphics) && (queueFamilyIndices.transfer != queueFamilyIndices.compute))
-				{
-					// If compute family index differs, we need an additional queue create info for the compute queue
-					VkDeviceQueueCreateInfo queueInfo{};
-					queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-					queueInfo.queueFamilyIndex = queueFamilyIndices.transfer;
-					queueInfo.queueCount = 1;
-					queueInfo.pQueuePriorities = &defaultQueuePriority;
-					queueCreateInfos.push_back(queueInfo);
-				}
-			}
-			else
-			{
-				// Else we use the same queue
-				queueFamilyIndices.transfer = queueFamilyIndices.graphics;
-			}
+            // Dedicated transfer queue
+            if (requestedQueueTypes & VK_QUEUE_TRANSFER_BIT)
+            {
+                queueFamilyIndices.transfer = getQueueFamilyIndex(VK_QUEUE_TRANSFER_BIT);
+                if ((queueFamilyIndices.transfer != queueFamilyIndices.graphics) && (queueFamilyIndices.transfer != queueFamilyIndices.compute))
+                {
+                    // If compute family index differs, we need an additional queue create info for the compute queue
+                    VkDeviceQueueCreateInfo queueInfo{};
+                    queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+                    queueInfo.queueFamilyIndex = queueFamilyIndices.transfer;
+                    queueInfo.queueCount = 1;
+                    queueInfo.pQueuePriorities = &defaultQueuePriority;
+                    queueCreateInfos.push_back(queueInfo);
+                }
+            }
+            else
+            {
+                // Else we use the same queue
+                queueFamilyIndices.transfer = queueFamilyIndices.graphics;
+            }
 
-			// Create the logical device representation
-			std::vector<const char*> deviceExtensions(enabledExtensions);
-			if (useSwapChain)
-			{
-				// If the device will be used for presenting to a display via a swapchain we need to request the swapchain extension
-				deviceExtensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
-			}
+            // Create the logical device representation
+            std::vector<const char*> deviceExtensions(enabledExtensions);
+            if (useSwapChain)
+            {
+                // If the device will be used for presenting to a display via a swapchain we need to request the swapchain extension
+                deviceExtensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+            }
 
-			VkDeviceCreateInfo deviceCreateInfo = {};
-			deviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-			deviceCreateInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());;
-			deviceCreateInfo.pQueueCreateInfos = queueCreateInfos.data();
-			deviceCreateInfo.pEnabledFeatures = &enabledFeatures;
-		
-			// If a pNext(Chain) has been passed, we need to add it to the device creation info
-			if (pNextChain) {
-				VkPhysicalDeviceFeatures2 physicalDeviceFeatures2{};
-				physicalDeviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-				physicalDeviceFeatures2.features = enabledFeatures;
-				physicalDeviceFeatures2.pNext = pNextChain;
-				deviceCreateInfo.pEnabledFeatures = nullptr;
-				deviceCreateInfo.pNext = &physicalDeviceFeatures2;
-			}
+            VkDeviceCreateInfo deviceCreateInfo = {};
+            deviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+            deviceCreateInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
+            ;
+            deviceCreateInfo.pQueueCreateInfos = queueCreateInfos.data();
+            deviceCreateInfo.pEnabledFeatures = &enabledFeatures;
 
-			// Enable the debug marker extension if it is present (likely meaning a debugging tool is present)
-			if (extensionSupported(VK_EXT_DEBUG_MARKER_EXTENSION_NAME))
-			{
-				deviceExtensions.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
-				enableDebugMarkers = true;
-			}
+            // If a pNext(Chain) has been passed, we need to add it to the device creation info
+            if (pNextChain)
+            {
+                VkPhysicalDeviceFeatures2 physicalDeviceFeatures2{};
+                physicalDeviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+                physicalDeviceFeatures2.features = enabledFeatures;
+                physicalDeviceFeatures2.pNext = pNextChain;
+                deviceCreateInfo.pEnabledFeatures = nullptr;
+                deviceCreateInfo.pNext = &physicalDeviceFeatures2;
+            }
 
-			if (deviceExtensions.size() > 0)
-			{
-				deviceCreateInfo.enabledExtensionCount = (uint32_t)deviceExtensions.size();
-				deviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.data();
-			}
+            // Enable the debug marker extension if it is present (likely meaning a debugging tool is present)
+            if (extensionSupported(VK_EXT_DEBUG_MARKER_EXTENSION_NAME))
+            {
+                deviceExtensions.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+                enableDebugMarkers = true;
+            }
 
-			VkResult result = vkCreateDevice(physicalDevice, &deviceCreateInfo, nullptr, &logicalDevice);
+            if (deviceExtensions.size() > 0)
+            {
+                deviceCreateInfo.enabledExtensionCount = (uint32_t)deviceExtensions.size();
+                deviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.data();
+            }
 
-			if (result == VK_SUCCESS)
-			{
-				// Create a default command pool for graphics command buffers
-				commandPool = createCommandPool(queueFamilyIndices.graphics);
-			}
+            VkResult result = vkCreateDevice(physicalDevice, &deviceCreateInfo, nullptr, &logicalDevice);
 
-			this->enabledFeatures = enabledFeatures;
+            if (result == VK_SUCCESS)
+            {
+                // Create a default command pool for graphics command buffers
+                commandPool = createCommandPool(queueFamilyIndices.graphics);
+            }
 
-			return result;
-		}
+            this->enabledFeatures = enabledFeatures;
 
-		/**
+            return result;
+        }
+
+        /**
 		* Create a buffer on the device
 		*
 		* @param usageFlags Usage flag bitmask for the buffer (i.e. index, vertex, uniform buffer)
@@ -347,47 +357,52 @@ namespace vks
 		*
 		* @return VK_SUCCESS if buffer handle and memory have been created and (optionally passed) data has been copied
 		*/
-		VkResult createBuffer(VkBufferUsageFlags usageFlags, VkMemoryPropertyFlags memoryPropertyFlags, VkDeviceSize size, VkBuffer *buffer, VkDeviceMemory *memory, void *data = nullptr)
-		{
-			// Create the buffer handle
-			VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo(usageFlags, size);
-			bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			VK_CHECK_RESULT(vkCreateBuffer(logicalDevice, &bufferCreateInfo, nullptr, buffer));
+        VkResult createBuffer(VkBufferUsageFlags usageFlags,
+                              VkMemoryPropertyFlags memoryPropertyFlags,
+                              VkDeviceSize size,
+                              VkBuffer* buffer,
+                              VkDeviceMemory* memory,
+                              void* data = nullptr)
+        {
+            // Create the buffer handle
+            VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo(usageFlags, size);
+            bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            VK_CHECK_RESULT(vkCreateBuffer(logicalDevice, &bufferCreateInfo, nullptr, buffer));
 
-			// Create the memory backing up the buffer handle
-			VkMemoryRequirements memReqs;
-			VkMemoryAllocateInfo memAlloc = vks::initializers::memoryAllocateInfo();
-			vkGetBufferMemoryRequirements(logicalDevice, *buffer, &memReqs);
-			memAlloc.allocationSize = memReqs.size;
-			// Find a memory type index that fits the properties of the buffer
-			memAlloc.memoryTypeIndex = getMemoryType(memReqs.memoryTypeBits, memoryPropertyFlags);
-			VK_CHECK_RESULT(vkAllocateMemory(logicalDevice, &memAlloc, nullptr, memory));
-			
-			// If a pointer to the buffer data has been passed, map the buffer and copy over the data
-			if (data != nullptr)
-			{
-				void *mapped;
-				VK_CHECK_RESULT(vkMapMemory(logicalDevice, *memory, 0, size, 0, &mapped));
-				memcpy(mapped, data, size);
-				// If host coherency hasn't been requested, do a manual flush to make writes visible
-				if ((memoryPropertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0)
-				{
-					VkMappedMemoryRange mappedRange = vks::initializers::mappedMemoryRange();
-					mappedRange.memory = *memory;
-					mappedRange.offset = 0;
-					mappedRange.size = size;
-					vkFlushMappedMemoryRanges(logicalDevice, 1, &mappedRange);
-				}
-				vkUnmapMemory(logicalDevice, *memory);
-			}
+            // Create the memory backing up the buffer handle
+            VkMemoryRequirements memReqs;
+            VkMemoryAllocateInfo memAlloc = vks::initializers::memoryAllocateInfo();
+            vkGetBufferMemoryRequirements(logicalDevice, *buffer, &memReqs);
+            memAlloc.allocationSize = memReqs.size;
+            // Find a memory type index that fits the properties of the buffer
+            memAlloc.memoryTypeIndex = getMemoryType(memReqs.memoryTypeBits, memoryPropertyFlags);
+            VK_CHECK_RESULT(vkAllocateMemory(logicalDevice, &memAlloc, nullptr, memory));
 
-			// Attach the memory to the buffer object
-			VK_CHECK_RESULT(vkBindBufferMemory(logicalDevice, *buffer, *memory, 0));
+            // If a pointer to the buffer data has been passed, map the buffer and copy over the data
+            if (data != nullptr)
+            {
+                void* mapped;
+                VK_CHECK_RESULT(vkMapMemory(logicalDevice, *memory, 0, size, 0, &mapped));
+                memcpy(mapped, data, size);
+                // If host coherency hasn't been requested, do a manual flush to make writes visible
+                if ((memoryPropertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0)
+                {
+                    VkMappedMemoryRange mappedRange = vks::initializers::mappedMemoryRange();
+                    mappedRange.memory = *memory;
+                    mappedRange.offset = 0;
+                    mappedRange.size = size;
+                    vkFlushMappedMemoryRanges(logicalDevice, 1, &mappedRange);
+                }
+                vkUnmapMemory(logicalDevice, *memory);
+            }
 
-			return VK_SUCCESS;
-		}
+            // Attach the memory to the buffer object
+            VK_CHECK_RESULT(vkBindBufferMemory(logicalDevice, *buffer, *memory, 0));
 
-		/**
+            return VK_SUCCESS;
+        }
+
+        /**
 		* Create a buffer on the device
 		*
 		* @param usageFlags Usage flag bitmask for the buffer (i.e. index, vertex, uniform buffer)
@@ -398,47 +413,51 @@ namespace vks
 		*
 		* @return VK_SUCCESS if buffer handle and memory have been created and (optionally passed) data has been copied
 		*/
-		VkResult createBuffer(VkBufferUsageFlags usageFlags, VkMemoryPropertyFlags memoryPropertyFlags, vks::Buffer *buffer, VkDeviceSize size, void *data = nullptr)
-		{
-			buffer->device = logicalDevice;
+        VkResult createBuffer(VkBufferUsageFlags usageFlags,
+                              VkMemoryPropertyFlags memoryPropertyFlags,
+                              vks::Buffer* buffer,
+                              VkDeviceSize size,
+                              void* data = nullptr)
+        {
+            buffer->device = logicalDevice;
 
-			// Create the buffer handle
-			VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo(usageFlags, size);
-			VK_CHECK_RESULT(vkCreateBuffer(logicalDevice, &bufferCreateInfo, nullptr, &buffer->buffer));
+            // Create the buffer handle
+            VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo(usageFlags, size);
+            VK_CHECK_RESULT(vkCreateBuffer(logicalDevice, &bufferCreateInfo, nullptr, &buffer->buffer));
 
-			// Create the memory backing up the buffer handle
-			VkMemoryRequirements memReqs;
-			VkMemoryAllocateInfo memAlloc = vks::initializers::memoryAllocateInfo();
-			vkGetBufferMemoryRequirements(logicalDevice, buffer->buffer, &memReqs);
-			memAlloc.allocationSize = memReqs.size;
-			// Find a memory type index that fits the properties of the buffer
-			memAlloc.memoryTypeIndex = getMemoryType(memReqs.memoryTypeBits, memoryPropertyFlags);
-			VK_CHECK_RESULT(vkAllocateMemory(logicalDevice, &memAlloc, nullptr, &buffer->memory));
+            // Create the memory backing up the buffer handle
+            VkMemoryRequirements memReqs;
+            VkMemoryAllocateInfo memAlloc = vks::initializers::memoryAllocateInfo();
+            vkGetBufferMemoryRequirements(logicalDevice, buffer->buffer, &memReqs);
+            memAlloc.allocationSize = memReqs.size;
+            // Find a memory type index that fits the properties of the buffer
+            memAlloc.memoryTypeIndex = getMemoryType(memReqs.memoryTypeBits, memoryPropertyFlags);
+            VK_CHECK_RESULT(vkAllocateMemory(logicalDevice, &memAlloc, nullptr, &buffer->memory));
 
-			buffer->alignment = memReqs.alignment;
-			buffer->size = memAlloc.allocationSize;
-			buffer->usageFlags = usageFlags;
-			buffer->memoryPropertyFlags = memoryPropertyFlags;
+            buffer->alignment = memReqs.alignment;
+            buffer->size = memAlloc.allocationSize;
+            buffer->usageFlags = usageFlags;
+            buffer->memoryPropertyFlags = memoryPropertyFlags;
 
-			// If a pointer to the buffer data has been passed, map the buffer and copy over the data
-			if (data != nullptr)
-			{
-				VK_CHECK_RESULT(buffer->map());
-				memcpy(buffer->mapped, data, size);
-				if ((memoryPropertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0)
-					buffer->flush();
+            // If a pointer to the buffer data has been passed, map the buffer and copy over the data
+            if (data != nullptr)
+            {
+                VK_CHECK_RESULT(buffer->map());
+                memcpy(buffer->mapped, data, size);
+                if ((memoryPropertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0)
+                    buffer->flush();
 
-				buffer->unmap();
-			}
+                buffer->unmap();
+            }
 
-			// Initialize a default descriptor that covers the whole buffer size
-			buffer->setupDescriptor();
+            // Initialize a default descriptor that covers the whole buffer size
+            buffer->setupDescriptor();
 
-			// Attach the memory to the buffer object
-			return buffer->bind();
-		}
+            // Attach the memory to the buffer object
+            return buffer->bind();
+        }
 
-		/**
+        /**
 		* Copy buffer data from src to dst using VkCmdCopyBuffer
 		* 
 		* @param src Pointer to the source buffer to copy from
@@ -448,27 +467,27 @@ namespace vks
 		*
 		* @note Source and destionation pointers must have the approriate transfer usage flags set (TRANSFER_SRC / TRANSFER_DST)
 		*/
-		void copyBuffer(vks::Buffer *src, vks::Buffer *dst, VkQueue queue, VkBufferCopy *copyRegion = nullptr)
-		{
-			assert(dst->size <= src->size);
-			assert(src->buffer);
-			VkCommandBuffer copyCmd = createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
-			VkBufferCopy bufferCopy{};
-			if (copyRegion == nullptr)
-			{
-				bufferCopy.size = src->size;
-			}
-			else
-			{
-				bufferCopy = *copyRegion;
-			}
+        void copyBuffer(vks::Buffer* src, vks::Buffer* dst, VkQueue queue, VkBufferCopy* copyRegion = nullptr)
+        {
+            assert(dst->size <= src->size);
+            assert(src->buffer);
+            VkCommandBuffer copyCmd = createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+            VkBufferCopy bufferCopy{};
+            if (copyRegion == nullptr)
+            {
+                bufferCopy.size = src->size;
+            }
+            else
+            {
+                bufferCopy = *copyRegion;
+            }
 
-			vkCmdCopyBuffer(copyCmd, src->buffer, dst->buffer, 1, &bufferCopy);
+            vkCmdCopyBuffer(copyCmd, src->buffer, dst->buffer, 1, &bufferCopy);
 
-			flushCommandBuffer(copyCmd, queue);
-		}
+            flushCommandBuffer(copyCmd, queue);
+        }
 
-		/** 
+        /** 
 		* Create a command pool for allocation command buffers from
 		* 
 		* @param queueFamilyIndex Family index of the queue to create the command pool for
@@ -478,18 +497,18 @@ namespace vks
 		*
 		* @return A handle to the created command buffer
 		*/
-		VkCommandPool createCommandPool(uint32_t queueFamilyIndex, VkCommandPoolCreateFlags createFlags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)
-		{
-			VkCommandPoolCreateInfo cmdPoolInfo = {};
-			cmdPoolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-			cmdPoolInfo.queueFamilyIndex = queueFamilyIndex;
-			cmdPoolInfo.flags = createFlags;
-			VkCommandPool cmdPool;
-			VK_CHECK_RESULT(vkCreateCommandPool(logicalDevice, &cmdPoolInfo, nullptr, &cmdPool));
-			return cmdPool;
-		}
+        VkCommandPool createCommandPool(uint32_t queueFamilyIndex, VkCommandPoolCreateFlags createFlags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)
+        {
+            VkCommandPoolCreateInfo cmdPoolInfo = {};
+            cmdPoolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+            cmdPoolInfo.queueFamilyIndex = queueFamilyIndex;
+            cmdPoolInfo.flags = createFlags;
+            VkCommandPool cmdPool;
+            VK_CHECK_RESULT(vkCreateCommandPool(logicalDevice, &cmdPoolInfo, nullptr, &cmdPool));
+            return cmdPool;
+        }
 
-		/**
+        /**
 		* Allocate a command buffer from the command pool
 		*
 		* @param level Level of the new command buffer (primary or secondary)
@@ -497,24 +516,24 @@ namespace vks
 		*
 		* @return A handle to the allocated command buffer
 		*/
-		VkCommandBuffer createCommandBuffer(VkCommandBufferLevel level, bool begin = false)
-		{
-			VkCommandBufferAllocateInfo cmdBufAllocateInfo = vks::initializers::commandBufferAllocateInfo(commandPool, level, 1);
+        VkCommandBuffer createCommandBuffer(VkCommandBufferLevel level, bool begin = false)
+        {
+            VkCommandBufferAllocateInfo cmdBufAllocateInfo = vks::initializers::commandBufferAllocateInfo(commandPool, level, 1);
 
-			VkCommandBuffer cmdBuffer;
-			VK_CHECK_RESULT(vkAllocateCommandBuffers(logicalDevice, &cmdBufAllocateInfo, &cmdBuffer));
+            VkCommandBuffer cmdBuffer;
+            VK_CHECK_RESULT(vkAllocateCommandBuffers(logicalDevice, &cmdBufAllocateInfo, &cmdBuffer));
 
-			// If requested, also start recording for the new command buffer
-			if (begin)
-			{
-				VkCommandBufferBeginInfo cmdBufInfo = vks::initializers::commandBufferBeginInfo();
-				VK_CHECK_RESULT(vkBeginCommandBuffer(cmdBuffer, &cmdBufInfo));
-			}
+            // If requested, also start recording for the new command buffer
+            if (begin)
+            {
+                VkCommandBufferBeginInfo cmdBufInfo = vks::initializers::commandBufferBeginInfo();
+                VK_CHECK_RESULT(vkBeginCommandBuffer(cmdBuffer, &cmdBufInfo));
+            }
 
-			return cmdBuffer;
-		}
+            return cmdBuffer;
+        }
 
-		/**
+        /**
 		* Finish command buffer recording and submit it to a queue
 		*
 		* @param commandBuffer Command buffer to flush
@@ -524,50 +543,50 @@ namespace vks
 		* @note The queue that the command buffer is submitted to must be from the same family index as the pool it was allocated from
 		* @note Uses a fence to ensure command buffer has finished executing
 		*/
-		void flushCommandBuffer(VkCommandBuffer commandBuffer, VkQueue queue, bool free = true)
-		{
-			if (commandBuffer == VK_NULL_HANDLE)
-			{
-				return;
-			}
+        void flushCommandBuffer(VkCommandBuffer commandBuffer, VkQueue queue, bool free = true)
+        {
+            if (commandBuffer == VK_NULL_HANDLE)
+            {
+                return;
+            }
 
-			VK_CHECK_RESULT(vkEndCommandBuffer(commandBuffer));
+            VK_CHECK_RESULT(vkEndCommandBuffer(commandBuffer));
 
-			VkSubmitInfo submitInfo = vks::initializers::submitInfo();
-			submitInfo.commandBufferCount = 1;
-			submitInfo.pCommandBuffers = &commandBuffer;
+            VkSubmitInfo submitInfo = vks::initializers::submitInfo();
+            submitInfo.commandBufferCount = 1;
+            submitInfo.pCommandBuffers = &commandBuffer;
 
-			// Create fence to ensure that the command buffer has finished executing
-			VkFenceCreateInfo fenceInfo = vks::initializers::fenceCreateInfo(VK_FLAGS_NONE);
-			VkFence fence;
-			VK_CHECK_RESULT(vkCreateFence(logicalDevice, &fenceInfo, nullptr, &fence));
-			
-			// Submit to the queue
-			VK_CHECK_RESULT(vkQueueSubmit(queue, 1, &submitInfo, fence));
-			// Wait for the fence to signal that command buffer has finished executing
-			VK_CHECK_RESULT(vkWaitForFences(logicalDevice, 1, &fence, VK_TRUE, DEFAULT_FENCE_TIMEOUT));
+            // Create fence to ensure that the command buffer has finished executing
+            VkFenceCreateInfo fenceInfo = vks::initializers::fenceCreateInfo(VK_FLAGS_NONE);
+            VkFence fence;
+            VK_CHECK_RESULT(vkCreateFence(logicalDevice, &fenceInfo, nullptr, &fence));
 
-			vkDestroyFence(logicalDevice, fence, nullptr);
+            // Submit to the queue
+            VK_CHECK_RESULT(vkQueueSubmit(queue, 1, &submitInfo, fence));
+            // Wait for the fence to signal that command buffer has finished executing
+            VK_CHECK_RESULT(vkWaitForFences(logicalDevice, 1, &fence, VK_TRUE, DEFAULT_FENCE_TIMEOUT));
 
-			if (free)
-			{
-				vkFreeCommandBuffers(logicalDevice, commandPool, 1, &commandBuffer);
-			}
-		}
+            vkDestroyFence(logicalDevice, fence, nullptr);
 
-		/**
+            if (free)
+            {
+                vkFreeCommandBuffers(logicalDevice, commandPool, 1, &commandBuffer);
+            }
+        }
+
+        /**
 		* Check if an extension is supported by the (physical device)
 		*
 		* @param extension Name of the extension to check
 		*
 		* @return True if the extension is supported (present in the list read at device creation time)
 		*/
-		bool extensionSupported(std::string extension)
-		{
-			return (std::find(supportedExtensions.begin(), supportedExtensions.end(), extension) != supportedExtensions.end());
-		}
+        bool extensionSupported(std::string extension)
+        {
+            return (std::find(supportedExtensions.begin(), supportedExtensions.end(), extension) != supportedExtensions.end());
+        }
 
-		/**
+        /**
 		* Select the best-fit depth format for this device from a list of possible depth (and stencil) formats
 		*
 		* @param checkSamplingSupport Check if the format can be sampled from (e.g. for shader reads)
@@ -576,27 +595,29 @@ namespace vks
 		*
 		* @throw Throws an exception if no depth format fits the requirements
 		*/
-		VkFormat getSupportedDepthFormat(bool checkSamplingSupport)
-		{
-			// All depth formats may be optional, so we need to find a suitable depth format to use
-			std::vector<VkFormat> depthFormats = { VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D32_SFLOAT, VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D16_UNORM_S8_UINT, VK_FORMAT_D16_UNORM };
-			for (auto& format : depthFormats)
-			{
-				VkFormatProperties formatProperties;
-				vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
-				// Format must support depth stencil attachment for optimal tiling
-				if (formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
-				{
-					if (checkSamplingSupport) {
-						if (!(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
-							continue;
-						}
-					}
-					return format;
-				}
-			}
-			throw std::runtime_error("Could not find a matching depth format");
-		}
-
-	};
-}
+        VkFormat getSupportedDepthFormat(bool checkSamplingSupport)
+        {
+            // All depth formats may be optional, so we need to find a suitable depth format to use
+            std::vector<VkFormat> depthFormats = { VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D32_SFLOAT, VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D16_UNORM_S8_UINT,
+                                                   VK_FORMAT_D16_UNORM };
+            for (auto& format : depthFormats)
+            {
+                VkFormatProperties formatProperties;
+                vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProperties);
+                // Format must support depth stencil attachment for optimal tiling
+                if (formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
+                {
+                    if (checkSamplingSupport)
+                    {
+                        if (!(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT))
+                        {
+                            continue;
+                        }
+                    }
+                    return format;
+                }
+            }
+            throw std::runtime_error("Could not find a matching depth format");
+        }
+    };
+}  // namespace vks

--- a/base/VulkanFrameBuffer.hpp
+++ b/base/VulkanFrameBuffer.hpp
@@ -17,214 +17,208 @@
 
 namespace vks
 {
-	/**
+    /**
 	* @brief Encapsulates a single frame buffer attachment 
 	*/
-	struct FramebufferAttachment
-	{
-		VkImage image;
-		VkDeviceMemory memory;
-		VkImageView view;
-		VkFormat format;
-		VkImageSubresourceRange subresourceRange;
-		VkAttachmentDescription description;
+    struct FramebufferAttachment
+    {
+        VkImage image;
+        VkDeviceMemory memory;
+        VkImageView view;
+        VkFormat format;
+        VkImageSubresourceRange subresourceRange;
+        VkAttachmentDescription description;
 
-		/**
+        /**
 		* @brief Returns true if the attachment has a depth component
 		*/
-		bool hasDepth()
-		{
-			std::vector<VkFormat> formats = 
-			{
-				VK_FORMAT_D16_UNORM,
-				VK_FORMAT_X8_D24_UNORM_PACK32,
-				VK_FORMAT_D32_SFLOAT,
-				VK_FORMAT_D16_UNORM_S8_UINT,
-				VK_FORMAT_D24_UNORM_S8_UINT,
-				VK_FORMAT_D32_SFLOAT_S8_UINT,
-			};
-			return std::find(formats.begin(), formats.end(), format) != std::end(formats);
-		}
+        bool hasDepth()
+        {
+            std::vector<VkFormat> formats = {
+                VK_FORMAT_D16_UNORM,         VK_FORMAT_X8_D24_UNORM_PACK32, VK_FORMAT_D32_SFLOAT,
+                VK_FORMAT_D16_UNORM_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT,   VK_FORMAT_D32_SFLOAT_S8_UINT,
+            };
+            return std::find(formats.begin(), formats.end(), format) != std::end(formats);
+        }
 
-		/**
+        /**
 		* @brief Returns true if the attachment has a stencil component
 		*/
-		bool hasStencil()
-		{
-			std::vector<VkFormat> formats = 
-			{
-				VK_FORMAT_S8_UINT,
-				VK_FORMAT_D16_UNORM_S8_UINT,
-				VK_FORMAT_D24_UNORM_S8_UINT,
-				VK_FORMAT_D32_SFLOAT_S8_UINT,
-			};
-			return std::find(formats.begin(), formats.end(), format) != std::end(formats);
-		}
+        bool hasStencil()
+        {
+            std::vector<VkFormat> formats = {
+                VK_FORMAT_S8_UINT,
+                VK_FORMAT_D16_UNORM_S8_UINT,
+                VK_FORMAT_D24_UNORM_S8_UINT,
+                VK_FORMAT_D32_SFLOAT_S8_UINT,
+            };
+            return std::find(formats.begin(), formats.end(), format) != std::end(formats);
+        }
 
-		/**
+        /**
 		* @brief Returns true if the attachment is a depth and/or stencil attachment
 		*/
-		bool isDepthStencil()
-		{
-			return(hasDepth() || hasStencil());
-		}
+        bool isDepthStencil()
+        {
+            return (hasDepth() || hasStencil());
+        }
+    };
 
-	};
-
-	/**
+    /**
 	* @brief Describes the attributes of an attachment to be created
 	*/
-	struct AttachmentCreateInfo
-	{
-		uint32_t width, height;
-		uint32_t layerCount;
-		VkFormat format;
-		VkImageUsageFlags usage;
-	};
+    struct AttachmentCreateInfo
+    {
+        uint32_t width, height;
+        uint32_t layerCount;
+        VkFormat format;
+        VkImageUsageFlags usage;
+    };
 
-	/**
+    /**
 	* @brief Encapsulates a complete Vulkan framebuffer with an arbitrary number and combination of attachments
 	*/
-	struct Framebuffer
-	{
-	private:
-		vks::VulkanDevice *vulkanDevice;
-	public:
-		uint32_t width, height;
-		VkFramebuffer framebuffer;
-		VkRenderPass renderPass;
-		VkSampler sampler;
-		std::vector<vks::FramebufferAttachment> attachments;
+    struct Framebuffer
+    {
+    private:
+        vks::VulkanDevice* vulkanDevice;
 
-		/**
+    public:
+        uint32_t width, height;
+        VkFramebuffer framebuffer;
+        VkRenderPass renderPass;
+        VkSampler sampler;
+        std::vector<vks::FramebufferAttachment> attachments;
+
+        /**
 		* Default constructor
 		*
 		* @param vulkanDevice Pointer to a valid VulkanDevice
 		*/
-		Framebuffer(vks::VulkanDevice *vulkanDevice)
-		{
-			assert(vulkanDevice);
-			this->vulkanDevice = vulkanDevice;
-		}
+        Framebuffer(vks::VulkanDevice* vulkanDevice)
+        {
+            assert(vulkanDevice);
+            this->vulkanDevice = vulkanDevice;
+        }
 
-		/**
+        /**
 		* Destroy and free Vulkan resources used for the framebuffer and all of it's attachments
 		*/
-		~Framebuffer()
-		{
-			assert(vulkanDevice);
-			for (auto attachment : attachments)
-			{
-				vkDestroyImage(vulkanDevice->logicalDevice, attachment.image, nullptr);
-				vkDestroyImageView(vulkanDevice->logicalDevice, attachment.view, nullptr);
-				vkFreeMemory(vulkanDevice->logicalDevice, attachment.memory, nullptr);
-			}
-			vkDestroySampler(vulkanDevice->logicalDevice, sampler, nullptr);
-			vkDestroyRenderPass(vulkanDevice->logicalDevice, renderPass, nullptr);
-			vkDestroyFramebuffer(vulkanDevice->logicalDevice, framebuffer, nullptr);
-		}
+        ~Framebuffer()
+        {
+            assert(vulkanDevice);
+            for (auto attachment : attachments)
+            {
+                vkDestroyImage(vulkanDevice->logicalDevice, attachment.image, nullptr);
+                vkDestroyImageView(vulkanDevice->logicalDevice, attachment.view, nullptr);
+                vkFreeMemory(vulkanDevice->logicalDevice, attachment.memory, nullptr);
+            }
+            vkDestroySampler(vulkanDevice->logicalDevice, sampler, nullptr);
+            vkDestroyRenderPass(vulkanDevice->logicalDevice, renderPass, nullptr);
+            vkDestroyFramebuffer(vulkanDevice->logicalDevice, framebuffer, nullptr);
+        }
 
-		/**
+        /**
 		* Add a new attachment described by createinfo to the framebuffer's attachment list
 		*
 		* @param createinfo Structure that specifices the framebuffer to be constructed
 		*
 		* @return Index of the new attachment
 		*/
-		uint32_t addAttachment(vks::AttachmentCreateInfo createinfo)
-		{
-			vks::FramebufferAttachment attachment;
+        uint32_t addAttachment(vks::AttachmentCreateInfo createinfo)
+        {
+            vks::FramebufferAttachment attachment;
 
-			attachment.format = createinfo.format;
+            attachment.format = createinfo.format;
 
-			VkImageAspectFlags aspectMask = VK_FLAGS_NONE;
+            VkImageAspectFlags aspectMask = VK_FLAGS_NONE;
 
-			// Select aspect mask and layout depending on usage
+            // Select aspect mask and layout depending on usage
 
-			// Color attachment
-			if (createinfo.usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-			{
-				aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			}
+            // Color attachment
+            if (createinfo.usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
+            {
+                aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            }
 
-			// Depth (and/or stencil) attachment
-			if (createinfo.usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
-			{
-				if (attachment.hasDepth())
-				{
-					aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-				}
-				if (attachment.hasStencil())
-				{
-					aspectMask = aspectMask | VK_IMAGE_ASPECT_STENCIL_BIT;
-				}
-			}
+            // Depth (and/or stencil) attachment
+            if (createinfo.usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
+            {
+                if (attachment.hasDepth())
+                {
+                    aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+                }
+                if (attachment.hasStencil())
+                {
+                    aspectMask = aspectMask | VK_IMAGE_ASPECT_STENCIL_BIT;
+                }
+            }
 
-			assert(aspectMask > 0);
+            assert(aspectMask > 0);
 
-			VkImageCreateInfo image = vks::initializers::imageCreateInfo();
-			image.imageType = VK_IMAGE_TYPE_2D;
-			image.format = createinfo.format;
-			image.extent.width = createinfo.width;
-			image.extent.height = createinfo.height;
-			image.extent.depth = 1;
-			image.mipLevels = 1;
-			image.arrayLayers = createinfo.layerCount;
-			image.samples = VK_SAMPLE_COUNT_1_BIT;
-			image.tiling = VK_IMAGE_TILING_OPTIMAL;
-			image.usage = createinfo.usage;
+            VkImageCreateInfo image = vks::initializers::imageCreateInfo();
+            image.imageType = VK_IMAGE_TYPE_2D;
+            image.format = createinfo.format;
+            image.extent.width = createinfo.width;
+            image.extent.height = createinfo.height;
+            image.extent.depth = 1;
+            image.mipLevels = 1;
+            image.arrayLayers = createinfo.layerCount;
+            image.samples = VK_SAMPLE_COUNT_1_BIT;
+            image.tiling = VK_IMAGE_TILING_OPTIMAL;
+            image.usage = createinfo.usage;
 
-			VkMemoryAllocateInfo memAlloc = vks::initializers::memoryAllocateInfo();
-			VkMemoryRequirements memReqs;
+            VkMemoryAllocateInfo memAlloc = vks::initializers::memoryAllocateInfo();
+            VkMemoryRequirements memReqs;
 
-			// Create image for this attachment
-			VK_CHECK_RESULT(vkCreateImage(vulkanDevice->logicalDevice, &image, nullptr, &attachment.image));
-			vkGetImageMemoryRequirements(vulkanDevice->logicalDevice, attachment.image, &memReqs);
-			memAlloc.allocationSize = memReqs.size;
-			memAlloc.memoryTypeIndex = vulkanDevice->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-			VK_CHECK_RESULT(vkAllocateMemory(vulkanDevice->logicalDevice, &memAlloc, nullptr, &attachment.memory));
-			VK_CHECK_RESULT(vkBindImageMemory(vulkanDevice->logicalDevice, attachment.image, attachment.memory, 0));
+            // Create image for this attachment
+            VK_CHECK_RESULT(vkCreateImage(vulkanDevice->logicalDevice, &image, nullptr, &attachment.image));
+            vkGetImageMemoryRequirements(vulkanDevice->logicalDevice, attachment.image, &memReqs);
+            memAlloc.allocationSize = memReqs.size;
+            memAlloc.memoryTypeIndex = vulkanDevice->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            VK_CHECK_RESULT(vkAllocateMemory(vulkanDevice->logicalDevice, &memAlloc, nullptr, &attachment.memory));
+            VK_CHECK_RESULT(vkBindImageMemory(vulkanDevice->logicalDevice, attachment.image, attachment.memory, 0));
 
-			attachment.subresourceRange = {};
-			attachment.subresourceRange.aspectMask = aspectMask;
-			attachment.subresourceRange.levelCount = 1;
-			attachment.subresourceRange.layerCount = createinfo.layerCount;
+            attachment.subresourceRange = {};
+            attachment.subresourceRange.aspectMask = aspectMask;
+            attachment.subresourceRange.levelCount = 1;
+            attachment.subresourceRange.layerCount = createinfo.layerCount;
 
-			VkImageViewCreateInfo imageView = vks::initializers::imageViewCreateInfo();
-			imageView.viewType = (createinfo.layerCount == 1) ? VK_IMAGE_VIEW_TYPE_2D : VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-			imageView.format = createinfo.format;
-			imageView.subresourceRange = attachment.subresourceRange;
-			//todo: workaround for depth+stencil attachments
-			imageView.subresourceRange.aspectMask = (attachment.hasDepth()) ? VK_IMAGE_ASPECT_DEPTH_BIT : aspectMask;
-			imageView.image = attachment.image;
-			VK_CHECK_RESULT(vkCreateImageView(vulkanDevice->logicalDevice, &imageView, nullptr, &attachment.view));
+            VkImageViewCreateInfo imageView = vks::initializers::imageViewCreateInfo();
+            imageView.viewType = (createinfo.layerCount == 1) ? VK_IMAGE_VIEW_TYPE_2D : VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+            imageView.format = createinfo.format;
+            imageView.subresourceRange = attachment.subresourceRange;
+            //todo: workaround for depth+stencil attachments
+            imageView.subresourceRange.aspectMask = (attachment.hasDepth()) ? VK_IMAGE_ASPECT_DEPTH_BIT : aspectMask;
+            imageView.image = attachment.image;
+            VK_CHECK_RESULT(vkCreateImageView(vulkanDevice->logicalDevice, &imageView, nullptr, &attachment.view));
 
-			// Fill attachment description
-			attachment.description = {};
-			attachment.description.samples = VK_SAMPLE_COUNT_1_BIT;
-			attachment.description.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-			attachment.description.storeOp = (createinfo.usage & VK_IMAGE_USAGE_SAMPLED_BIT) ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE;
-			attachment.description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-			attachment.description.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-			attachment.description.format = createinfo.format;
-			attachment.description.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-			// Final layout
-			// If not, final layout depends on attachment type
-			if (attachment.hasDepth() || attachment.hasStencil())
-			{
-				attachment.description.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
-			}
-			else
-			{
-				attachment.description.finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-			}
+            // Fill attachment description
+            attachment.description = {};
+            attachment.description.samples = VK_SAMPLE_COUNT_1_BIT;
+            attachment.description.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+            attachment.description.storeOp = (createinfo.usage & VK_IMAGE_USAGE_SAMPLED_BIT) ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            attachment.description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+            attachment.description.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            attachment.description.format = createinfo.format;
+            attachment.description.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            // Final layout
+            // If not, final layout depends on attachment type
+            if (attachment.hasDepth() || attachment.hasStencil())
+            {
+                attachment.description.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+            }
+            else
+            {
+                attachment.description.finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            }
 
-			attachments.push_back(attachment);
+            attachments.push_back(attachment);
 
-			return static_cast<uint32_t>(attachments.size() - 1);
-		}
+            return static_cast<uint32_t>(attachments.size() - 1);
+        }
 
-		/**
+        /**
 		* Creates a default sampler for sampling from any of the framebuffer attachments
 		* Applications are free to create their own samplers for different use cases 
 		*
@@ -234,132 +228,132 @@ namespace vks
 		*
 		* @return VkResult for the sampler creation
 		*/
-		VkResult createSampler(VkFilter magFilter, VkFilter minFilter, VkSamplerAddressMode adressMode)
-		{
-			VkSamplerCreateInfo samplerInfo = vks::initializers::samplerCreateInfo();
-			samplerInfo.magFilter = magFilter;
-			samplerInfo.minFilter = minFilter;
-			samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-			samplerInfo.addressModeU = adressMode;
-			samplerInfo.addressModeV = adressMode;
-			samplerInfo.addressModeW = adressMode;
-			samplerInfo.mipLodBias = 0.0f;
-			samplerInfo.maxAnisotropy = 1.0f;
-			samplerInfo.minLod = 0.0f;
-			samplerInfo.maxLod = 1.0f;
-			samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-			return vkCreateSampler(vulkanDevice->logicalDevice, &samplerInfo, nullptr, &sampler);
-		}
+        VkResult createSampler(VkFilter magFilter, VkFilter minFilter, VkSamplerAddressMode adressMode)
+        {
+            VkSamplerCreateInfo samplerInfo = vks::initializers::samplerCreateInfo();
+            samplerInfo.magFilter = magFilter;
+            samplerInfo.minFilter = minFilter;
+            samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            samplerInfo.addressModeU = adressMode;
+            samplerInfo.addressModeV = adressMode;
+            samplerInfo.addressModeW = adressMode;
+            samplerInfo.mipLodBias = 0.0f;
+            samplerInfo.maxAnisotropy = 1.0f;
+            samplerInfo.minLod = 0.0f;
+            samplerInfo.maxLod = 1.0f;
+            samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+            return vkCreateSampler(vulkanDevice->logicalDevice, &samplerInfo, nullptr, &sampler);
+        }
 
-		/**
+        /**
 		* Creates a default render pass setup with one sub pass
 		*
 		* @return VK_SUCCESS if all resources have been created successfully
 		*/
-		VkResult createRenderPass()
-		{
-			std::vector<VkAttachmentDescription> attachmentDescriptions;
-			for (auto& attachment : attachments)
-			{
-				attachmentDescriptions.push_back(attachment.description);
-			};
+        VkResult createRenderPass()
+        {
+            std::vector<VkAttachmentDescription> attachmentDescriptions;
+            for (auto& attachment : attachments)
+            {
+                attachmentDescriptions.push_back(attachment.description);
+            };
 
-			// Collect attachment references
-			std::vector<VkAttachmentReference> colorReferences;
-			VkAttachmentReference depthReference = {};
-			bool hasDepth = false; 
-			bool hasColor = false;
+            // Collect attachment references
+            std::vector<VkAttachmentReference> colorReferences;
+            VkAttachmentReference depthReference = {};
+            bool hasDepth = false;
+            bool hasColor = false;
 
-			uint32_t attachmentIndex = 0;
+            uint32_t attachmentIndex = 0;
 
-			for (auto& attachment : attachments)
-			{
-				if (attachment.isDepthStencil())
-				{
-					// Only one depth attachment allowed
-					assert(!hasDepth);
-					depthReference.attachment = attachmentIndex;
-					depthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-					hasDepth = true;
-				}
-				else
-				{
-					colorReferences.push_back({ attachmentIndex, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL });
-					hasColor = true;
-				}
-				attachmentIndex++;
-			};
+            for (auto& attachment : attachments)
+            {
+                if (attachment.isDepthStencil())
+                {
+                    // Only one depth attachment allowed
+                    assert(!hasDepth);
+                    depthReference.attachment = attachmentIndex;
+                    depthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+                    hasDepth = true;
+                }
+                else
+                {
+                    colorReferences.push_back({ attachmentIndex, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL });
+                    hasColor = true;
+                }
+                attachmentIndex++;
+            };
 
-			// Default render pass setup uses only one subpass
-			VkSubpassDescription subpass = {};
-			subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-			if (hasColor)
-			{
-				subpass.pColorAttachments = colorReferences.data();
-				subpass.colorAttachmentCount = static_cast<uint32_t>(colorReferences.size());
-			}
-			if (hasDepth)
-			{
-				subpass.pDepthStencilAttachment = &depthReference;
-			}
+            // Default render pass setup uses only one subpass
+            VkSubpassDescription subpass = {};
+            subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+            if (hasColor)
+            {
+                subpass.pColorAttachments = colorReferences.data();
+                subpass.colorAttachmentCount = static_cast<uint32_t>(colorReferences.size());
+            }
+            if (hasDepth)
+            {
+                subpass.pDepthStencilAttachment = &depthReference;
+            }
 
-			// Use subpass dependencies for attachment layout transitions
-			std::array<VkSubpassDependency, 2> dependencies;
+            // Use subpass dependencies for attachment layout transitions
+            std::array<VkSubpassDependency, 2> dependencies;
 
-			dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-			dependencies[0].dstSubpass = 0;
-			dependencies[0].srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-			dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-			dependencies[0].srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-			dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-			dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+            dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+            dependencies[0].dstSubpass = 0;
+            dependencies[0].srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+            dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            dependencies[0].srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+            dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+            dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 
-			dependencies[1].srcSubpass = 0;
-			dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
-			dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-			dependencies[1].dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-			dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-			dependencies[1].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-			dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+            dependencies[1].srcSubpass = 0;
+            dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+            dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            dependencies[1].dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+            dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+            dependencies[1].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+            dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 
-			// Create render pass
-			VkRenderPassCreateInfo renderPassInfo = {};
-			renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-			renderPassInfo.pAttachments = attachmentDescriptions.data();
-			renderPassInfo.attachmentCount = static_cast<uint32_t>(attachmentDescriptions.size());
-			renderPassInfo.subpassCount = 1;
-			renderPassInfo.pSubpasses = &subpass;
-			renderPassInfo.dependencyCount = 2;
-			renderPassInfo.pDependencies = dependencies.data();
-			VK_CHECK_RESULT(vkCreateRenderPass(vulkanDevice->logicalDevice, &renderPassInfo, nullptr, &renderPass));
+            // Create render pass
+            VkRenderPassCreateInfo renderPassInfo = {};
+            renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+            renderPassInfo.pAttachments = attachmentDescriptions.data();
+            renderPassInfo.attachmentCount = static_cast<uint32_t>(attachmentDescriptions.size());
+            renderPassInfo.subpassCount = 1;
+            renderPassInfo.pSubpasses = &subpass;
+            renderPassInfo.dependencyCount = 2;
+            renderPassInfo.pDependencies = dependencies.data();
+            VK_CHECK_RESULT(vkCreateRenderPass(vulkanDevice->logicalDevice, &renderPassInfo, nullptr, &renderPass));
 
-			std::vector<VkImageView> attachmentViews;
-			for (auto attachment : attachments)
-			{
-				attachmentViews.push_back(attachment.view);
-			}
+            std::vector<VkImageView> attachmentViews;
+            for (auto attachment : attachments)
+            {
+                attachmentViews.push_back(attachment.view);
+            }
 
-			// Find. max number of layers across attachments
-			uint32_t maxLayers = 0;
-			for (auto attachment : attachments)
-			{
-				if (attachment.subresourceRange.layerCount > maxLayers)
-				{
-					maxLayers = attachment.subresourceRange.layerCount;
-				}
-			}
+            // Find. max number of layers across attachments
+            uint32_t maxLayers = 0;
+            for (auto attachment : attachments)
+            {
+                if (attachment.subresourceRange.layerCount > maxLayers)
+                {
+                    maxLayers = attachment.subresourceRange.layerCount;
+                }
+            }
 
-			VkFramebufferCreateInfo framebufferInfo = {};
-			framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-			framebufferInfo.renderPass = renderPass;
-			framebufferInfo.pAttachments = attachmentViews.data();
-			framebufferInfo.attachmentCount = static_cast<uint32_t>(attachmentViews.size());
-			framebufferInfo.width = width;
-			framebufferInfo.height = height;
-			framebufferInfo.layers = maxLayers;
-			VK_CHECK_RESULT(vkCreateFramebuffer(vulkanDevice->logicalDevice, &framebufferInfo, nullptr, &framebuffer));
+            VkFramebufferCreateInfo framebufferInfo = {};
+            framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+            framebufferInfo.renderPass = renderPass;
+            framebufferInfo.pAttachments = attachmentViews.data();
+            framebufferInfo.attachmentCount = static_cast<uint32_t>(attachmentViews.size());
+            framebufferInfo.width = width;
+            framebufferInfo.height = height;
+            framebufferInfo.layers = maxLayers;
+            VK_CHECK_RESULT(vkCreateFramebuffer(vulkanDevice->logicalDevice, &framebufferInfo, nullptr, &framebuffer));
 
-			return VK_SUCCESS;
-		}
-	};
-}
+            return VK_SUCCESS;
+        }
+    };
+}  // namespace vks

--- a/base/VulkanHeightmap.hpp
+++ b/base/VulkanHeightmap.hpp
@@ -15,245 +15,219 @@
 #include <ktx.h>
 #include <ktxvulkan.h>
 
-namespace vks 
+namespace vks
 {
-	class HeightMap
-	{
-	private:
-		uint16_t *heightdata;
-		uint32_t dim;
-		uint32_t scale;
+    class HeightMap
+    {
+    private:
+        uint16_t* heightdata;
+        uint32_t dim;
+        uint32_t scale;
 
-		vks::VulkanDevice *device = nullptr;
-		VkQueue copyQueue = VK_NULL_HANDLE;
-	public:
-		enum Topology { topologyTriangles, topologyQuads };
+        vks::VulkanDevice* device = nullptr;
+        VkQueue copyQueue = VK_NULL_HANDLE;
 
-		float heightScale = 1.0f;
-		float uvScale = 1.0f;
+    public:
+        enum Topology { topologyTriangles, topologyQuads };
 
-		vks::Buffer vertexBuffer;
-		vks::Buffer indexBuffer;
+        float heightScale = 1.0f;
+        float uvScale = 1.0f;
 
-		struct Vertex {
-			glm::vec3 pos;
-			glm::vec3 normal;
-			glm::vec2 uv;
-		};
+        vks::Buffer vertexBuffer;
+        vks::Buffer indexBuffer;
 
-		size_t vertexBufferSize = 0;
-		size_t indexBufferSize = 0;
-		uint32_t indexCount = 0;
+        struct Vertex
+        {
+            glm::vec3 pos;
+            glm::vec3 normal;
+            glm::vec2 uv;
+        };
 
-		HeightMap(vks::VulkanDevice *device, VkQueue copyQueue)
-		{
-			this->device = device;
-			this->copyQueue = copyQueue;
-		};
+        size_t vertexBufferSize = 0;
+        size_t indexBufferSize = 0;
+        uint32_t indexCount = 0;
 
-		~HeightMap()
-		{
-			vertexBuffer.destroy();
-			indexBuffer.destroy();
-			delete[] heightdata;
-		}
+        HeightMap(vks::VulkanDevice* device, VkQueue copyQueue)
+        {
+            this->device = device;
+            this->copyQueue = copyQueue;
+        };
 
-		float getHeight(uint32_t x, uint32_t y)
-		{
-			glm::ivec2 rpos = glm::ivec2(x, y) * glm::ivec2(scale);
-			rpos.x = std::max(0, std::min(rpos.x, (int)dim - 1));
-			rpos.y = std::max(0, std::min(rpos.y, (int)dim - 1));
-			rpos /= glm::ivec2(scale);
-			return *(heightdata + (rpos.x + rpos.y * dim) * scale) / 65535.0f * heightScale;
-		}
+        ~HeightMap()
+        {
+            vertexBuffer.destroy();
+            indexBuffer.destroy();
+            delete[] heightdata;
+        }
+
+        float getHeight(uint32_t x, uint32_t y)
+        {
+            glm::ivec2 rpos = glm::ivec2(x, y) * glm::ivec2(scale);
+            rpos.x = std::max(0, std::min(rpos.x, (int)dim - 1));
+            rpos.y = std::max(0, std::min(rpos.y, (int)dim - 1));
+            rpos /= glm::ivec2(scale);
+            return *(heightdata + (rpos.x + rpos.y * dim) * scale) / 65535.0f * heightScale;
+        }
 
 #if defined(__ANDROID__)
-		void loadFromFile(const std::string filename, uint32_t patchsize, glm::vec3 scale, Topology topology, AAssetManager* assetManager)
+        void loadFromFile(const std::string filename, uint32_t patchsize, glm::vec3 scale, Topology topology, AAssetManager* assetManager)
 #else
-		void loadFromFile(const std::string filename, uint32_t patchsize, glm::vec3 scale, Topology topology)
+        void loadFromFile(const std::string filename, uint32_t patchsize, glm::vec3 scale, Topology topology)
 #endif
-		{
-			assert(device);
-			assert(copyQueue != VK_NULL_HANDLE);
+        {
+            assert(device);
+            assert(copyQueue != VK_NULL_HANDLE);
 
-			ktxResult result;
-			ktxTexture* ktxTexture;
+            ktxResult result;
+            ktxTexture* ktxTexture;
 #if defined(__ANDROID__)
-			AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, filename.c_str(), AASSET_MODE_STREAMING);
-			assert(asset);
-			size_t size = AAsset_getLength(asset);
-			assert(size > 0);
-			void *textureData = malloc(size);
-			AAsset_read(asset, textureData, size);
-			AAsset_close(asset);
-			result = ktxTexture_CreateFromMemory(textureData, size, KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, target);
-			free(textureData);
+            AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, filename.c_str(), AASSET_MODE_STREAMING);
+            assert(asset);
+            size_t size = AAsset_getLength(asset);
+            assert(size > 0);
+            void* textureData = malloc(size);
+            AAsset_read(asset, textureData, size);
+            AAsset_close(asset);
+            result = ktxTexture_CreateFromMemory(textureData, size, KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, target);
+            free(textureData);
 #else
-			result = ktxTexture_CreateFromNamedFile(filename.c_str(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, &ktxTexture);
+            result = ktxTexture_CreateFromNamedFile(filename.c_str(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, &ktxTexture);
 #endif
-			assert(result == KTX_SUCCESS);
-			ktx_size_t ktxSize = ktxTexture_GetImageSize(ktxTexture, 0);
-			ktx_uint8_t* ktxImage = ktxTexture_GetData(ktxTexture);
-			dim = ktxTexture->baseWidth;
-			heightdata = new uint16_t[dim * dim];
-			memcpy(heightdata, ktxImage, ktxSize);
-			this->scale = dim / patchsize;
-			ktxTexture_Destroy(ktxTexture);
+            assert(result == KTX_SUCCESS);
+            ktx_size_t ktxSize = ktxTexture_GetImageSize(ktxTexture, 0);
+            ktx_uint8_t* ktxImage = ktxTexture_GetData(ktxTexture);
+            dim = ktxTexture->baseWidth;
+            heightdata = new uint16_t[dim * dim];
+            memcpy(heightdata, ktxImage, ktxSize);
+            this->scale = dim / patchsize;
+            ktxTexture_Destroy(ktxTexture);
 
-			// Generate vertices
-			Vertex * vertices = new Vertex[patchsize * patchsize * 4];
+            // Generate vertices
+            Vertex* vertices = new Vertex[patchsize * patchsize * 4];
 
-			const float wx = 2.0f;
-			const float wy = 2.0f;
+            const float wx = 2.0f;
+            const float wy = 2.0f;
 
-			for (uint32_t x = 0; x < patchsize; x++)
-			{
-				for (uint32_t y = 0; y < patchsize; y++)
-				{
-					uint32_t index = (x + y * patchsize);
-					vertices[index].pos[0] = (x * wx + wx / 2.0f - (float)patchsize * wx / 2.0f) * scale.x;
-					vertices[index].pos[1] = -getHeight(x, y);
-					vertices[index].pos[2] = (y * wy + wy / 2.0f - (float)patchsize * wy / 2.0f) * scale.z;
-					vertices[index].uv = glm::vec2((float)x / patchsize, (float)y / patchsize) * uvScale;
-				}
-			}
+            for (uint32_t x = 0; x < patchsize; x++)
+            {
+                for (uint32_t y = 0; y < patchsize; y++)
+                {
+                    uint32_t index = (x + y * patchsize);
+                    vertices[index].pos[0] = (x * wx + wx / 2.0f - (float)patchsize * wx / 2.0f) * scale.x;
+                    vertices[index].pos[1] = -getHeight(x, y);
+                    vertices[index].pos[2] = (y * wy + wy / 2.0f - (float)patchsize * wy / 2.0f) * scale.z;
+                    vertices[index].uv = glm::vec2((float)x / patchsize, (float)y / patchsize) * uvScale;
+                }
+            }
 
-			for (uint32_t y = 0; y < patchsize; y++)
-			{
-				for (uint32_t x = 0; x < patchsize; x++)
-				{
-					float dx = getHeight(x < patchsize - 1 ? x + 1 : x, y) - getHeight(x > 0 ? x - 1 : x, y);
-					if (x == 0 || x == patchsize - 1)
-						dx *= 2.0f;
+            for (uint32_t y = 0; y < patchsize; y++)
+            {
+                for (uint32_t x = 0; x < patchsize; x++)
+                {
+                    float dx = getHeight(x < patchsize - 1 ? x + 1 : x, y) - getHeight(x > 0 ? x - 1 : x, y);
+                    if (x == 0 || x == patchsize - 1)
+                        dx *= 2.0f;
 
-					float dy = getHeight(x, y < patchsize - 1 ? y + 1 : y) - getHeight(x, y > 0 ? y - 1 : y);
-					if (y == 0 || y == patchsize - 1)
-						dy *= 2.0f;
+                    float dy = getHeight(x, y < patchsize - 1 ? y + 1 : y) - getHeight(x, y > 0 ? y - 1 : y);
+                    if (y == 0 || y == patchsize - 1)
+                        dy *= 2.0f;
 
-					glm::vec3 A = glm::vec3(1.0f, 0.0f, dx);
-					glm::vec3 B = glm::vec3(0.0f, 1.0f, dy);
+                    glm::vec3 A = glm::vec3(1.0f, 0.0f, dx);
+                    glm::vec3 B = glm::vec3(0.0f, 1.0f, dy);
 
-					glm::vec3 normal = (glm::normalize(glm::cross(A, B)) + 1.0f) * 0.5f;
+                    glm::vec3 normal = (glm::normalize(glm::cross(A, B)) + 1.0f) * 0.5f;
 
-					vertices[x + y * patchsize].normal = glm::vec3(normal.x, normal.z, normal.y);
-				}
-			}
+                    vertices[x + y * patchsize].normal = glm::vec3(normal.x, normal.z, normal.y);
+                }
+            }
 
-			// Generate indices
+            // Generate indices
 
-			const uint32_t w = (patchsize - 1);
-			uint32_t *indices;
+            const uint32_t w = (patchsize - 1);
+            uint32_t* indices;
 
-			switch (topology)
-			{
-				// Indices for triangles
-			case topologyTriangles:
-			{
-				indices = new uint32_t[w * w * 6];
-				for (uint32_t x = 0; x < w; x++)
-				{
-					for (uint32_t y = 0; y < w; y++)
-					{
-						uint32_t index = (x + y * w) * 6;
-						indices[index] = (x + y * patchsize);
-						indices[index + 1] = indices[index] + patchsize;
-						indices[index + 2] = indices[index + 1] + 1;
+            switch (topology)
+            {
+                    // Indices for triangles
+                case topologyTriangles: {
+                    indices = new uint32_t[w * w * 6];
+                    for (uint32_t x = 0; x < w; x++)
+                    {
+                        for (uint32_t y = 0; y < w; y++)
+                        {
+                            uint32_t index = (x + y * w) * 6;
+                            indices[index] = (x + y * patchsize);
+                            indices[index + 1] = indices[index] + patchsize;
+                            indices[index + 2] = indices[index + 1] + 1;
 
-						indices[index + 3] = indices[index + 1] + 1;
-						indices[index + 4] = indices[index] + 1;
-						indices[index + 5] = indices[index];
-					}
-				}
-				indexCount = (patchsize - 1) * (patchsize - 1) * 6;
-				indexBufferSize = (w * w * 6) * sizeof(uint32_t);
-				break;
-			}
-			// Indices for quad patches (tessellation)
-			case topologyQuads:
-			{
+                            indices[index + 3] = indices[index + 1] + 1;
+                            indices[index + 4] = indices[index] + 1;
+                            indices[index + 5] = indices[index];
+                        }
+                    }
+                    indexCount = (patchsize - 1) * (patchsize - 1) * 6;
+                    indexBufferSize = (w * w * 6) * sizeof(uint32_t);
+                    break;
+                }
+                // Indices for quad patches (tessellation)
+                case topologyQuads: {
+                    indices = new uint32_t[w * w * 4];
+                    for (uint32_t x = 0; x < w; x++)
+                    {
+                        for (uint32_t y = 0; y < w; y++)
+                        {
+                            uint32_t index = (x + y * w) * 4;
+                            indices[index] = (x + y * patchsize);
+                            indices[index + 1] = indices[index] + patchsize;
+                            indices[index + 2] = indices[index + 1] + 1;
+                            indices[index + 3] = indices[index] + 1;
+                        }
+                    }
+                    indexCount = (patchsize - 1) * (patchsize - 1) * 4;
+                    indexBufferSize = (w * w * 4) * sizeof(uint32_t);
+                    break;
+                }
+            }
 
-				indices = new uint32_t[w * w * 4];
-				for (uint32_t x = 0; x < w; x++)
-				{
-					for (uint32_t y = 0; y < w; y++)
-					{
-						uint32_t index = (x + y * w) * 4;
-						indices[index] = (x + y * patchsize);
-						indices[index + 1] = indices[index] + patchsize;
-						indices[index + 2] = indices[index + 1] + 1;
-						indices[index + 3] = indices[index] + 1;
-					}
-				}
-				indexCount = (patchsize - 1) * (patchsize - 1) * 4;
-				indexBufferSize = (w * w * 4) * sizeof(uint32_t);
-				break;
-			}
+            assert(indexBufferSize > 0);
 
-			}
+            vertexBufferSize = (patchsize * patchsize * 4) * sizeof(Vertex);
 
-			assert(indexBufferSize > 0);
+            // Generate Vulkan buffers
 
-			vertexBufferSize = (patchsize * patchsize * 4) * sizeof(Vertex);
+            vks::Buffer vertexStaging, indexStaging;
 
-			// Generate Vulkan buffers
+            // Create staging buffers
+            device->createBuffer(VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &vertexStaging,
+                                 vertexBufferSize, vertices);
 
-			vks::Buffer vertexStaging, indexStaging;
+            device->createBuffer(VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &indexStaging,
+                                 indexBufferSize, indices);
 
-			// Create staging buffers
-			device->createBuffer(
-				VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-				&vertexStaging,
-				vertexBufferSize,
-				vertices);
+            // Device local (target) buffer
+            device->createBuffer(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &vertexBuffer,
+                                 vertexBufferSize);
 
-			device->createBuffer(
-				VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-				&indexStaging,
-				indexBufferSize,
-				indices);
+            device->createBuffer(VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &indexBuffer,
+                                 indexBufferSize);
 
-			// Device local (target) buffer
-			device->createBuffer(
-				VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				&vertexBuffer,
-				vertexBufferSize);
+            // Copy from staging buffers
+            VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-			device->createBuffer(
-				VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				&indexBuffer,
-				indexBufferSize);
+            VkBufferCopy copyRegion = {};
 
-			// Copy from staging buffers
-			VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+            copyRegion.size = vertexBufferSize;
+            vkCmdCopyBuffer(copyCmd, vertexStaging.buffer, vertexBuffer.buffer, 1, &copyRegion);
 
-			VkBufferCopy copyRegion = {};
+            copyRegion.size = indexBufferSize;
+            vkCmdCopyBuffer(copyCmd, indexStaging.buffer, indexBuffer.buffer, 1, &copyRegion);
 
-			copyRegion.size = vertexBufferSize;
-			vkCmdCopyBuffer(
-				copyCmd,
-				vertexStaging.buffer,
-				vertexBuffer.buffer,
-				1,
-				&copyRegion);
+            device->flushCommandBuffer(copyCmd, copyQueue, true);
 
-			copyRegion.size = indexBufferSize;
-			vkCmdCopyBuffer(
-				copyCmd,
-				indexStaging.buffer,
-				indexBuffer.buffer,
-				1,
-				&copyRegion);
-
-			device->flushCommandBuffer(copyCmd, copyQueue, true);
-
-			vkDestroyBuffer(device->logicalDevice, vertexStaging.buffer, nullptr);
-			vkFreeMemory(device->logicalDevice, vertexStaging.memory, nullptr);
-			vkDestroyBuffer(device->logicalDevice, indexStaging.buffer, nullptr);
-			vkFreeMemory(device->logicalDevice, indexStaging.memory, nullptr);
-		}
-	};
-}
+            vkDestroyBuffer(device->logicalDevice, vertexStaging.buffer, nullptr);
+            vkFreeMemory(device->logicalDevice, vertexStaging.memory, nullptr);
+            vkDestroyBuffer(device->logicalDevice, indexStaging.buffer, nullptr);
+            vkFreeMemory(device->logicalDevice, indexStaging.memory, nullptr);
+        }
+    };
+}  // namespace vks

--- a/base/VulkanInitializers.hpp
+++ b/base/VulkanInitializers.hpp
@@ -15,577 +15,521 @@
 
 namespace vks
 {
-	namespace initializers
-	{
+    namespace initializers
+    {
+        inline VkMemoryAllocateInfo memoryAllocateInfo()
+        {
+            VkMemoryAllocateInfo memAllocInfo{};
+            memAllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            return memAllocInfo;
+        }
 
-		inline VkMemoryAllocateInfo memoryAllocateInfo()
-		{
-			VkMemoryAllocateInfo memAllocInfo {};
-			memAllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-			return memAllocInfo;
-		}
+        inline VkMappedMemoryRange mappedMemoryRange()
+        {
+            VkMappedMemoryRange mappedMemoryRange{};
+            mappedMemoryRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+            return mappedMemoryRange;
+        }
 
-		inline VkMappedMemoryRange mappedMemoryRange()
-		{
-			VkMappedMemoryRange mappedMemoryRange {};
-			mappedMemoryRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
-			return mappedMemoryRange;
-		}
+        inline VkCommandBufferAllocateInfo commandBufferAllocateInfo(VkCommandPool commandPool, VkCommandBufferLevel level, uint32_t bufferCount)
+        {
+            VkCommandBufferAllocateInfo commandBufferAllocateInfo{};
+            commandBufferAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            commandBufferAllocateInfo.commandPool = commandPool;
+            commandBufferAllocateInfo.level = level;
+            commandBufferAllocateInfo.commandBufferCount = bufferCount;
+            return commandBufferAllocateInfo;
+        }
 
-		inline VkCommandBufferAllocateInfo commandBufferAllocateInfo(
-			VkCommandPool commandPool, 
-			VkCommandBufferLevel level, 
-			uint32_t bufferCount)
-		{
-			VkCommandBufferAllocateInfo commandBufferAllocateInfo {};
-			commandBufferAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-			commandBufferAllocateInfo.commandPool = commandPool;
-			commandBufferAllocateInfo.level = level;
-			commandBufferAllocateInfo.commandBufferCount = bufferCount;
-			return commandBufferAllocateInfo;
-		}
+        inline VkCommandPoolCreateInfo commandPoolCreateInfo()
+        {
+            VkCommandPoolCreateInfo cmdPoolCreateInfo{};
+            cmdPoolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+            return cmdPoolCreateInfo;
+        }
 
-		inline VkCommandPoolCreateInfo commandPoolCreateInfo()
-		{
-			VkCommandPoolCreateInfo cmdPoolCreateInfo {};
-			cmdPoolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-			return cmdPoolCreateInfo;
-		}
+        inline VkCommandBufferBeginInfo commandBufferBeginInfo()
+        {
+            VkCommandBufferBeginInfo cmdBufferBeginInfo{};
+            cmdBufferBeginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+            return cmdBufferBeginInfo;
+        }
 
-		inline VkCommandBufferBeginInfo commandBufferBeginInfo()
-		{
-			VkCommandBufferBeginInfo cmdBufferBeginInfo {};
-			cmdBufferBeginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-			return cmdBufferBeginInfo;
-		}
+        inline VkCommandBufferInheritanceInfo commandBufferInheritanceInfo()
+        {
+            VkCommandBufferInheritanceInfo cmdBufferInheritanceInfo{};
+            cmdBufferInheritanceInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO;
+            return cmdBufferInheritanceInfo;
+        }
 
-		inline VkCommandBufferInheritanceInfo commandBufferInheritanceInfo()
-		{
-			VkCommandBufferInheritanceInfo cmdBufferInheritanceInfo {};
-			cmdBufferInheritanceInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO;
-			return cmdBufferInheritanceInfo;
-		}
+        inline VkRenderPassBeginInfo renderPassBeginInfo()
+        {
+            VkRenderPassBeginInfo renderPassBeginInfo{};
+            renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+            return renderPassBeginInfo;
+        }
 
-		inline VkRenderPassBeginInfo renderPassBeginInfo()
-		{
-			VkRenderPassBeginInfo renderPassBeginInfo {};
-			renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-			return renderPassBeginInfo;
-		}
+        inline VkRenderPassCreateInfo renderPassCreateInfo()
+        {
+            VkRenderPassCreateInfo renderPassCreateInfo{};
+            renderPassCreateInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+            return renderPassCreateInfo;
+        }
 
-		inline VkRenderPassCreateInfo renderPassCreateInfo()
-		{
-			VkRenderPassCreateInfo renderPassCreateInfo {};
-			renderPassCreateInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-			return renderPassCreateInfo;
-		}
+        /** @brief Initialize an image memory barrier with no image transfer ownership */
+        inline VkImageMemoryBarrier imageMemoryBarrier()
+        {
+            VkImageMemoryBarrier imageMemoryBarrier{};
+            imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            imageMemoryBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            imageMemoryBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            return imageMemoryBarrier;
+        }
 
-		/** @brief Initialize an image memory barrier with no image transfer ownership */
-		inline VkImageMemoryBarrier imageMemoryBarrier()
-		{
-			VkImageMemoryBarrier imageMemoryBarrier {};
-			imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-			imageMemoryBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			imageMemoryBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			return imageMemoryBarrier;
-		}
+        /** @brief Initialize a buffer memory barrier with no image transfer ownership */
+        inline VkBufferMemoryBarrier bufferMemoryBarrier()
+        {
+            VkBufferMemoryBarrier bufferMemoryBarrier{};
+            bufferMemoryBarrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+            bufferMemoryBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            bufferMemoryBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            return bufferMemoryBarrier;
+        }
 
-		/** @brief Initialize a buffer memory barrier with no image transfer ownership */
-		inline VkBufferMemoryBarrier bufferMemoryBarrier()
-		{
-			VkBufferMemoryBarrier bufferMemoryBarrier {};
-			bufferMemoryBarrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-			bufferMemoryBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			bufferMemoryBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			return bufferMemoryBarrier;
-		}
+        inline VkMemoryBarrier memoryBarrier()
+        {
+            VkMemoryBarrier memoryBarrier{};
+            memoryBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+            return memoryBarrier;
+        }
 
-		inline VkMemoryBarrier memoryBarrier()
-		{
-			VkMemoryBarrier memoryBarrier {};
-			memoryBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-			return memoryBarrier;
-		}
+        inline VkImageCreateInfo imageCreateInfo()
+        {
+            VkImageCreateInfo imageCreateInfo{};
+            imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            return imageCreateInfo;
+        }
 
-		inline VkImageCreateInfo imageCreateInfo()
-		{
-			VkImageCreateInfo imageCreateInfo {};
-			imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-			return imageCreateInfo;
-		}
+        inline VkSamplerCreateInfo samplerCreateInfo()
+        {
+            VkSamplerCreateInfo samplerCreateInfo{};
+            samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+            samplerCreateInfo.maxAnisotropy = 1.0f;
+            return samplerCreateInfo;
+        }
 
-		inline VkSamplerCreateInfo samplerCreateInfo()
-		{
-			VkSamplerCreateInfo samplerCreateInfo {};
-			samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-			samplerCreateInfo.maxAnisotropy = 1.0f;
-			return samplerCreateInfo;
-		}
+        inline VkImageViewCreateInfo imageViewCreateInfo()
+        {
+            VkImageViewCreateInfo imageViewCreateInfo{};
+            imageViewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            return imageViewCreateInfo;
+        }
 
-		inline VkImageViewCreateInfo imageViewCreateInfo()
-		{
-			VkImageViewCreateInfo imageViewCreateInfo {};
-			imageViewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-			return imageViewCreateInfo;
-		}
+        inline VkFramebufferCreateInfo framebufferCreateInfo()
+        {
+            VkFramebufferCreateInfo framebufferCreateInfo{};
+            framebufferCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+            return framebufferCreateInfo;
+        }
 
-		inline VkFramebufferCreateInfo framebufferCreateInfo()
-		{
-			VkFramebufferCreateInfo framebufferCreateInfo {};
-			framebufferCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-			return framebufferCreateInfo;
-		}
+        inline VkSemaphoreCreateInfo semaphoreCreateInfo()
+        {
+            VkSemaphoreCreateInfo semaphoreCreateInfo{};
+            semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+            return semaphoreCreateInfo;
+        }
 
-		inline VkSemaphoreCreateInfo semaphoreCreateInfo()
-		{
-			VkSemaphoreCreateInfo semaphoreCreateInfo {};
-			semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-			return semaphoreCreateInfo;
-		}
+        inline VkFenceCreateInfo fenceCreateInfo(VkFenceCreateFlags flags = 0)
+        {
+            VkFenceCreateInfo fenceCreateInfo{};
+            fenceCreateInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+            fenceCreateInfo.flags = flags;
+            return fenceCreateInfo;
+        }
 
-		inline VkFenceCreateInfo fenceCreateInfo(VkFenceCreateFlags flags = 0)
-		{
-			VkFenceCreateInfo fenceCreateInfo {};
-			fenceCreateInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-			fenceCreateInfo.flags = flags;
-			return fenceCreateInfo;
-		}
+        inline VkEventCreateInfo eventCreateInfo()
+        {
+            VkEventCreateInfo eventCreateInfo{};
+            eventCreateInfo.sType = VK_STRUCTURE_TYPE_EVENT_CREATE_INFO;
+            return eventCreateInfo;
+        }
 
-		inline VkEventCreateInfo eventCreateInfo()
-		{
-			VkEventCreateInfo eventCreateInfo {};
-			eventCreateInfo.sType = VK_STRUCTURE_TYPE_EVENT_CREATE_INFO;
-			return eventCreateInfo;
-		}
+        inline VkSubmitInfo submitInfo()
+        {
+            VkSubmitInfo submitInfo{};
+            submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            return submitInfo;
+        }
 
-		inline VkSubmitInfo submitInfo()
-		{
-			VkSubmitInfo submitInfo {};
-			submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-			return submitInfo;
-		}
+        inline VkViewport viewport(float width, float height, float minDepth, float maxDepth)
+        {
+            VkViewport viewport{};
+            viewport.width = width;
+            viewport.height = height;
+            viewport.minDepth = minDepth;
+            viewport.maxDepth = maxDepth;
+            return viewport;
+        }
 
-		inline VkViewport viewport(
-			float width,
-			float height,
-			float minDepth,
-			float maxDepth)
-		{
-			VkViewport viewport {};
-			viewport.width = width;
-			viewport.height = height;
-			viewport.minDepth = minDepth;
-			viewport.maxDepth = maxDepth;
-			return viewport;
-		}
+        inline VkRect2D rect2D(int32_t width, int32_t height, int32_t offsetX, int32_t offsetY)
+        {
+            VkRect2D rect2D{};
+            rect2D.extent.width = width;
+            rect2D.extent.height = height;
+            rect2D.offset.x = offsetX;
+            rect2D.offset.y = offsetY;
+            return rect2D;
+        }
 
-		inline VkRect2D rect2D(
-			int32_t width,
-			int32_t height,
-			int32_t offsetX,
-			int32_t offsetY)
-		{
-			VkRect2D rect2D {};
-			rect2D.extent.width = width;
-			rect2D.extent.height = height;
-			rect2D.offset.x = offsetX;
-			rect2D.offset.y = offsetY;
-			return rect2D;
-		}
+        inline VkBufferCreateInfo bufferCreateInfo()
+        {
+            VkBufferCreateInfo bufCreateInfo{};
+            bufCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            return bufCreateInfo;
+        }
 
-		inline VkBufferCreateInfo bufferCreateInfo()
-		{
-			VkBufferCreateInfo bufCreateInfo {};
-			bufCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-			return bufCreateInfo;
-		}
+        inline VkBufferCreateInfo bufferCreateInfo(VkBufferUsageFlags usage, VkDeviceSize size)
+        {
+            VkBufferCreateInfo bufCreateInfo{};
+            bufCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bufCreateInfo.usage = usage;
+            bufCreateInfo.size = size;
+            return bufCreateInfo;
+        }
 
-		inline VkBufferCreateInfo bufferCreateInfo(
-			VkBufferUsageFlags usage,
-			VkDeviceSize size)
-		{
-			VkBufferCreateInfo bufCreateInfo {};
-			bufCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-			bufCreateInfo.usage = usage;
-			bufCreateInfo.size = size;
-			return bufCreateInfo;
-		}
+        inline VkDescriptorPoolCreateInfo descriptorPoolCreateInfo(uint32_t poolSizeCount, VkDescriptorPoolSize* pPoolSizes, uint32_t maxSets)
+        {
+            VkDescriptorPoolCreateInfo descriptorPoolInfo{};
+            descriptorPoolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+            descriptorPoolInfo.poolSizeCount = poolSizeCount;
+            descriptorPoolInfo.pPoolSizes = pPoolSizes;
+            descriptorPoolInfo.maxSets = maxSets;
+            return descriptorPoolInfo;
+        }
 
-		inline VkDescriptorPoolCreateInfo descriptorPoolCreateInfo(
-			uint32_t poolSizeCount,
-			VkDescriptorPoolSize* pPoolSizes,
-			uint32_t maxSets)
-		{
-			VkDescriptorPoolCreateInfo descriptorPoolInfo {};
-			descriptorPoolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-			descriptorPoolInfo.poolSizeCount = poolSizeCount;
-			descriptorPoolInfo.pPoolSizes = pPoolSizes;
-			descriptorPoolInfo.maxSets = maxSets;
-			return descriptorPoolInfo;
-		}
+        inline VkDescriptorPoolCreateInfo descriptorPoolCreateInfo(const std::vector<VkDescriptorPoolSize>& poolSizes, uint32_t maxSets)
+        {
+            VkDescriptorPoolCreateInfo descriptorPoolInfo{};
+            descriptorPoolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+            descriptorPoolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
+            descriptorPoolInfo.pPoolSizes = poolSizes.data();
+            descriptorPoolInfo.maxSets = maxSets;
+            return descriptorPoolInfo;
+        }
 
-		inline VkDescriptorPoolCreateInfo descriptorPoolCreateInfo(
-			const std::vector<VkDescriptorPoolSize>& poolSizes,
-			uint32_t maxSets)
-		{
-			VkDescriptorPoolCreateInfo descriptorPoolInfo{};
-			descriptorPoolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-			descriptorPoolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
-			descriptorPoolInfo.pPoolSizes = poolSizes.data();
-			descriptorPoolInfo.maxSets = maxSets;
-			return descriptorPoolInfo;
-		}
+        inline VkDescriptorPoolSize descriptorPoolSize(VkDescriptorType type, uint32_t descriptorCount)
+        {
+            VkDescriptorPoolSize descriptorPoolSize{};
+            descriptorPoolSize.type = type;
+            descriptorPoolSize.descriptorCount = descriptorCount;
+            return descriptorPoolSize;
+        }
 
-		inline VkDescriptorPoolSize descriptorPoolSize(
-			VkDescriptorType type,
-			uint32_t descriptorCount)
-		{
-			VkDescriptorPoolSize descriptorPoolSize {};
-			descriptorPoolSize.type = type;
-			descriptorPoolSize.descriptorCount = descriptorCount;
-			return descriptorPoolSize;
-		}
+        inline VkDescriptorSetLayoutBinding descriptorSetLayoutBinding(VkDescriptorType type,
+                                                                       VkShaderStageFlags stageFlags,
+                                                                       uint32_t binding,
+                                                                       uint32_t descriptorCount = 1)
+        {
+            VkDescriptorSetLayoutBinding setLayoutBinding{};
+            setLayoutBinding.descriptorType = type;
+            setLayoutBinding.stageFlags = stageFlags;
+            setLayoutBinding.binding = binding;
+            setLayoutBinding.descriptorCount = descriptorCount;
+            return setLayoutBinding;
+        }
 
-		inline VkDescriptorSetLayoutBinding descriptorSetLayoutBinding(
-			VkDescriptorType type,
-			VkShaderStageFlags stageFlags,
-			uint32_t binding,
-			uint32_t descriptorCount = 1)
-		{
-			VkDescriptorSetLayoutBinding setLayoutBinding {};
-			setLayoutBinding.descriptorType = type;
-			setLayoutBinding.stageFlags = stageFlags;
-			setLayoutBinding.binding = binding;
-			setLayoutBinding.descriptorCount = descriptorCount;
-			return setLayoutBinding;
-		}
+        inline VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo(const VkDescriptorSetLayoutBinding* pBindings, uint32_t bindingCount)
+        {
+            VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo{};
+            descriptorSetLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+            descriptorSetLayoutCreateInfo.pBindings = pBindings;
+            descriptorSetLayoutCreateInfo.bindingCount = bindingCount;
+            return descriptorSetLayoutCreateInfo;
+        }
 
-		inline VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo(
-			const VkDescriptorSetLayoutBinding* pBindings,
-			uint32_t bindingCount)
-		{
-			VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo {};
-			descriptorSetLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-			descriptorSetLayoutCreateInfo.pBindings = pBindings;
-			descriptorSetLayoutCreateInfo.bindingCount = bindingCount;
-			return descriptorSetLayoutCreateInfo;
-		}
+        inline VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo(const std::vector<VkDescriptorSetLayoutBinding>& bindings)
+        {
+            VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo{};
+            descriptorSetLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+            descriptorSetLayoutCreateInfo.pBindings = bindings.data();
+            descriptorSetLayoutCreateInfo.bindingCount = static_cast<uint32_t>(bindings.size());
+            return descriptorSetLayoutCreateInfo;
+        }
 
-		inline VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo(
-			const std::vector<VkDescriptorSetLayoutBinding>& bindings)
-		{
-			VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo{};
-			descriptorSetLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-			descriptorSetLayoutCreateInfo.pBindings = bindings.data();
-			descriptorSetLayoutCreateInfo.bindingCount = static_cast<uint32_t>(bindings.size());
-			return descriptorSetLayoutCreateInfo;
-		}
+        inline VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo(const VkDescriptorSetLayout* pSetLayouts, uint32_t setLayoutCount = 1)
+        {
+            VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo{};
+            pipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+            pipelineLayoutCreateInfo.setLayoutCount = setLayoutCount;
+            pipelineLayoutCreateInfo.pSetLayouts = pSetLayouts;
+            return pipelineLayoutCreateInfo;
+        }
 
-		inline VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo(
-			const VkDescriptorSetLayout* pSetLayouts,
-			uint32_t setLayoutCount = 1)
-		{
-			VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo {};
-			pipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-			pipelineLayoutCreateInfo.setLayoutCount = setLayoutCount;
-			pipelineLayoutCreateInfo.pSetLayouts = pSetLayouts;
-			return pipelineLayoutCreateInfo;
-		}
+        inline VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo(uint32_t setLayoutCount = 1)
+        {
+            VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo{};
+            pipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+            pipelineLayoutCreateInfo.setLayoutCount = setLayoutCount;
+            return pipelineLayoutCreateInfo;
+        }
 
-		inline VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo(
-			uint32_t setLayoutCount = 1)
-		{
-			VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo{};
-			pipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-			pipelineLayoutCreateInfo.setLayoutCount = setLayoutCount;
-			return pipelineLayoutCreateInfo;
-		}
+        inline VkDescriptorSetAllocateInfo descriptorSetAllocateInfo(VkDescriptorPool descriptorPool,
+                                                                     const VkDescriptorSetLayout* pSetLayouts,
+                                                                     uint32_t descriptorSetCount)
+        {
+            VkDescriptorSetAllocateInfo descriptorSetAllocateInfo{};
+            descriptorSetAllocateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+            descriptorSetAllocateInfo.descriptorPool = descriptorPool;
+            descriptorSetAllocateInfo.pSetLayouts = pSetLayouts;
+            descriptorSetAllocateInfo.descriptorSetCount = descriptorSetCount;
+            return descriptorSetAllocateInfo;
+        }
 
-		inline VkDescriptorSetAllocateInfo descriptorSetAllocateInfo(
-			VkDescriptorPool descriptorPool,
-			const VkDescriptorSetLayout* pSetLayouts,
-			uint32_t descriptorSetCount)
-		{
-			VkDescriptorSetAllocateInfo descriptorSetAllocateInfo {};
-			descriptorSetAllocateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-			descriptorSetAllocateInfo.descriptorPool = descriptorPool;
-			descriptorSetAllocateInfo.pSetLayouts = pSetLayouts;
-			descriptorSetAllocateInfo.descriptorSetCount = descriptorSetCount;
-			return descriptorSetAllocateInfo;
-		}
+        inline VkDescriptorImageInfo descriptorImageInfo(VkSampler sampler, VkImageView imageView, VkImageLayout imageLayout)
+        {
+            VkDescriptorImageInfo descriptorImageInfo{};
+            descriptorImageInfo.sampler = sampler;
+            descriptorImageInfo.imageView = imageView;
+            descriptorImageInfo.imageLayout = imageLayout;
+            return descriptorImageInfo;
+        }
 
-		inline VkDescriptorImageInfo descriptorImageInfo(VkSampler sampler, VkImageView imageView, VkImageLayout imageLayout)
-		{
-			VkDescriptorImageInfo descriptorImageInfo {};
-			descriptorImageInfo.sampler = sampler;
-			descriptorImageInfo.imageView = imageView;
-			descriptorImageInfo.imageLayout = imageLayout;
-			return descriptorImageInfo;
-		}
+        inline VkWriteDescriptorSet writeDescriptorSet(VkDescriptorSet dstSet,
+                                                       VkDescriptorType type,
+                                                       uint32_t binding,
+                                                       VkDescriptorBufferInfo* bufferInfo,
+                                                       uint32_t descriptorCount = 1)
+        {
+            VkWriteDescriptorSet writeDescriptorSet{};
+            writeDescriptorSet.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writeDescriptorSet.dstSet = dstSet;
+            writeDescriptorSet.descriptorType = type;
+            writeDescriptorSet.dstBinding = binding;
+            writeDescriptorSet.pBufferInfo = bufferInfo;
+            writeDescriptorSet.descriptorCount = descriptorCount;
+            return writeDescriptorSet;
+        }
 
-		inline VkWriteDescriptorSet writeDescriptorSet(
-			VkDescriptorSet dstSet,
-			VkDescriptorType type,
-			uint32_t binding,
-			VkDescriptorBufferInfo* bufferInfo,
-			uint32_t descriptorCount = 1)
-		{
-			VkWriteDescriptorSet writeDescriptorSet {};
-			writeDescriptorSet.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-			writeDescriptorSet.dstSet = dstSet;
-			writeDescriptorSet.descriptorType = type;
-			writeDescriptorSet.dstBinding = binding;
-			writeDescriptorSet.pBufferInfo = bufferInfo;
-			writeDescriptorSet.descriptorCount = descriptorCount;
-			return writeDescriptorSet;
-		}
+        inline VkWriteDescriptorSet writeDescriptorSet(VkDescriptorSet dstSet,
+                                                       VkDescriptorType type,
+                                                       uint32_t binding,
+                                                       VkDescriptorImageInfo* imageInfo,
+                                                       uint32_t descriptorCount = 1)
+        {
+            VkWriteDescriptorSet writeDescriptorSet{};
+            writeDescriptorSet.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writeDescriptorSet.dstSet = dstSet;
+            writeDescriptorSet.descriptorType = type;
+            writeDescriptorSet.dstBinding = binding;
+            writeDescriptorSet.pImageInfo = imageInfo;
+            writeDescriptorSet.descriptorCount = descriptorCount;
+            return writeDescriptorSet;
+        }
 
-		inline VkWriteDescriptorSet writeDescriptorSet(
-			VkDescriptorSet dstSet,
-			VkDescriptorType type,
-			uint32_t binding,
-			VkDescriptorImageInfo *imageInfo,
-			uint32_t descriptorCount = 1)
-		{
-			VkWriteDescriptorSet writeDescriptorSet {};
-			writeDescriptorSet.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-			writeDescriptorSet.dstSet = dstSet;
-			writeDescriptorSet.descriptorType = type;
-			writeDescriptorSet.dstBinding = binding;
-			writeDescriptorSet.pImageInfo = imageInfo;
-			writeDescriptorSet.descriptorCount = descriptorCount;
-			return writeDescriptorSet;
-		}
+        inline VkVertexInputBindingDescription vertexInputBindingDescription(uint32_t binding, uint32_t stride, VkVertexInputRate inputRate)
+        {
+            VkVertexInputBindingDescription vInputBindDescription{};
+            vInputBindDescription.binding = binding;
+            vInputBindDescription.stride = stride;
+            vInputBindDescription.inputRate = inputRate;
+            return vInputBindDescription;
+        }
 
-		inline VkVertexInputBindingDescription vertexInputBindingDescription(
-			uint32_t binding,
-			uint32_t stride,
-			VkVertexInputRate inputRate)
-		{
-			VkVertexInputBindingDescription vInputBindDescription {};
-			vInputBindDescription.binding = binding;
-			vInputBindDescription.stride = stride;
-			vInputBindDescription.inputRate = inputRate;
-			return vInputBindDescription;
-		}
+        inline VkVertexInputAttributeDescription vertexInputAttributeDescription(uint32_t binding, uint32_t location, VkFormat format, uint32_t offset)
+        {
+            VkVertexInputAttributeDescription vInputAttribDescription{};
+            vInputAttribDescription.location = location;
+            vInputAttribDescription.binding = binding;
+            vInputAttribDescription.format = format;
+            vInputAttribDescription.offset = offset;
+            return vInputAttribDescription;
+        }
 
-		inline VkVertexInputAttributeDescription vertexInputAttributeDescription(
-			uint32_t binding,
-			uint32_t location,
-			VkFormat format,
-			uint32_t offset)
-		{
-			VkVertexInputAttributeDescription vInputAttribDescription {};
-			vInputAttribDescription.location = location;
-			vInputAttribDescription.binding = binding;
-			vInputAttribDescription.format = format;
-			vInputAttribDescription.offset = offset;
-			return vInputAttribDescription;
-		}
+        inline VkPipelineVertexInputStateCreateInfo pipelineVertexInputStateCreateInfo()
+        {
+            VkPipelineVertexInputStateCreateInfo pipelineVertexInputStateCreateInfo{};
+            pipelineVertexInputStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+            return pipelineVertexInputStateCreateInfo;
+        }
 
-		inline VkPipelineVertexInputStateCreateInfo pipelineVertexInputStateCreateInfo()
-		{
-			VkPipelineVertexInputStateCreateInfo pipelineVertexInputStateCreateInfo {};
-			pipelineVertexInputStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-			return pipelineVertexInputStateCreateInfo;
-		}
+        inline VkPipelineInputAssemblyStateCreateInfo pipelineInputAssemblyStateCreateInfo(VkPrimitiveTopology topology,
+                                                                                           VkPipelineInputAssemblyStateCreateFlags flags,
+                                                                                           VkBool32 primitiveRestartEnable)
+        {
+            VkPipelineInputAssemblyStateCreateInfo pipelineInputAssemblyStateCreateInfo{};
+            pipelineInputAssemblyStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+            pipelineInputAssemblyStateCreateInfo.topology = topology;
+            pipelineInputAssemblyStateCreateInfo.flags = flags;
+            pipelineInputAssemblyStateCreateInfo.primitiveRestartEnable = primitiveRestartEnable;
+            return pipelineInputAssemblyStateCreateInfo;
+        }
 
-		inline VkPipelineInputAssemblyStateCreateInfo pipelineInputAssemblyStateCreateInfo(
-			VkPrimitiveTopology topology,
-			VkPipelineInputAssemblyStateCreateFlags flags,
-			VkBool32 primitiveRestartEnable)
-		{
-			VkPipelineInputAssemblyStateCreateInfo pipelineInputAssemblyStateCreateInfo {};
-			pipelineInputAssemblyStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-			pipelineInputAssemblyStateCreateInfo.topology = topology;
-			pipelineInputAssemblyStateCreateInfo.flags = flags;
-			pipelineInputAssemblyStateCreateInfo.primitiveRestartEnable = primitiveRestartEnable;
-			return pipelineInputAssemblyStateCreateInfo;
-		}
+        inline VkPipelineRasterizationStateCreateInfo pipelineRasterizationStateCreateInfo(VkPolygonMode polygonMode,
+                                                                                           VkCullModeFlags cullMode,
+                                                                                           VkFrontFace frontFace,
+                                                                                           VkPipelineRasterizationStateCreateFlags flags = 0)
+        {
+            VkPipelineRasterizationStateCreateInfo pipelineRasterizationStateCreateInfo{};
+            pipelineRasterizationStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+            pipelineRasterizationStateCreateInfo.polygonMode = polygonMode;
+            pipelineRasterizationStateCreateInfo.cullMode = cullMode;
+            pipelineRasterizationStateCreateInfo.frontFace = frontFace;
+            pipelineRasterizationStateCreateInfo.flags = flags;
+            pipelineRasterizationStateCreateInfo.depthClampEnable = VK_FALSE;
+            pipelineRasterizationStateCreateInfo.lineWidth = 1.0f;
+            return pipelineRasterizationStateCreateInfo;
+        }
 
-		inline VkPipelineRasterizationStateCreateInfo pipelineRasterizationStateCreateInfo(
-			VkPolygonMode polygonMode,
-			VkCullModeFlags cullMode,
-			VkFrontFace frontFace,
-			VkPipelineRasterizationStateCreateFlags flags = 0)
-		{
-			VkPipelineRasterizationStateCreateInfo pipelineRasterizationStateCreateInfo {};
-			pipelineRasterizationStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-			pipelineRasterizationStateCreateInfo.polygonMode = polygonMode;
-			pipelineRasterizationStateCreateInfo.cullMode = cullMode;
-			pipelineRasterizationStateCreateInfo.frontFace = frontFace;
-			pipelineRasterizationStateCreateInfo.flags = flags;
-			pipelineRasterizationStateCreateInfo.depthClampEnable = VK_FALSE;
-			pipelineRasterizationStateCreateInfo.lineWidth = 1.0f;
-			return pipelineRasterizationStateCreateInfo;
-		}
+        inline VkPipelineColorBlendAttachmentState pipelineColorBlendAttachmentState(VkColorComponentFlags colorWriteMask, VkBool32 blendEnable)
+        {
+            VkPipelineColorBlendAttachmentState pipelineColorBlendAttachmentState{};
+            pipelineColorBlendAttachmentState.colorWriteMask = colorWriteMask;
+            pipelineColorBlendAttachmentState.blendEnable = blendEnable;
+            return pipelineColorBlendAttachmentState;
+        }
 
-		inline VkPipelineColorBlendAttachmentState pipelineColorBlendAttachmentState(
-			VkColorComponentFlags colorWriteMask,
-			VkBool32 blendEnable)
-		{
-			VkPipelineColorBlendAttachmentState pipelineColorBlendAttachmentState {};
-			pipelineColorBlendAttachmentState.colorWriteMask = colorWriteMask;
-			pipelineColorBlendAttachmentState.blendEnable = blendEnable;
-			return pipelineColorBlendAttachmentState;
-		}
+        inline VkPipelineColorBlendStateCreateInfo pipelineColorBlendStateCreateInfo(uint32_t attachmentCount,
+                                                                                     const VkPipelineColorBlendAttachmentState* pAttachments)
+        {
+            VkPipelineColorBlendStateCreateInfo pipelineColorBlendStateCreateInfo{};
+            pipelineColorBlendStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+            pipelineColorBlendStateCreateInfo.attachmentCount = attachmentCount;
+            pipelineColorBlendStateCreateInfo.pAttachments = pAttachments;
+            return pipelineColorBlendStateCreateInfo;
+        }
 
-		inline VkPipelineColorBlendStateCreateInfo pipelineColorBlendStateCreateInfo(
-			uint32_t attachmentCount,
-			const VkPipelineColorBlendAttachmentState * pAttachments)
-		{
-			VkPipelineColorBlendStateCreateInfo pipelineColorBlendStateCreateInfo {};
-			pipelineColorBlendStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-			pipelineColorBlendStateCreateInfo.attachmentCount = attachmentCount;
-			pipelineColorBlendStateCreateInfo.pAttachments = pAttachments;
-			return pipelineColorBlendStateCreateInfo;
-		}
+        inline VkPipelineDepthStencilStateCreateInfo pipelineDepthStencilStateCreateInfo(VkBool32 depthTestEnable,
+                                                                                         VkBool32 depthWriteEnable,
+                                                                                         VkCompareOp depthCompareOp)
+        {
+            VkPipelineDepthStencilStateCreateInfo pipelineDepthStencilStateCreateInfo{};
+            pipelineDepthStencilStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+            pipelineDepthStencilStateCreateInfo.depthTestEnable = depthTestEnable;
+            pipelineDepthStencilStateCreateInfo.depthWriteEnable = depthWriteEnable;
+            pipelineDepthStencilStateCreateInfo.depthCompareOp = depthCompareOp;
+            pipelineDepthStencilStateCreateInfo.front = pipelineDepthStencilStateCreateInfo.back;
+            pipelineDepthStencilStateCreateInfo.back.compareOp = VK_COMPARE_OP_ALWAYS;
+            return pipelineDepthStencilStateCreateInfo;
+        }
 
-		inline VkPipelineDepthStencilStateCreateInfo pipelineDepthStencilStateCreateInfo(
-			VkBool32 depthTestEnable,
-			VkBool32 depthWriteEnable,
-			VkCompareOp depthCompareOp)
-		{
-			VkPipelineDepthStencilStateCreateInfo pipelineDepthStencilStateCreateInfo {};
-			pipelineDepthStencilStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-			pipelineDepthStencilStateCreateInfo.depthTestEnable = depthTestEnable;
-			pipelineDepthStencilStateCreateInfo.depthWriteEnable = depthWriteEnable;
-			pipelineDepthStencilStateCreateInfo.depthCompareOp = depthCompareOp;
-			pipelineDepthStencilStateCreateInfo.front = pipelineDepthStencilStateCreateInfo.back;
-			pipelineDepthStencilStateCreateInfo.back.compareOp = VK_COMPARE_OP_ALWAYS;
-			return pipelineDepthStencilStateCreateInfo;
-		}
+        inline VkPipelineViewportStateCreateInfo pipelineViewportStateCreateInfo(uint32_t viewportCount,
+                                                                                 uint32_t scissorCount,
+                                                                                 VkPipelineViewportStateCreateFlags flags = 0)
+        {
+            VkPipelineViewportStateCreateInfo pipelineViewportStateCreateInfo{};
+            pipelineViewportStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+            pipelineViewportStateCreateInfo.viewportCount = viewportCount;
+            pipelineViewportStateCreateInfo.scissorCount = scissorCount;
+            pipelineViewportStateCreateInfo.flags = flags;
+            return pipelineViewportStateCreateInfo;
+        }
 
-		inline VkPipelineViewportStateCreateInfo pipelineViewportStateCreateInfo(
-			uint32_t viewportCount,
-			uint32_t scissorCount,
-			VkPipelineViewportStateCreateFlags flags = 0)
-		{
-			VkPipelineViewportStateCreateInfo pipelineViewportStateCreateInfo {};
-			pipelineViewportStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-			pipelineViewportStateCreateInfo.viewportCount = viewportCount;
-			pipelineViewportStateCreateInfo.scissorCount = scissorCount;
-			pipelineViewportStateCreateInfo.flags = flags;
-			return pipelineViewportStateCreateInfo;
-		}
+        inline VkPipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo(VkSampleCountFlagBits rasterizationSamples,
+                                                                                       VkPipelineMultisampleStateCreateFlags flags = 0)
+        {
+            VkPipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo{};
+            pipelineMultisampleStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+            pipelineMultisampleStateCreateInfo.rasterizationSamples = rasterizationSamples;
+            pipelineMultisampleStateCreateInfo.flags = flags;
+            return pipelineMultisampleStateCreateInfo;
+        }
 
-		inline VkPipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo(
-			VkSampleCountFlagBits rasterizationSamples,
-			VkPipelineMultisampleStateCreateFlags flags = 0)
-		{
-			VkPipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo {};
-			pipelineMultisampleStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-			pipelineMultisampleStateCreateInfo.rasterizationSamples = rasterizationSamples;
-			pipelineMultisampleStateCreateInfo.flags = flags;
-			return pipelineMultisampleStateCreateInfo;
-		}
+        inline VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo(const VkDynamicState* pDynamicStates,
+                                                                               uint32_t dynamicStateCount,
+                                                                               VkPipelineDynamicStateCreateFlags flags = 0)
+        {
+            VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo{};
+            pipelineDynamicStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+            pipelineDynamicStateCreateInfo.pDynamicStates = pDynamicStates;
+            pipelineDynamicStateCreateInfo.dynamicStateCount = dynamicStateCount;
+            pipelineDynamicStateCreateInfo.flags = flags;
+            return pipelineDynamicStateCreateInfo;
+        }
 
-		inline VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo(
-			const VkDynamicState * pDynamicStates,
-			uint32_t dynamicStateCount,
-			VkPipelineDynamicStateCreateFlags flags = 0)
-		{
-			VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo {};
-			pipelineDynamicStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-			pipelineDynamicStateCreateInfo.pDynamicStates = pDynamicStates;
-			pipelineDynamicStateCreateInfo.dynamicStateCount = dynamicStateCount;
-			pipelineDynamicStateCreateInfo.flags = flags;
-			return pipelineDynamicStateCreateInfo;
-		}
+        inline VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo(const std::vector<VkDynamicState>& pDynamicStates,
+                                                                               VkPipelineDynamicStateCreateFlags flags = 0)
+        {
+            VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo{};
+            pipelineDynamicStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+            pipelineDynamicStateCreateInfo.pDynamicStates = pDynamicStates.data();
+            pipelineDynamicStateCreateInfo.dynamicStateCount = static_cast<uint32_t>(pDynamicStates.size());
+            pipelineDynamicStateCreateInfo.flags = flags;
+            return pipelineDynamicStateCreateInfo;
+        }
 
-		inline VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo(
-			const std::vector<VkDynamicState>& pDynamicStates,
-			VkPipelineDynamicStateCreateFlags flags = 0)
-		{
-			VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo{};
-			pipelineDynamicStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-			pipelineDynamicStateCreateInfo.pDynamicStates = pDynamicStates.data();
-			pipelineDynamicStateCreateInfo.dynamicStateCount = static_cast<uint32_t>(pDynamicStates.size());
-			pipelineDynamicStateCreateInfo.flags = flags;
-			return pipelineDynamicStateCreateInfo;
-		}
+        inline VkPipelineTessellationStateCreateInfo pipelineTessellationStateCreateInfo(uint32_t patchControlPoints)
+        {
+            VkPipelineTessellationStateCreateInfo pipelineTessellationStateCreateInfo{};
+            pipelineTessellationStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
+            pipelineTessellationStateCreateInfo.patchControlPoints = patchControlPoints;
+            return pipelineTessellationStateCreateInfo;
+        }
 
-		inline VkPipelineTessellationStateCreateInfo pipelineTessellationStateCreateInfo(uint32_t patchControlPoints)
-		{
-			VkPipelineTessellationStateCreateInfo pipelineTessellationStateCreateInfo {};
-			pipelineTessellationStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
-			pipelineTessellationStateCreateInfo.patchControlPoints = patchControlPoints;
-			return pipelineTessellationStateCreateInfo;
-		}
+        inline VkGraphicsPipelineCreateInfo pipelineCreateInfo(VkPipelineLayout layout, VkRenderPass renderPass, VkPipelineCreateFlags flags = 0)
+        {
+            VkGraphicsPipelineCreateInfo pipelineCreateInfo{};
+            pipelineCreateInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+            pipelineCreateInfo.layout = layout;
+            pipelineCreateInfo.renderPass = renderPass;
+            pipelineCreateInfo.flags = flags;
+            pipelineCreateInfo.basePipelineIndex = -1;
+            pipelineCreateInfo.basePipelineHandle = VK_NULL_HANDLE;
+            return pipelineCreateInfo;
+        }
 
-		inline VkGraphicsPipelineCreateInfo pipelineCreateInfo(
-			VkPipelineLayout layout,
-			VkRenderPass renderPass,
-			VkPipelineCreateFlags flags = 0)
-		{
-			VkGraphicsPipelineCreateInfo pipelineCreateInfo {};
-			pipelineCreateInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-			pipelineCreateInfo.layout = layout;
-			pipelineCreateInfo.renderPass = renderPass;
-			pipelineCreateInfo.flags = flags;
-			pipelineCreateInfo.basePipelineIndex = -1;
-			pipelineCreateInfo.basePipelineHandle = VK_NULL_HANDLE;
-			return pipelineCreateInfo;
-		}
+        inline VkGraphicsPipelineCreateInfo pipelineCreateInfo()
+        {
+            VkGraphicsPipelineCreateInfo pipelineCreateInfo{};
+            pipelineCreateInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+            pipelineCreateInfo.basePipelineIndex = -1;
+            pipelineCreateInfo.basePipelineHandle = VK_NULL_HANDLE;
+            return pipelineCreateInfo;
+        }
 
-		inline VkGraphicsPipelineCreateInfo pipelineCreateInfo()
-		{
-			VkGraphicsPipelineCreateInfo pipelineCreateInfo{};
-			pipelineCreateInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-			pipelineCreateInfo.basePipelineIndex = -1;
-			pipelineCreateInfo.basePipelineHandle = VK_NULL_HANDLE;
-			return pipelineCreateInfo;
-		}
+        inline VkComputePipelineCreateInfo computePipelineCreateInfo(VkPipelineLayout layout, VkPipelineCreateFlags flags = 0)
+        {
+            VkComputePipelineCreateInfo computePipelineCreateInfo{};
+            computePipelineCreateInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+            computePipelineCreateInfo.layout = layout;
+            computePipelineCreateInfo.flags = flags;
+            return computePipelineCreateInfo;
+        }
 
-		inline VkComputePipelineCreateInfo computePipelineCreateInfo(
-			VkPipelineLayout layout, 
-			VkPipelineCreateFlags flags = 0)
-		{
-			VkComputePipelineCreateInfo computePipelineCreateInfo {};
-			computePipelineCreateInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-			computePipelineCreateInfo.layout = layout;
-			computePipelineCreateInfo.flags = flags;
-			return computePipelineCreateInfo;
-		}
+        inline VkPushConstantRange pushConstantRange(VkShaderStageFlags stageFlags, uint32_t size, uint32_t offset)
+        {
+            VkPushConstantRange pushConstantRange{};
+            pushConstantRange.stageFlags = stageFlags;
+            pushConstantRange.offset = offset;
+            pushConstantRange.size = size;
+            return pushConstantRange;
+        }
 
-		inline VkPushConstantRange pushConstantRange(
-			VkShaderStageFlags stageFlags,
-			uint32_t size,
-			uint32_t offset)
-		{
-			VkPushConstantRange pushConstantRange {};
-			pushConstantRange.stageFlags = stageFlags;
-			pushConstantRange.offset = offset;
-			pushConstantRange.size = size;
-			return pushConstantRange;
-		}
+        inline VkBindSparseInfo bindSparseInfo()
+        {
+            VkBindSparseInfo bindSparseInfo{};
+            bindSparseInfo.sType = VK_STRUCTURE_TYPE_BIND_SPARSE_INFO;
+            return bindSparseInfo;
+        }
 
-		inline VkBindSparseInfo bindSparseInfo()
-		{
-			VkBindSparseInfo bindSparseInfo{};
-			bindSparseInfo.sType = VK_STRUCTURE_TYPE_BIND_SPARSE_INFO;
-			return bindSparseInfo;
-		}
+        /** @brief Initialize a map entry for a shader specialization constant */
+        inline VkSpecializationMapEntry specializationMapEntry(uint32_t constantID, uint32_t offset, size_t size)
+        {
+            VkSpecializationMapEntry specializationMapEntry{};
+            specializationMapEntry.constantID = constantID;
+            specializationMapEntry.offset = offset;
+            specializationMapEntry.size = size;
+            return specializationMapEntry;
+        }
 
-		/** @brief Initialize a map entry for a shader specialization constant */
-		inline VkSpecializationMapEntry specializationMapEntry(uint32_t constantID, uint32_t offset, size_t size)
-		{
-			VkSpecializationMapEntry specializationMapEntry{};
-			specializationMapEntry.constantID = constantID;
-			specializationMapEntry.offset = offset;
-			specializationMapEntry.size = size;
-			return specializationMapEntry;
-		}
-
-		/** @brief Initialize a specialization constant info structure to pass to a shader stage */
-		inline VkSpecializationInfo specializationInfo(uint32_t mapEntryCount, const VkSpecializationMapEntry* mapEntries, size_t dataSize, const void* data)
-		{
-			VkSpecializationInfo specializationInfo{};
-			specializationInfo.mapEntryCount = mapEntryCount;
-			specializationInfo.pMapEntries = mapEntries;
-			specializationInfo.dataSize = dataSize;
-			specializationInfo.pData = data;
-			return specializationInfo;
-		}
-	}
-}
+        /** @brief Initialize a specialization constant info structure to pass to a shader stage */
+        inline VkSpecializationInfo specializationInfo(uint32_t mapEntryCount, const VkSpecializationMapEntry* mapEntries, size_t dataSize, const void* data)
+        {
+            VkSpecializationInfo specializationInfo{};
+            specializationInfo.mapEntryCount = mapEntryCount;
+            specializationInfo.pMapEntries = mapEntries;
+            specializationInfo.dataSize = dataSize;
+            specializationInfo.pData = data;
+            return specializationInfo;
+        }
+    }  // namespace initializers
+}  // namespace vks

--- a/base/VulkanModel.hpp
+++ b/base/VulkanModel.hpp
@@ -15,8 +15,8 @@
 
 #include "vulkan/vulkan.h"
 
-#include <assimp/Importer.hpp> 
-#include <assimp/scene.h>     
+#include <assimp/Importer.hpp>
+#include <assimp/scene.h>
 #include <assimp/postprocess.h>
 #include <assimp/cimport.h>
 
@@ -33,118 +33,125 @@
 
 namespace vks
 {
-	/** @brief Vertex layout components */
-	typedef enum Component {
-		VERTEX_COMPONENT_POSITION = 0x0,
-		VERTEX_COMPONENT_NORMAL = 0x1,
-		VERTEX_COMPONENT_COLOR = 0x2,
-		VERTEX_COMPONENT_UV = 0x3,
-		VERTEX_COMPONENT_TANGENT = 0x4,
-		VERTEX_COMPONENT_BITANGENT = 0x5,
-		VERTEX_COMPONENT_DUMMY_FLOAT = 0x6,
-		VERTEX_COMPONENT_DUMMY_VEC4 = 0x7
-	} Component;
+    /** @brief Vertex layout components */
+    typedef enum Component {
+        VERTEX_COMPONENT_POSITION = 0x0,
+        VERTEX_COMPONENT_NORMAL = 0x1,
+        VERTEX_COMPONENT_COLOR = 0x2,
+        VERTEX_COMPONENT_UV = 0x3,
+        VERTEX_COMPONENT_TANGENT = 0x4,
+        VERTEX_COMPONENT_BITANGENT = 0x5,
+        VERTEX_COMPONENT_DUMMY_FLOAT = 0x6,
+        VERTEX_COMPONENT_DUMMY_VEC4 = 0x7
+    } Component;
 
-	/** @brief Stores vertex layout components for model loading and Vulkan vertex input and atribute bindings  */
-	struct VertexLayout {
-	public:
-		/** @brief Components used to generate vertices from */
-		std::vector<Component> components;
+    /** @brief Stores vertex layout components for model loading and Vulkan vertex input and atribute bindings  */
+    struct VertexLayout
+    {
+    public:
+        /** @brief Components used to generate vertices from */
+        std::vector<Component> components;
 
-		VertexLayout(std::vector<Component> components)
-		{
-			this->components = std::move(components);
-		}
+        VertexLayout(std::vector<Component> components)
+        {
+            this->components = std::move(components);
+        }
 
-		uint32_t stride()
-		{
-			uint32_t res = 0;
-			for (auto& component : components)
-			{
-				switch (component)
-				{
-				case VERTEX_COMPONENT_UV:
-					res += 2 * sizeof(float);
-					break;
-				case VERTEX_COMPONENT_DUMMY_FLOAT:
-					res += sizeof(float);
-					break;
-				case VERTEX_COMPONENT_DUMMY_VEC4:
-					res += 4 * sizeof(float);
-					break;
-				default:
-					// All components except the ones listed above are made up of 3 floats
-					res += 3 * sizeof(float);
-				}
-			}
-			return res;
-		}
-	};
+        uint32_t stride()
+        {
+            uint32_t res = 0;
+            for (auto& component : components)
+            {
+                switch (component)
+                {
+                    case VERTEX_COMPONENT_UV:
+                        res += 2 * sizeof(float);
+                        break;
+                    case VERTEX_COMPONENT_DUMMY_FLOAT:
+                        res += sizeof(float);
+                        break;
+                    case VERTEX_COMPONENT_DUMMY_VEC4:
+                        res += 4 * sizeof(float);
+                        break;
+                    default:
+                        // All components except the ones listed above are made up of 3 floats
+                        res += 3 * sizeof(float);
+                }
+            }
+            return res;
+        }
+    };
 
-	/** @brief Used to parametrize model loading */
-	struct ModelCreateInfo {
-		glm::vec3 center;
-		glm::vec3 scale;
-		glm::vec2 uvscale;
-		VkMemoryPropertyFlags memoryPropertyFlags = 0;
+    /** @brief Used to parametrize model loading */
+    struct ModelCreateInfo
+    {
+        glm::vec3 center;
+        glm::vec3 scale;
+        glm::vec2 uvscale;
+        VkMemoryPropertyFlags memoryPropertyFlags = 0;
 
-		ModelCreateInfo() : center(glm::vec3(0.0f)), scale(glm::vec3(1.0f)), uvscale(glm::vec2(1.0f)) {};
+        ModelCreateInfo()
+            : center(glm::vec3(0.0f))
+            , scale(glm::vec3(1.0f))
+            , uvscale(glm::vec2(1.0f)){};
 
-		ModelCreateInfo(glm::vec3 scale, glm::vec2 uvscale, glm::vec3 center)
-		{
-			this->center = center;
-			this->scale = scale;
-			this->uvscale = uvscale;
-		}
+        ModelCreateInfo(glm::vec3 scale, glm::vec2 uvscale, glm::vec3 center)
+        {
+            this->center = center;
+            this->scale = scale;
+            this->uvscale = uvscale;
+        }
 
-		ModelCreateInfo(float scale, float uvscale, float center)
-		{
-			this->center = glm::vec3(center);
-			this->scale = glm::vec3(scale);
-			this->uvscale = glm::vec2(uvscale);
-		}
+        ModelCreateInfo(float scale, float uvscale, float center)
+        {
+            this->center = glm::vec3(center);
+            this->scale = glm::vec3(scale);
+            this->uvscale = glm::vec2(uvscale);
+        }
+    };
 
-	};
+    struct Model
+    {
+        VkDevice device = nullptr;
+        vks::Buffer vertices;
+        vks::Buffer indices;
+        uint32_t indexCount = 0;
+        uint32_t vertexCount = 0;
 
-	struct Model {
-		VkDevice device = nullptr;
-		vks::Buffer vertices;
-		vks::Buffer indices;
-		uint32_t indexCount = 0;
-		uint32_t vertexCount = 0;
+        /** @brief Stores vertex and index base and counts for each part of a model */
+        struct ModelPart
+        {
+            uint32_t vertexBase;
+            uint32_t vertexCount;
+            uint32_t indexBase;
+            uint32_t indexCount;
+        };
+        std::vector<ModelPart> parts;
 
-		/** @brief Stores vertex and index base and counts for each part of a model */
-		struct ModelPart {
-			uint32_t vertexBase;
-			uint32_t vertexCount;
-			uint32_t indexBase;
-			uint32_t indexCount;
-		};
-		std::vector<ModelPart> parts;
+        static const int defaultFlags =
+            aiProcess_FlipWindingOrder | aiProcess_Triangulate | aiProcess_PreTransformVertices | aiProcess_CalcTangentSpace | aiProcess_GenSmoothNormals;
 
-		static const int defaultFlags = aiProcess_FlipWindingOrder | aiProcess_Triangulate | aiProcess_PreTransformVertices | aiProcess_CalcTangentSpace | aiProcess_GenSmoothNormals;
+        struct Dimension
+        {
+            glm::vec3 min = glm::vec3(FLT_MAX);
+            glm::vec3 max = glm::vec3(-FLT_MAX);
+            glm::vec3 size;
+        } dim;
 
-		struct Dimension
-		{
-			glm::vec3 min = glm::vec3(FLT_MAX);
-			glm::vec3 max = glm::vec3(-FLT_MAX);
-			glm::vec3 size;
-		} dim;
+        /** @brief Release all Vulkan resources of this model */
+        void destroy()
+        {
+            assert(device);
+            vkDestroyBuffer(device, vertices.buffer, nullptr);
+            vkFreeMemory(device, vertices.memory, nullptr);
+            if (indices.buffer != VK_NULL_HANDLE)
+            {
+                vkDestroyBuffer(device, indices.buffer, nullptr);
+                vkFreeMemory(device, indices.memory, nullptr);
+            }
+        }
 
-		/** @brief Release all Vulkan resources of this model */
-		void destroy()
-		{		
-			assert(device);
-			vkDestroyBuffer(device, vertices.buffer, nullptr);
-			vkFreeMemory(device, vertices.memory, nullptr);
-			if (indices.buffer != VK_NULL_HANDLE)
-			{
-				vkDestroyBuffer(device, indices.buffer, nullptr);
-				vkFreeMemory(device, indices.memory, nullptr);
-			}
-		}
-
-		/**
+        /**
 		* Loads a 3D model from a file into Vulkan buffers
 		*
 		* @param device Pointer to the Vulkan device used to generated the vertex and index buffers on
@@ -153,231 +160,224 @@ namespace vks
 		* @param createInfo MeshCreateInfo structure for load time settings like scale, center, etc.
 		* @param copyQueue Queue used for the memory staging copy commands (must support transfer)
 		*/
-		bool loadFromFile(const std::string& filename, vks::VertexLayout layout, vks::ModelCreateInfo *createInfo, vks::VulkanDevice *device, VkQueue copyQueue)
-		{
-			this->device = device->logicalDevice;
+        bool loadFromFile(const std::string& filename, vks::VertexLayout layout, vks::ModelCreateInfo* createInfo, vks::VulkanDevice* device, VkQueue copyQueue)
+        {
+            this->device = device->logicalDevice;
 
-			Assimp::Importer Importer;
-			const aiScene* pScene;
+            Assimp::Importer Importer;
+            const aiScene* pScene;
 
-			// Load file
+            // Load file
 #if defined(__ANDROID__)
-			// Meshes are stored inside the apk on Android (compressed)
-			// So they need to be loaded via the asset manager
+            // Meshes are stored inside the apk on Android (compressed)
+            // So they need to be loaded via the asset manager
 
-			AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, filename.c_str(), AASSET_MODE_STREAMING);
-			if (!asset) {
-				LOGE("Could not load mesh from \"%s\"!", filename.c_str());
-				return false;
-			}
-			assert(asset);
-			size_t size = AAsset_getLength(asset);
+            AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, filename.c_str(), AASSET_MODE_STREAMING);
+            if (!asset)
+            {
+                LOGE("Could not load mesh from \"%s\"!", filename.c_str());
+                return false;
+            }
+            assert(asset);
+            size_t size = AAsset_getLength(asset);
 
-			assert(size > 0);
+            assert(size > 0);
 
-			void *meshData = malloc(size);
-			AAsset_read(asset, meshData, size);
-			AAsset_close(asset);
+            void* meshData = malloc(size);
+            AAsset_read(asset, meshData, size);
+            AAsset_close(asset);
 
-			pScene = Importer.ReadFileFromMemory(meshData, size, defaultFlags);
+            pScene = Importer.ReadFileFromMemory(meshData, size, defaultFlags);
 
-			free(meshData);
+            free(meshData);
 #else
-			pScene = Importer.ReadFile(filename.c_str(), defaultFlags);
-			if (!pScene) {
-				std::string error = Importer.GetErrorString();
-				vks::tools::exitFatal(error + "\n\nThe file may be part of the additional asset pack.\n\nRun \"download_assets.py\" in the repository root to download the latest version.", -1);
-			}
+            pScene = Importer.ReadFile(filename.c_str(), defaultFlags);
+            if (!pScene)
+            {
+                std::string error = Importer.GetErrorString();
+                vks::tools::exitFatal(error +
+                                          "\n\nThe file may be part of the additional asset pack.\n\nRun \"download_assets.py\" in the repository root to "
+                                          "download the latest version.",
+                                      -1);
+            }
 #endif
 
-			if (pScene)
-			{
-				parts.clear();
-				parts.resize(pScene->mNumMeshes);
+            if (pScene)
+            {
+                parts.clear();
+                parts.resize(pScene->mNumMeshes);
 
-				glm::vec3 scale(1.0f);
-				glm::vec2 uvscale(1.0f);
-				glm::vec3 center(0.0f);
-				if (createInfo)
-				{
-					scale = createInfo->scale;
-					uvscale = createInfo->uvscale;
-					center = createInfo->center;
-				}
+                glm::vec3 scale(1.0f);
+                glm::vec2 uvscale(1.0f);
+                glm::vec3 center(0.0f);
+                if (createInfo)
+                {
+                    scale = createInfo->scale;
+                    uvscale = createInfo->uvscale;
+                    center = createInfo->center;
+                }
 
-				std::vector<float> vertexBuffer;
-				std::vector<uint32_t> indexBuffer;
+                std::vector<float> vertexBuffer;
+                std::vector<uint32_t> indexBuffer;
 
-				vertexCount = 0;
-				indexCount = 0;
+                vertexCount = 0;
+                indexCount = 0;
 
-				// Load meshes
-				for (unsigned int i = 0; i < pScene->mNumMeshes; i++)
-				{
-					const aiMesh* paiMesh = pScene->mMeshes[i];
+                // Load meshes
+                for (unsigned int i = 0; i < pScene->mNumMeshes; i++)
+                {
+                    const aiMesh* paiMesh = pScene->mMeshes[i];
 
-					parts[i] = {};
-					parts[i].vertexBase = vertexCount;
-					parts[i].indexBase = indexCount;
+                    parts[i] = {};
+                    parts[i].vertexBase = vertexCount;
+                    parts[i].indexBase = indexCount;
 
-					vertexCount += pScene->mMeshes[i]->mNumVertices;
+                    vertexCount += pScene->mMeshes[i]->mNumVertices;
 
-					aiColor3D pColor(0.f, 0.f, 0.f);
-					pScene->mMaterials[paiMesh->mMaterialIndex]->Get(AI_MATKEY_COLOR_DIFFUSE, pColor);
+                    aiColor3D pColor(0.f, 0.f, 0.f);
+                    pScene->mMaterials[paiMesh->mMaterialIndex]->Get(AI_MATKEY_COLOR_DIFFUSE, pColor);
 
-					const aiVector3D Zero3D(0.0f, 0.0f, 0.0f);
+                    const aiVector3D Zero3D(0.0f, 0.0f, 0.0f);
 
-					for (unsigned int j = 0; j < paiMesh->mNumVertices; j++)
-					{
-						const aiVector3D* pPos = &(paiMesh->mVertices[j]);
-						const aiVector3D* pNormal = &(paiMesh->mNormals[j]);
-						const aiVector3D* pTexCoord = (paiMesh->HasTextureCoords(0)) ? &(paiMesh->mTextureCoords[0][j]) : &Zero3D;
-						const aiVector3D* pTangent = (paiMesh->HasTangentsAndBitangents()) ? &(paiMesh->mTangents[j]) : &Zero3D;
-						const aiVector3D* pBiTangent = (paiMesh->HasTangentsAndBitangents()) ? &(paiMesh->mBitangents[j]) : &Zero3D;
+                    for (unsigned int j = 0; j < paiMesh->mNumVertices; j++)
+                    {
+                        const aiVector3D* pPos = &(paiMesh->mVertices[j]);
+                        const aiVector3D* pNormal = &(paiMesh->mNormals[j]);
+                        const aiVector3D* pTexCoord = (paiMesh->HasTextureCoords(0)) ? &(paiMesh->mTextureCoords[0][j]) : &Zero3D;
+                        const aiVector3D* pTangent = (paiMesh->HasTangentsAndBitangents()) ? &(paiMesh->mTangents[j]) : &Zero3D;
+                        const aiVector3D* pBiTangent = (paiMesh->HasTangentsAndBitangents()) ? &(paiMesh->mBitangents[j]) : &Zero3D;
 
-						for (auto& component : layout.components)
-						{
-							switch (component) {
-							case VERTEX_COMPONENT_POSITION:
-								vertexBuffer.push_back(pPos->x * scale.x + center.x);
-								vertexBuffer.push_back(-pPos->y * scale.y + center.y);
-								vertexBuffer.push_back(pPos->z * scale.z + center.z);
-								break;
-							case VERTEX_COMPONENT_NORMAL:
-								vertexBuffer.push_back(pNormal->x);
-								vertexBuffer.push_back(-pNormal->y);
-								vertexBuffer.push_back(pNormal->z);
-								break;
-							case VERTEX_COMPONENT_UV:
-								vertexBuffer.push_back(pTexCoord->x * uvscale.s);
-								vertexBuffer.push_back(pTexCoord->y * uvscale.t);
-								break;
-							case VERTEX_COMPONENT_COLOR:
-								vertexBuffer.push_back(pColor.r);
-								vertexBuffer.push_back(pColor.g);
-								vertexBuffer.push_back(pColor.b);
-								break;
-							case VERTEX_COMPONENT_TANGENT:
-								vertexBuffer.push_back(pTangent->x);
-								vertexBuffer.push_back(pTangent->y);
-								vertexBuffer.push_back(pTangent->z);
-								break;
-							case VERTEX_COMPONENT_BITANGENT:
-								vertexBuffer.push_back(pBiTangent->x);
-								vertexBuffer.push_back(pBiTangent->y);
-								vertexBuffer.push_back(pBiTangent->z);
-								break;
-							// Dummy components for padding
-							case VERTEX_COMPONENT_DUMMY_FLOAT:
-								vertexBuffer.push_back(0.0f);
-								break;
-							case VERTEX_COMPONENT_DUMMY_VEC4:
-								vertexBuffer.push_back(0.0f);
-								vertexBuffer.push_back(0.0f);
-								vertexBuffer.push_back(0.0f);
-								vertexBuffer.push_back(0.0f);
-								break;
-							};
-						}
+                        for (auto& component : layout.components)
+                        {
+                            switch (component)
+                            {
+                                case VERTEX_COMPONENT_POSITION:
+                                    vertexBuffer.push_back(pPos->x * scale.x + center.x);
+                                    vertexBuffer.push_back(-pPos->y * scale.y + center.y);
+                                    vertexBuffer.push_back(pPos->z * scale.z + center.z);
+                                    break;
+                                case VERTEX_COMPONENT_NORMAL:
+                                    vertexBuffer.push_back(pNormal->x);
+                                    vertexBuffer.push_back(-pNormal->y);
+                                    vertexBuffer.push_back(pNormal->z);
+                                    break;
+                                case VERTEX_COMPONENT_UV:
+                                    vertexBuffer.push_back(pTexCoord->x * uvscale.s);
+                                    vertexBuffer.push_back(pTexCoord->y * uvscale.t);
+                                    break;
+                                case VERTEX_COMPONENT_COLOR:
+                                    vertexBuffer.push_back(pColor.r);
+                                    vertexBuffer.push_back(pColor.g);
+                                    vertexBuffer.push_back(pColor.b);
+                                    break;
+                                case VERTEX_COMPONENT_TANGENT:
+                                    vertexBuffer.push_back(pTangent->x);
+                                    vertexBuffer.push_back(pTangent->y);
+                                    vertexBuffer.push_back(pTangent->z);
+                                    break;
+                                case VERTEX_COMPONENT_BITANGENT:
+                                    vertexBuffer.push_back(pBiTangent->x);
+                                    vertexBuffer.push_back(pBiTangent->y);
+                                    vertexBuffer.push_back(pBiTangent->z);
+                                    break;
+                                // Dummy components for padding
+                                case VERTEX_COMPONENT_DUMMY_FLOAT:
+                                    vertexBuffer.push_back(0.0f);
+                                    break;
+                                case VERTEX_COMPONENT_DUMMY_VEC4:
+                                    vertexBuffer.push_back(0.0f);
+                                    vertexBuffer.push_back(0.0f);
+                                    vertexBuffer.push_back(0.0f);
+                                    vertexBuffer.push_back(0.0f);
+                                    break;
+                            };
+                        }
 
-						dim.max.x = fmax(pPos->x, dim.max.x);
-						dim.max.y = fmax(pPos->y, dim.max.y);
-						dim.max.z = fmax(pPos->z, dim.max.z);
+                        dim.max.x = fmax(pPos->x, dim.max.x);
+                        dim.max.y = fmax(pPos->y, dim.max.y);
+                        dim.max.z = fmax(pPos->z, dim.max.z);
 
-						dim.min.x = fmin(pPos->x, dim.min.x);
-						dim.min.y = fmin(pPos->y, dim.min.y);
-						dim.min.z = fmin(pPos->z, dim.min.z);
-					}
+                        dim.min.x = fmin(pPos->x, dim.min.x);
+                        dim.min.y = fmin(pPos->y, dim.min.y);
+                        dim.min.z = fmin(pPos->z, dim.min.z);
+                    }
 
-					dim.size = dim.max - dim.min;
+                    dim.size = dim.max - dim.min;
 
-					parts[i].vertexCount = paiMesh->mNumVertices;
+                    parts[i].vertexCount = paiMesh->mNumVertices;
 
-					uint32_t indexBase = static_cast<uint32_t>(indexBuffer.size());
-					for (unsigned int j = 0; j < paiMesh->mNumFaces; j++)
-					{
-						const aiFace& Face = paiMesh->mFaces[j];
-						if (Face.mNumIndices != 3)
-							continue;
-						indexBuffer.push_back(indexBase + Face.mIndices[0]);
-						indexBuffer.push_back(indexBase + Face.mIndices[1]);
-						indexBuffer.push_back(indexBase + Face.mIndices[2]);
-						parts[i].indexCount += 3;
-						indexCount += 3;
-					}
-				}
+                    uint32_t indexBase = static_cast<uint32_t>(indexBuffer.size());
+                    for (unsigned int j = 0; j < paiMesh->mNumFaces; j++)
+                    {
+                        const aiFace& Face = paiMesh->mFaces[j];
+                        if (Face.mNumIndices != 3)
+                            continue;
+                        indexBuffer.push_back(indexBase + Face.mIndices[0]);
+                        indexBuffer.push_back(indexBase + Face.mIndices[1]);
+                        indexBuffer.push_back(indexBase + Face.mIndices[2]);
+                        parts[i].indexCount += 3;
+                        indexCount += 3;
+                    }
+                }
 
+                uint32_t vBufferSize = static_cast<uint32_t>(vertexBuffer.size()) * sizeof(float);
+                uint32_t iBufferSize = static_cast<uint32_t>(indexBuffer.size()) * sizeof(uint32_t);
 
-				uint32_t vBufferSize = static_cast<uint32_t>(vertexBuffer.size()) * sizeof(float);
-				uint32_t iBufferSize = static_cast<uint32_t>(indexBuffer.size()) * sizeof(uint32_t);
+                // Use staging buffer to move vertex and index buffer to device local memory
+                // Create staging buffers
+                vks::Buffer vertexStaging, indexStaging;
 
-				// Use staging buffer to move vertex and index buffer to device local memory
-				// Create staging buffers
-				vks::Buffer vertexStaging, indexStaging;
+                // Vertex buffer
+                VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &vertexStaging, vBufferSize,
+                                                     vertexBuffer.data()));
 
-				// Vertex buffer
-				VK_CHECK_RESULT(device->createBuffer(
-					VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-					&vertexStaging,
-					vBufferSize,
-					vertexBuffer.data()));
+                // Index buffer
+                VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &indexStaging, iBufferSize,
+                                                     indexBuffer.data()));
 
-				// Index buffer
-				VK_CHECK_RESULT(device->createBuffer(
-					VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-					&indexStaging,
-					iBufferSize,
-					indexBuffer.data()));
+                // Create device local target buffers
+                // Vertex buffer
+                VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | createInfo->memoryPropertyFlags,
+                                                     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &vertices, vBufferSize));
 
-				// Create device local target buffers
-				// Vertex buffer
-				VK_CHECK_RESULT(device->createBuffer(
-					VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | createInfo->memoryPropertyFlags,
-					VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-					&vertices,
-					vBufferSize));
+                // Index buffer
+                VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | createInfo->memoryPropertyFlags,
+                                                     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &indices, iBufferSize));
 
-				// Index buffer
-				VK_CHECK_RESULT(device->createBuffer(
-					VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | createInfo->memoryPropertyFlags,
-					VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-					&indices,
-					iBufferSize));
+                // Copy from staging buffers
+                VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-				// Copy from staging buffers
-				VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+                VkBufferCopy copyRegion{};
 
-				VkBufferCopy copyRegion{};
+                copyRegion.size = vBufferSize;
+                vkCmdCopyBuffer(copyCmd, vertexStaging.buffer, vertices.buffer, 1, &copyRegion);
 
-				copyRegion.size = vBufferSize;
-				vkCmdCopyBuffer(copyCmd, vertexStaging.buffer, vertices.buffer, 1, &copyRegion);
+                copyRegion.size = iBufferSize;
+                vkCmdCopyBuffer(copyCmd, indexStaging.buffer, indices.buffer, 1, &copyRegion);
 
-				copyRegion.size = iBufferSize;
-				vkCmdCopyBuffer(copyCmd, indexStaging.buffer, indices.buffer, 1, &copyRegion);
+                device->flushCommandBuffer(copyCmd, copyQueue);
 
-				device->flushCommandBuffer(copyCmd, copyQueue);
+                // Destroy staging resources
+                vkDestroyBuffer(device->logicalDevice, vertexStaging.buffer, nullptr);
+                vkFreeMemory(device->logicalDevice, vertexStaging.memory, nullptr);
+                vkDestroyBuffer(device->logicalDevice, indexStaging.buffer, nullptr);
+                vkFreeMemory(device->logicalDevice, indexStaging.memory, nullptr);
 
-				// Destroy staging resources
-				vkDestroyBuffer(device->logicalDevice, vertexStaging.buffer, nullptr);
-				vkFreeMemory(device->logicalDevice, vertexStaging.memory, nullptr);
-				vkDestroyBuffer(device->logicalDevice, indexStaging.buffer, nullptr);
-				vkFreeMemory(device->logicalDevice, indexStaging.memory, nullptr);
-
-				return true;
-			}
-			else
-			{
-				printf("Error parsing '%s': '%s'\n", filename.c_str(), Importer.GetErrorString());
+                return true;
+            }
+            else
+            {
+                printf("Error parsing '%s': '%s'\n", filename.c_str(), Importer.GetErrorString());
 #if defined(__ANDROID__)
-				LOGE("Error parsing '%s': '%s'", filename.c_str(), Importer.GetErrorString());
+                LOGE("Error parsing '%s': '%s'", filename.c_str(), Importer.GetErrorString());
 #endif
-				return false;
-			}
-		};
+                return false;
+            }
+        };
 
-		/**
+        /**
 		* Loads a 3D model from a file into Vulkan buffers
 		*
 		* @param device Pointer to the Vulkan device used to generated the vertex and index buffers on
@@ -386,10 +386,10 @@ namespace vks
 		* @param scale Load time scene scale
 		* @param copyQueue Queue used for the memory staging copy commands (must support transfer)
 		*/
-		bool loadFromFile(const std::string& filename, vks::VertexLayout layout, float scale, vks::VulkanDevice *device, VkQueue copyQueue)
-		{
-			vks::ModelCreateInfo modelCreateInfo(scale, 1.0f, 0.0f);
-			return loadFromFile(filename, layout, &modelCreateInfo, device, copyQueue);
-		}
-	};
-};
+        bool loadFromFile(const std::string& filename, vks::VertexLayout layout, float scale, vks::VulkanDevice* device, VkQueue copyQueue)
+        {
+            vks::ModelCreateInfo modelCreateInfo(scale, 1.0f, 0.0f);
+            return loadFromFile(filename, layout, &modelCreateInfo, device, copyQueue);
+        }
+    };
+};  // namespace vks

--- a/base/VulkanSwapChain.hpp
+++ b/base/VulkanSwapChain.hpp
@@ -24,230 +24,232 @@
 #endif
 
 // Macro to get a procedure address based on a vulkan instance
-#define GET_INSTANCE_PROC_ADDR(inst, entrypoint)                        \
-{                                                                       \
-	fp##entrypoint = reinterpret_cast<PFN_vk##entrypoint>(vkGetInstanceProcAddr(inst, "vk"#entrypoint)); \
-	if (fp##entrypoint == NULL)                                         \
-	{																    \
-		exit(1);                                                        \
-	}                                                                   \
-}
+#define GET_INSTANCE_PROC_ADDR(inst, entrypoint)                                                              \
+    {                                                                                                         \
+        fp##entrypoint = reinterpret_cast<PFN_vk##entrypoint>(vkGetInstanceProcAddr(inst, "vk" #entrypoint)); \
+        if (fp##entrypoint == NULL)                                                                           \
+        {                                                                                                     \
+            exit(1);                                                                                          \
+        }                                                                                                     \
+    }
 
 // Macro to get a procedure address based on a vulkan device
-#define GET_DEVICE_PROC_ADDR(dev, entrypoint)                           \
-{                                                                       \
-	fp##entrypoint = reinterpret_cast<PFN_vk##entrypoint>(vkGetDeviceProcAddr(dev, "vk"#entrypoint));   \
-	if (fp##entrypoint == NULL)                                         \
-	{																    \
-		exit(1);                                                        \
-	}                                                                   \
-}
+#define GET_DEVICE_PROC_ADDR(dev, entrypoint)                                                              \
+    {                                                                                                      \
+        fp##entrypoint = reinterpret_cast<PFN_vk##entrypoint>(vkGetDeviceProcAddr(dev, "vk" #entrypoint)); \
+        if (fp##entrypoint == NULL)                                                                        \
+        {                                                                                                  \
+            exit(1);                                                                                       \
+        }                                                                                                  \
+    }
 
-typedef struct _SwapChainBuffers {
-	VkImage image;
-	VkImageView view;
+typedef struct _SwapChainBuffers
+{
+    VkImage image;
+    VkImageView view;
 } SwapChainBuffer;
 
 class VulkanSwapChain
 {
-private: 
-	VkInstance instance;
-	VkDevice device;
-	VkPhysicalDevice physicalDevice;
-	VkSurfaceKHR surface;
-	// Function pointers
-	PFN_vkGetPhysicalDeviceSurfaceSupportKHR fpGetPhysicalDeviceSurfaceSupportKHR;
-	PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR fpGetPhysicalDeviceSurfaceCapabilitiesKHR; 
-	PFN_vkGetPhysicalDeviceSurfaceFormatsKHR fpGetPhysicalDeviceSurfaceFormatsKHR;
-	PFN_vkGetPhysicalDeviceSurfacePresentModesKHR fpGetPhysicalDeviceSurfacePresentModesKHR;
-	PFN_vkCreateSwapchainKHR fpCreateSwapchainKHR;
-	PFN_vkDestroySwapchainKHR fpDestroySwapchainKHR;
-	PFN_vkGetSwapchainImagesKHR fpGetSwapchainImagesKHR;
-	PFN_vkAcquireNextImageKHR fpAcquireNextImageKHR;
-	PFN_vkQueuePresentKHR fpQueuePresentKHR;
+private:
+    VkInstance instance;
+    VkDevice device;
+    VkPhysicalDevice physicalDevice;
+    VkSurfaceKHR surface;
+    // Function pointers
+    PFN_vkGetPhysicalDeviceSurfaceSupportKHR fpGetPhysicalDeviceSurfaceSupportKHR;
+    PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR fpGetPhysicalDeviceSurfaceCapabilitiesKHR;
+    PFN_vkGetPhysicalDeviceSurfaceFormatsKHR fpGetPhysicalDeviceSurfaceFormatsKHR;
+    PFN_vkGetPhysicalDeviceSurfacePresentModesKHR fpGetPhysicalDeviceSurfacePresentModesKHR;
+    PFN_vkCreateSwapchainKHR fpCreateSwapchainKHR;
+    PFN_vkDestroySwapchainKHR fpDestroySwapchainKHR;
+    PFN_vkGetSwapchainImagesKHR fpGetSwapchainImagesKHR;
+    PFN_vkAcquireNextImageKHR fpAcquireNextImageKHR;
+    PFN_vkQueuePresentKHR fpQueuePresentKHR;
+
 public:
-	VkFormat colorFormat;
-	VkColorSpaceKHR colorSpace;
-	/** @brief Handle to the current swap chain, required for recreation */
-	VkSwapchainKHR swapChain = VK_NULL_HANDLE;	
-	uint32_t imageCount;
-	std::vector<VkImage> images;
-	std::vector<SwapChainBuffer> buffers;
-	/** @brief Queue family index of the detected graphics and presenting device queue */
-	uint32_t queueNodeIndex = UINT32_MAX;
+    VkFormat colorFormat;
+    VkColorSpaceKHR colorSpace;
+    /** @brief Handle to the current swap chain, required for recreation */
+    VkSwapchainKHR swapChain = VK_NULL_HANDLE;
+    uint32_t imageCount;
+    std::vector<VkImage> images;
+    std::vector<SwapChainBuffer> buffers;
+    /** @brief Queue family index of the detected graphics and presenting device queue */
+    uint32_t queueNodeIndex = UINT32_MAX;
 
-	/** @brief Creates the platform specific surface abstraction of the native platform window used for presentation */	
+    /** @brief Creates the platform specific surface abstraction of the native platform window used for presentation */
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-	void initSurface(void* platformHandle, void* platformWindow)
+    void initSurface(void* platformHandle, void* platformWindow)
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-	void initSurface(ANativeWindow* window)
+    void initSurface(ANativeWindow* window)
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	void initSurface(wl_display *display, wl_surface *window)
+    void initSurface(wl_display* display, wl_surface* window)
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-	void initSurface(xcb_connection_t* connection, xcb_window_t window)
+    void initSurface(xcb_connection_t* connection, xcb_window_t window)
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-	void initSurface(void* view)
+    void initSurface(void* view)
 #elif defined(_DIRECT2DISPLAY)
-	void initSurface(uint32_t width, uint32_t height)
+    void initSurface(uint32_t width, uint32_t height)
 #endif
-	{
-		VkResult err = VK_SUCCESS;
+    {
+        VkResult err = VK_SUCCESS;
 
-		// Create the os-specific surface
+        // Create the os-specific surface
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-		VkWin32SurfaceCreateInfoKHR surfaceCreateInfo = {};
-		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-		surfaceCreateInfo.hinstance = (HINSTANCE)platformHandle;
-		surfaceCreateInfo.hwnd = (HWND)platformWindow;
-		err = vkCreateWin32SurfaceKHR(instance, &surfaceCreateInfo, nullptr, &surface);
+        VkWin32SurfaceCreateInfoKHR surfaceCreateInfo = {};
+        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+        surfaceCreateInfo.hinstance = (HINSTANCE)platformHandle;
+        surfaceCreateInfo.hwnd = (HWND)platformWindow;
+        err = vkCreateWin32SurfaceKHR(instance, &surfaceCreateInfo, nullptr, &surface);
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-		VkAndroidSurfaceCreateInfoKHR surfaceCreateInfo = {};
-		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
-		surfaceCreateInfo.window = window;
-		err = vkCreateAndroidSurfaceKHR(instance, &surfaceCreateInfo, NULL, &surface);
+        VkAndroidSurfaceCreateInfoKHR surfaceCreateInfo = {};
+        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
+        surfaceCreateInfo.window = window;
+        err = vkCreateAndroidSurfaceKHR(instance, &surfaceCreateInfo, NULL, &surface);
 #elif defined(VK_USE_PLATFORM_IOS_MVK)
-		VkIOSSurfaceCreateInfoMVK surfaceCreateInfo = {};
-		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK;
-		surfaceCreateInfo.pNext = NULL;
-		surfaceCreateInfo.flags = 0;
-		surfaceCreateInfo.pView = view;
-		err = vkCreateIOSSurfaceMVK(instance, &surfaceCreateInfo, nullptr, &surface);
+        VkIOSSurfaceCreateInfoMVK surfaceCreateInfo = {};
+        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK;
+        surfaceCreateInfo.pNext = NULL;
+        surfaceCreateInfo.flags = 0;
+        surfaceCreateInfo.pView = view;
+        err = vkCreateIOSSurfaceMVK(instance, &surfaceCreateInfo, nullptr, &surface);
 #elif defined(VK_USE_PLATFORM_MACOS_MVK)
-		VkMacOSSurfaceCreateInfoMVK surfaceCreateInfo = {};
-		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK;
-		surfaceCreateInfo.pNext = NULL;
-		surfaceCreateInfo.flags = 0;
-		surfaceCreateInfo.pView = view;
-		err = vkCreateMacOSSurfaceMVK(instance, &surfaceCreateInfo, NULL, &surface);
+        VkMacOSSurfaceCreateInfoMVK surfaceCreateInfo = {};
+        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK;
+        surfaceCreateInfo.pNext = NULL;
+        surfaceCreateInfo.flags = 0;
+        surfaceCreateInfo.pView = view;
+        err = vkCreateMacOSSurfaceMVK(instance, &surfaceCreateInfo, NULL, &surface);
 #elif defined(_DIRECT2DISPLAY)
-		createDirect2DisplaySurface(width, height);
+        createDirect2DisplaySurface(width, height);
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-		VkWaylandSurfaceCreateInfoKHR surfaceCreateInfo = {};
-		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
-		surfaceCreateInfo.display = display;
-		surfaceCreateInfo.surface = window;
-		err = vkCreateWaylandSurfaceKHR(instance, &surfaceCreateInfo, nullptr, &surface);
+        VkWaylandSurfaceCreateInfoKHR surfaceCreateInfo = {};
+        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+        surfaceCreateInfo.display = display;
+        surfaceCreateInfo.surface = window;
+        err = vkCreateWaylandSurfaceKHR(instance, &surfaceCreateInfo, nullptr, &surface);
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-		VkXcbSurfaceCreateInfoKHR surfaceCreateInfo = {};
-		surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
-		surfaceCreateInfo.connection = connection;
-		surfaceCreateInfo.window = window;
-		err = vkCreateXcbSurfaceKHR(instance, &surfaceCreateInfo, nullptr, &surface);
+        VkXcbSurfaceCreateInfoKHR surfaceCreateInfo = {};
+        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+        surfaceCreateInfo.connection = connection;
+        surfaceCreateInfo.window = window;
+        err = vkCreateXcbSurfaceKHR(instance, &surfaceCreateInfo, nullptr, &surface);
 #endif
 
-		if (err != VK_SUCCESS) {
-			vks::tools::exitFatal("Could not create surface!", err);
-		}
+        if (err != VK_SUCCESS)
+        {
+            vks::tools::exitFatal("Could not create surface!", err);
+        }
 
-		// Get available queue family properties
-		uint32_t queueCount;
-		vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueCount, NULL);
-		assert(queueCount >= 1);
+        // Get available queue family properties
+        uint32_t queueCount;
+        vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueCount, NULL);
+        assert(queueCount >= 1);
 
-		std::vector<VkQueueFamilyProperties> queueProps(queueCount);
-		vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueCount, queueProps.data());
+        std::vector<VkQueueFamilyProperties> queueProps(queueCount);
+        vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueCount, queueProps.data());
 
-		// Iterate over each queue to learn whether it supports presenting:
-		// Find a queue with present support
-		// Will be used to present the swap chain images to the windowing system
-		std::vector<VkBool32> supportsPresent(queueCount);
-		for (uint32_t i = 0; i < queueCount; i++) 
-		{
-			fpGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, i, surface, &supportsPresent[i]);
-		}
+        // Iterate over each queue to learn whether it supports presenting:
+        // Find a queue with present support
+        // Will be used to present the swap chain images to the windowing system
+        std::vector<VkBool32> supportsPresent(queueCount);
+        for (uint32_t i = 0; i < queueCount; i++)
+        {
+            fpGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, i, surface, &supportsPresent[i]);
+        }
 
-		// Search for a graphics and a present queue in the array of queue
-		// families, try to find one that supports both
-		uint32_t graphicsQueueNodeIndex = UINT32_MAX;
-		uint32_t presentQueueNodeIndex = UINT32_MAX;
-		for (uint32_t i = 0; i < queueCount; i++) 
-		{
-			if ((queueProps[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0) 
-			{
-				if (graphicsQueueNodeIndex == UINT32_MAX) 
-				{
-					graphicsQueueNodeIndex = i;
-				}
+        // Search for a graphics and a present queue in the array of queue
+        // families, try to find one that supports both
+        uint32_t graphicsQueueNodeIndex = UINT32_MAX;
+        uint32_t presentQueueNodeIndex = UINT32_MAX;
+        for (uint32_t i = 0; i < queueCount; i++)
+        {
+            if ((queueProps[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0)
+            {
+                if (graphicsQueueNodeIndex == UINT32_MAX)
+                {
+                    graphicsQueueNodeIndex = i;
+                }
 
-				if (supportsPresent[i] == VK_TRUE) 
-				{
-					graphicsQueueNodeIndex = i;
-					presentQueueNodeIndex = i;
-					break;
-				}
-			}
-		}
-		if (presentQueueNodeIndex == UINT32_MAX) 
-		{	
-			// If there's no queue that supports both present and graphics
-			// try to find a separate present queue
-			for (uint32_t i = 0; i < queueCount; ++i) 
-			{
-				if (supportsPresent[i] == VK_TRUE) 
-				{
-					presentQueueNodeIndex = i;
-					break;
-				}
-			}
-		}
+                if (supportsPresent[i] == VK_TRUE)
+                {
+                    graphicsQueueNodeIndex = i;
+                    presentQueueNodeIndex = i;
+                    break;
+                }
+            }
+        }
+        if (presentQueueNodeIndex == UINT32_MAX)
+        {
+            // If there's no queue that supports both present and graphics
+            // try to find a separate present queue
+            for (uint32_t i = 0; i < queueCount; ++i)
+            {
+                if (supportsPresent[i] == VK_TRUE)
+                {
+                    presentQueueNodeIndex = i;
+                    break;
+                }
+            }
+        }
 
-		// Exit if either a graphics or a presenting queue hasn't been found
-		if (graphicsQueueNodeIndex == UINT32_MAX || presentQueueNodeIndex == UINT32_MAX) 
-		{
-			vks::tools::exitFatal("Could not find a graphics and/or presenting queue!", -1);
-		}
+        // Exit if either a graphics or a presenting queue hasn't been found
+        if (graphicsQueueNodeIndex == UINT32_MAX || presentQueueNodeIndex == UINT32_MAX)
+        {
+            vks::tools::exitFatal("Could not find a graphics and/or presenting queue!", -1);
+        }
 
-		// todo : Add support for separate graphics and presenting queue
-		if (graphicsQueueNodeIndex != presentQueueNodeIndex) 
-		{
-			vks::tools::exitFatal("Separate graphics and presenting queues are not supported yet!", -1);
-		}
+        // todo : Add support for separate graphics and presenting queue
+        if (graphicsQueueNodeIndex != presentQueueNodeIndex)
+        {
+            vks::tools::exitFatal("Separate graphics and presenting queues are not supported yet!", -1);
+        }
 
-		queueNodeIndex = graphicsQueueNodeIndex;
+        queueNodeIndex = graphicsQueueNodeIndex;
 
-		// Get list of supported surface formats
-		uint32_t formatCount;
-		VK_CHECK_RESULT(fpGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, &formatCount, NULL));
-		assert(formatCount > 0);
+        // Get list of supported surface formats
+        uint32_t formatCount;
+        VK_CHECK_RESULT(fpGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, &formatCount, NULL));
+        assert(formatCount > 0);
 
-		std::vector<VkSurfaceFormatKHR> surfaceFormats(formatCount);
-		VK_CHECK_RESULT(fpGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, &formatCount, surfaceFormats.data()));
+        std::vector<VkSurfaceFormatKHR> surfaceFormats(formatCount);
+        VK_CHECK_RESULT(fpGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, &formatCount, surfaceFormats.data()));
 
-		// If the surface format list only includes one entry with VK_FORMAT_UNDEFINED,
-		// there is no preferered format, so we assume VK_FORMAT_B8G8R8A8_UNORM
-		if ((formatCount == 1) && (surfaceFormats[0].format == VK_FORMAT_UNDEFINED))
-		{
-			colorFormat = VK_FORMAT_B8G8R8A8_UNORM;
-			colorSpace = surfaceFormats[0].colorSpace;
-		}
-		else
-		{
-			// iterate over the list of available surface format and
-			// check for the presence of VK_FORMAT_B8G8R8A8_UNORM
-			bool found_B8G8R8A8_UNORM = false;
-			for (auto&& surfaceFormat : surfaceFormats)
-			{
-				if (surfaceFormat.format == VK_FORMAT_B8G8R8A8_UNORM)
-				{
-					colorFormat = surfaceFormat.format;
-					colorSpace = surfaceFormat.colorSpace;
-					found_B8G8R8A8_UNORM = true;
-					break;
-				}
-			}
+        // If the surface format list only includes one entry with VK_FORMAT_UNDEFINED,
+        // there is no preferered format, so we assume VK_FORMAT_B8G8R8A8_UNORM
+        if ((formatCount == 1) && (surfaceFormats[0].format == VK_FORMAT_UNDEFINED))
+        {
+            colorFormat = VK_FORMAT_B8G8R8A8_UNORM;
+            colorSpace = surfaceFormats[0].colorSpace;
+        }
+        else
+        {
+            // iterate over the list of available surface format and
+            // check for the presence of VK_FORMAT_B8G8R8A8_UNORM
+            bool found_B8G8R8A8_UNORM = false;
+            for (auto&& surfaceFormat : surfaceFormats)
+            {
+                if (surfaceFormat.format == VK_FORMAT_B8G8R8A8_UNORM)
+                {
+                    colorFormat = surfaceFormat.format;
+                    colorSpace = surfaceFormat.colorSpace;
+                    found_B8G8R8A8_UNORM = true;
+                    break;
+                }
+            }
 
-			// in case VK_FORMAT_B8G8R8A8_UNORM is not available
-			// select the first available color format
-			if (!found_B8G8R8A8_UNORM)
-			{
-				colorFormat = surfaceFormats[0].format;
-				colorSpace = surfaceFormats[0].colorSpace;
-			}
-		}
+            // in case VK_FORMAT_B8G8R8A8_UNORM is not available
+            // select the first available color format
+            if (!found_B8G8R8A8_UNORM)
+            {
+                colorFormat = surfaceFormats[0].format;
+                colorSpace = surfaceFormats[0].colorSpace;
+            }
+        }
+    }
 
-	}
-
-	/**
+    /**
 	* Set instance, physical and logical device to use for the swapchain and get all required function pointers
 	* 
 	* @param instance Vulkan instance to use
@@ -255,201 +257,199 @@ public:
 	* @param device Logical representation of the device to create the swapchain for
 	*
 	*/
-	void connect(VkInstance instance, VkPhysicalDevice physicalDevice, VkDevice device)
-	{
-		this->instance = instance;
-		this->physicalDevice = physicalDevice;
-		this->device = device;
-		GET_INSTANCE_PROC_ADDR(instance, GetPhysicalDeviceSurfaceSupportKHR);
-		GET_INSTANCE_PROC_ADDR(instance, GetPhysicalDeviceSurfaceCapabilitiesKHR);
-		GET_INSTANCE_PROC_ADDR(instance, GetPhysicalDeviceSurfaceFormatsKHR);
-		GET_INSTANCE_PROC_ADDR(instance, GetPhysicalDeviceSurfacePresentModesKHR);
-		GET_DEVICE_PROC_ADDR(device, CreateSwapchainKHR);
-		GET_DEVICE_PROC_ADDR(device, DestroySwapchainKHR);
-		GET_DEVICE_PROC_ADDR(device, GetSwapchainImagesKHR);
-		GET_DEVICE_PROC_ADDR(device, AcquireNextImageKHR);
-		GET_DEVICE_PROC_ADDR(device, QueuePresentKHR);
-	}
+    void connect(VkInstance instance, VkPhysicalDevice physicalDevice, VkDevice device)
+    {
+        this->instance = instance;
+        this->physicalDevice = physicalDevice;
+        this->device = device;
+        GET_INSTANCE_PROC_ADDR(instance, GetPhysicalDeviceSurfaceSupportKHR);
+        GET_INSTANCE_PROC_ADDR(instance, GetPhysicalDeviceSurfaceCapabilitiesKHR);
+        GET_INSTANCE_PROC_ADDR(instance, GetPhysicalDeviceSurfaceFormatsKHR);
+        GET_INSTANCE_PROC_ADDR(instance, GetPhysicalDeviceSurfacePresentModesKHR);
+        GET_DEVICE_PROC_ADDR(device, CreateSwapchainKHR);
+        GET_DEVICE_PROC_ADDR(device, DestroySwapchainKHR);
+        GET_DEVICE_PROC_ADDR(device, GetSwapchainImagesKHR);
+        GET_DEVICE_PROC_ADDR(device, AcquireNextImageKHR);
+        GET_DEVICE_PROC_ADDR(device, QueuePresentKHR);
+    }
 
-	/** 
+    /** 
 	* Create the swapchain and get it's images with given width and height
 	* 
 	* @param width Pointer to the width of the swapchain (may be adjusted to fit the requirements of the swapchain)
 	* @param height Pointer to the height of the swapchain (may be adjusted to fit the requirements of the swapchain)
 	* @param vsync (Optional) Can be used to force vsync'd rendering (by using VK_PRESENT_MODE_FIFO_KHR as presentation mode)
 	*/
-	void create(uint32_t *width, uint32_t *height, bool vsync = false)
-	{
-		VkSwapchainKHR oldSwapchain = swapChain;
+    void create(uint32_t* width, uint32_t* height, bool vsync = false)
+    {
+        VkSwapchainKHR oldSwapchain = swapChain;
 
-		// Get physical device surface properties and formats
-		VkSurfaceCapabilitiesKHR surfCaps;
-		VK_CHECK_RESULT(fpGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, &surfCaps));
+        // Get physical device surface properties and formats
+        VkSurfaceCapabilitiesKHR surfCaps;
+        VK_CHECK_RESULT(fpGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, &surfCaps));
 
-		// Get available present modes
-		uint32_t presentModeCount;
-		VK_CHECK_RESULT(fpGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, &presentModeCount, NULL));
-		assert(presentModeCount > 0);
+        // Get available present modes
+        uint32_t presentModeCount;
+        VK_CHECK_RESULT(fpGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, &presentModeCount, NULL));
+        assert(presentModeCount > 0);
 
-		std::vector<VkPresentModeKHR> presentModes(presentModeCount);
-		VK_CHECK_RESULT(fpGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, &presentModeCount, presentModes.data()));
+        std::vector<VkPresentModeKHR> presentModes(presentModeCount);
+        VK_CHECK_RESULT(fpGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, &presentModeCount, presentModes.data()));
 
-		VkExtent2D swapchainExtent = {};
-		// If width (and height) equals the special value 0xFFFFFFFF, the size of the surface will be set by the swapchain
-		if (surfCaps.currentExtent.width == (uint32_t)-1)
-		{
-			// If the surface size is undefined, the size is set to
-			// the size of the images requested.
-			swapchainExtent.width = *width;
-			swapchainExtent.height = *height;
-		}
-		else
-		{
-			// If the surface size is defined, the swap chain size must match
-			swapchainExtent = surfCaps.currentExtent;
-			*width = surfCaps.currentExtent.width;
-			*height = surfCaps.currentExtent.height;
-		}
+        VkExtent2D swapchainExtent = {};
+        // If width (and height) equals the special value 0xFFFFFFFF, the size of the surface will be set by the swapchain
+        if (surfCaps.currentExtent.width == (uint32_t)-1)
+        {
+            // If the surface size is undefined, the size is set to
+            // the size of the images requested.
+            swapchainExtent.width = *width;
+            swapchainExtent.height = *height;
+        }
+        else
+        {
+            // If the surface size is defined, the swap chain size must match
+            swapchainExtent = surfCaps.currentExtent;
+            *width = surfCaps.currentExtent.width;
+            *height = surfCaps.currentExtent.height;
+        }
 
+        // Select a present mode for the swapchain
 
-		// Select a present mode for the swapchain
+        // The VK_PRESENT_MODE_FIFO_KHR mode must always be present as per spec
+        // This mode waits for the vertical blank ("v-sync")
+        VkPresentModeKHR swapchainPresentMode = VK_PRESENT_MODE_FIFO_KHR;
 
-		// The VK_PRESENT_MODE_FIFO_KHR mode must always be present as per spec
-		// This mode waits for the vertical blank ("v-sync")
-		VkPresentModeKHR swapchainPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+        // If v-sync is not requested, try to find a mailbox mode
+        // It's the lowest latency non-tearing present mode available
+        if (!vsync)
+        {
+            for (size_t i = 0; i < presentModeCount; i++)
+            {
+                if (presentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR)
+                {
+                    swapchainPresentMode = VK_PRESENT_MODE_MAILBOX_KHR;
+                    break;
+                }
+                if ((swapchainPresentMode != VK_PRESENT_MODE_MAILBOX_KHR) && (presentModes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR))
+                {
+                    swapchainPresentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+                }
+            }
+        }
 
-		// If v-sync is not requested, try to find a mailbox mode
-		// It's the lowest latency non-tearing present mode available
-		if (!vsync)
-		{
-			for (size_t i = 0; i < presentModeCount; i++)
-			{
-				if (presentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR)
-				{
-					swapchainPresentMode = VK_PRESENT_MODE_MAILBOX_KHR;
-					break;
-				}
-				if ((swapchainPresentMode != VK_PRESENT_MODE_MAILBOX_KHR) && (presentModes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR))
-				{
-					swapchainPresentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
-				}
-			}
-		}
+        // Determine the number of images
+        uint32_t desiredNumberOfSwapchainImages = surfCaps.minImageCount + 1;
+        if ((surfCaps.maxImageCount > 0) && (desiredNumberOfSwapchainImages > surfCaps.maxImageCount))
+        {
+            desiredNumberOfSwapchainImages = surfCaps.maxImageCount;
+        }
 
-		// Determine the number of images
-		uint32_t desiredNumberOfSwapchainImages = surfCaps.minImageCount + 1;
-		if ((surfCaps.maxImageCount > 0) && (desiredNumberOfSwapchainImages > surfCaps.maxImageCount))
-		{
-			desiredNumberOfSwapchainImages = surfCaps.maxImageCount;
-		}
+        // Find the transformation of the surface
+        VkSurfaceTransformFlagsKHR preTransform;
+        if (surfCaps.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR)
+        {
+            // We prefer a non-rotated transform
+            preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+        }
+        else
+        {
+            preTransform = surfCaps.currentTransform;
+        }
 
-		// Find the transformation of the surface
-		VkSurfaceTransformFlagsKHR preTransform;
-		if (surfCaps.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR)
-		{
-			// We prefer a non-rotated transform
-			preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
-		}
-		else
-		{
-			preTransform = surfCaps.currentTransform;
-		}
+        // Find a supported composite alpha format (not all devices support alpha opaque)
+        VkCompositeAlphaFlagBitsKHR compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+        // Simply select the first composite alpha format available
+        std::vector<VkCompositeAlphaFlagBitsKHR> compositeAlphaFlags = {
+            VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+            VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR,
+            VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR,
+            VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR,
+        };
+        for (auto& compositeAlphaFlag : compositeAlphaFlags)
+        {
+            if (surfCaps.supportedCompositeAlpha & compositeAlphaFlag)
+            {
+                compositeAlpha = compositeAlphaFlag;
+                break;
+            };
+        }
 
-		// Find a supported composite alpha format (not all devices support alpha opaque)
-		VkCompositeAlphaFlagBitsKHR compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-		// Simply select the first composite alpha format available
-		std::vector<VkCompositeAlphaFlagBitsKHR> compositeAlphaFlags = {
-			VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
-			VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR,
-			VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR,
-			VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR,
-		};
-		for (auto& compositeAlphaFlag : compositeAlphaFlags) {
-			if (surfCaps.supportedCompositeAlpha & compositeAlphaFlag) {
-				compositeAlpha = compositeAlphaFlag;
-				break;
-			};
-		}
+        VkSwapchainCreateInfoKHR swapchainCI = {};
+        swapchainCI.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+        swapchainCI.pNext = NULL;
+        swapchainCI.surface = surface;
+        swapchainCI.minImageCount = desiredNumberOfSwapchainImages;
+        swapchainCI.imageFormat = colorFormat;
+        swapchainCI.imageColorSpace = colorSpace;
+        swapchainCI.imageExtent = { swapchainExtent.width, swapchainExtent.height };
+        swapchainCI.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        swapchainCI.preTransform = (VkSurfaceTransformFlagBitsKHR)preTransform;
+        swapchainCI.imageArrayLayers = 1;
+        swapchainCI.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        swapchainCI.queueFamilyIndexCount = 0;
+        swapchainCI.pQueueFamilyIndices = NULL;
+        swapchainCI.presentMode = swapchainPresentMode;
+        swapchainCI.oldSwapchain = oldSwapchain;
+        // Setting clipped to VK_TRUE allows the implementation to discard rendering outside of the surface area
+        swapchainCI.clipped = VK_TRUE;
+        swapchainCI.compositeAlpha = compositeAlpha;
 
-		VkSwapchainCreateInfoKHR swapchainCI = {};
-		swapchainCI.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
-		swapchainCI.pNext = NULL;
-		swapchainCI.surface = surface;
-		swapchainCI.minImageCount = desiredNumberOfSwapchainImages;
-		swapchainCI.imageFormat = colorFormat;
-		swapchainCI.imageColorSpace = colorSpace;
-		swapchainCI.imageExtent = { swapchainExtent.width, swapchainExtent.height };
-		swapchainCI.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-		swapchainCI.preTransform = (VkSurfaceTransformFlagBitsKHR)preTransform;
-		swapchainCI.imageArrayLayers = 1;
-		swapchainCI.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
-		swapchainCI.queueFamilyIndexCount = 0;
-		swapchainCI.pQueueFamilyIndices = NULL;
-		swapchainCI.presentMode = swapchainPresentMode;
-		swapchainCI.oldSwapchain = oldSwapchain;
-		// Setting clipped to VK_TRUE allows the implementation to discard rendering outside of the surface area
-		swapchainCI.clipped = VK_TRUE;
-		swapchainCI.compositeAlpha = compositeAlpha;
+        // Enable transfer source on swap chain images if supported
+        if (surfCaps.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
+        {
+            swapchainCI.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        }
 
-		// Enable transfer source on swap chain images if supported
-		if (surfCaps.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
-			swapchainCI.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-		}
+        // Enable transfer destination on swap chain images if supported
+        if (surfCaps.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT)
+        {
+            swapchainCI.imageUsage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        }
 
-		// Enable transfer destination on swap chain images if supported
-		if (surfCaps.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) {
-			swapchainCI.imageUsage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-		}
+        VK_CHECK_RESULT(fpCreateSwapchainKHR(device, &swapchainCI, nullptr, &swapChain));
 
-		VK_CHECK_RESULT(fpCreateSwapchainKHR(device, &swapchainCI, nullptr, &swapChain));
+        // If an existing swap chain is re-created, destroy the old swap chain
+        // This also cleans up all the presentable images
+        if (oldSwapchain != VK_NULL_HANDLE)
+        {
+            for (uint32_t i = 0; i < imageCount; i++)
+            {
+                vkDestroyImageView(device, buffers[i].view, nullptr);
+            }
+            fpDestroySwapchainKHR(device, oldSwapchain, nullptr);
+        }
+        VK_CHECK_RESULT(fpGetSwapchainImagesKHR(device, swapChain, &imageCount, NULL));
 
-		// If an existing swap chain is re-created, destroy the old swap chain
-		// This also cleans up all the presentable images
-		if (oldSwapchain != VK_NULL_HANDLE) 
-		{ 
-			for (uint32_t i = 0; i < imageCount; i++)
-			{
-				vkDestroyImageView(device, buffers[i].view, nullptr);
-			}
-			fpDestroySwapchainKHR(device, oldSwapchain, nullptr);
-		}
-		VK_CHECK_RESULT(fpGetSwapchainImagesKHR(device, swapChain, &imageCount, NULL));
+        // Get the swap chain images
+        images.resize(imageCount);
+        VK_CHECK_RESULT(fpGetSwapchainImagesKHR(device, swapChain, &imageCount, images.data()));
 
-		// Get the swap chain images
-		images.resize(imageCount);
-		VK_CHECK_RESULT(fpGetSwapchainImagesKHR(device, swapChain, &imageCount, images.data()));
+        // Get the swap chain buffers containing the image and imageview
+        buffers.resize(imageCount);
+        for (uint32_t i = 0; i < imageCount; i++)
+        {
+            VkImageViewCreateInfo colorAttachmentView = {};
+            colorAttachmentView.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            colorAttachmentView.pNext = NULL;
+            colorAttachmentView.format = colorFormat;
+            colorAttachmentView.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
+            colorAttachmentView.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            colorAttachmentView.subresourceRange.baseMipLevel = 0;
+            colorAttachmentView.subresourceRange.levelCount = 1;
+            colorAttachmentView.subresourceRange.baseArrayLayer = 0;
+            colorAttachmentView.subresourceRange.layerCount = 1;
+            colorAttachmentView.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            colorAttachmentView.flags = 0;
 
-		// Get the swap chain buffers containing the image and imageview
-		buffers.resize(imageCount);
-		for (uint32_t i = 0; i < imageCount; i++)
-		{
-			VkImageViewCreateInfo colorAttachmentView = {};
-			colorAttachmentView.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-			colorAttachmentView.pNext = NULL;
-			colorAttachmentView.format = colorFormat;
-			colorAttachmentView.components = {
-				VK_COMPONENT_SWIZZLE_R,
-				VK_COMPONENT_SWIZZLE_G,
-				VK_COMPONENT_SWIZZLE_B,
-				VK_COMPONENT_SWIZZLE_A
-			};
-			colorAttachmentView.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			colorAttachmentView.subresourceRange.baseMipLevel = 0;
-			colorAttachmentView.subresourceRange.levelCount = 1;
-			colorAttachmentView.subresourceRange.baseArrayLayer = 0;
-			colorAttachmentView.subresourceRange.layerCount = 1;
-			colorAttachmentView.viewType = VK_IMAGE_VIEW_TYPE_2D;
-			colorAttachmentView.flags = 0;
+            buffers[i].image = images[i];
 
-			buffers[i].image = images[i];
+            colorAttachmentView.image = buffers[i].image;
 
-			colorAttachmentView.image = buffers[i].image;
+            VK_CHECK_RESULT(vkCreateImageView(device, &colorAttachmentView, nullptr, &buffers[i].view));
+        }
+    }
 
-			VK_CHECK_RESULT(vkCreateImageView(device, &colorAttachmentView, nullptr, &buffers[i].view));
-		}
-	}
-
-	/** 
+    /** 
 	* Acquires the next image in the swap chain
 	*
 	* @param presentCompleteSemaphore (Optional) Semaphore that is signaled when the image is ready for use
@@ -459,14 +459,14 @@ public:
 	*
 	* @return VkResult of the image acquisition
 	*/
-	VkResult acquireNextImage(VkSemaphore presentCompleteSemaphore, uint32_t *imageIndex)
-	{
-		// By setting timeout to UINT64_MAX we will always wait until the next image has been acquired or an actual error is thrown
-		// With that we don't have to handle VK_NOT_READY
-		return fpAcquireNextImageKHR(device, swapChain, UINT64_MAX, presentCompleteSemaphore, (VkFence)nullptr, imageIndex);
-	}
+    VkResult acquireNextImage(VkSemaphore presentCompleteSemaphore, uint32_t* imageIndex)
+    {
+        // By setting timeout to UINT64_MAX we will always wait until the next image has been acquired or an actual error is thrown
+        // With that we don't have to handle VK_NOT_READY
+        return fpAcquireNextImageKHR(device, swapChain, UINT64_MAX, presentCompleteSemaphore, (VkFence) nullptr, imageIndex);
+    }
 
-	/**
+    /**
 	* Queue an image for presentation
 	*
 	* @param queue Presentation queue for presenting the image
@@ -475,181 +475,181 @@ public:
 	*
 	* @return VkResult of the queue presentation
 	*/
-	VkResult queuePresent(VkQueue queue, uint32_t imageIndex, VkSemaphore waitSemaphore = VK_NULL_HANDLE)
-	{
-		VkPresentInfoKHR presentInfo = {};
-		presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-		presentInfo.pNext = NULL;
-		presentInfo.swapchainCount = 1;
-		presentInfo.pSwapchains = &swapChain;
-		presentInfo.pImageIndices = &imageIndex;
-		// Check if a wait semaphore has been specified to wait for before presenting the image
-		if (waitSemaphore != VK_NULL_HANDLE)
-		{
-			presentInfo.pWaitSemaphores = &waitSemaphore;
-			presentInfo.waitSemaphoreCount = 1;
-		}
-		return fpQueuePresentKHR(queue, &presentInfo);
-	}
+    VkResult queuePresent(VkQueue queue, uint32_t imageIndex, VkSemaphore waitSemaphore = VK_NULL_HANDLE)
+    {
+        VkPresentInfoKHR presentInfo = {};
+        presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+        presentInfo.pNext = NULL;
+        presentInfo.swapchainCount = 1;
+        presentInfo.pSwapchains = &swapChain;
+        presentInfo.pImageIndices = &imageIndex;
+        // Check if a wait semaphore has been specified to wait for before presenting the image
+        if (waitSemaphore != VK_NULL_HANDLE)
+        {
+            presentInfo.pWaitSemaphores = &waitSemaphore;
+            presentInfo.waitSemaphoreCount = 1;
+        }
+        return fpQueuePresentKHR(queue, &presentInfo);
+    }
 
-
-	/**
+    /**
 	* Destroy and free Vulkan resources used for the swapchain
 	*/
-	void cleanup()
-	{
-		if (swapChain != VK_NULL_HANDLE)
-		{
-			for (uint32_t i = 0; i < imageCount; i++)
-			{
-				vkDestroyImageView(device, buffers[i].view, nullptr);
-			}
-		}
-		if (surface != VK_NULL_HANDLE)
-		{
-			fpDestroySwapchainKHR(device, swapChain, nullptr);
-			vkDestroySurfaceKHR(instance, surface, nullptr);
-		}
-		surface = VK_NULL_HANDLE;
-		swapChain = VK_NULL_HANDLE;
-	}
+    void cleanup()
+    {
+        if (swapChain != VK_NULL_HANDLE)
+        {
+            for (uint32_t i = 0; i < imageCount; i++)
+            {
+                vkDestroyImageView(device, buffers[i].view, nullptr);
+            }
+        }
+        if (surface != VK_NULL_HANDLE)
+        {
+            fpDestroySwapchainKHR(device, swapChain, nullptr);
+            vkDestroySurfaceKHR(instance, surface, nullptr);
+        }
+        surface = VK_NULL_HANDLE;
+        swapChain = VK_NULL_HANDLE;
+    }
 
 #if defined(_DIRECT2DISPLAY)
-	/**
+    /**
 	* Create direct to display surface
-	*/	
-	void createDirect2DisplaySurface(uint32_t width, uint32_t height)
-	{
-		uint32_t displayPropertyCount;
-		
-		// Get display property
-		vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, &displayPropertyCount, NULL);
-		VkDisplayPropertiesKHR* pDisplayProperties = new VkDisplayPropertiesKHR[displayPropertyCount];
-		vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, &displayPropertyCount, pDisplayProperties);
+	*/
+    void createDirect2DisplaySurface(uint32_t width, uint32_t height)
+    {
+        uint32_t displayPropertyCount;
 
-		// Get plane property
-		uint32_t planePropertyCount;
-		vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, &planePropertyCount, NULL);
-		VkDisplayPlanePropertiesKHR* pPlaneProperties = new VkDisplayPlanePropertiesKHR[planePropertyCount];
-		vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, &planePropertyCount, pPlaneProperties);
+        // Get display property
+        vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, &displayPropertyCount, NULL);
+        VkDisplayPropertiesKHR* pDisplayProperties = new VkDisplayPropertiesKHR[displayPropertyCount];
+        vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, &displayPropertyCount, pDisplayProperties);
 
-		VkDisplayKHR display = VK_NULL_HANDLE;
-		VkDisplayModeKHR displayMode;
-		VkDisplayModePropertiesKHR* pModeProperties;
-		bool foundMode = false;
+        // Get plane property
+        uint32_t planePropertyCount;
+        vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, &planePropertyCount, NULL);
+        VkDisplayPlanePropertiesKHR* pPlaneProperties = new VkDisplayPlanePropertiesKHR[planePropertyCount];
+        vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, &planePropertyCount, pPlaneProperties);
 
-		for(uint32_t i = 0; i < displayPropertyCount;++i)
-		{
-			display = pDisplayProperties[i].display;
-			uint32_t modeCount;
-			vkGetDisplayModePropertiesKHR(physicalDevice, display, &modeCount, NULL);
-			pModeProperties = new VkDisplayModePropertiesKHR[modeCount];
-			vkGetDisplayModePropertiesKHR(physicalDevice, display, &modeCount, pModeProperties);
+        VkDisplayKHR display = VK_NULL_HANDLE;
+        VkDisplayModeKHR displayMode;
+        VkDisplayModePropertiesKHR* pModeProperties;
+        bool foundMode = false;
 
-			for (uint32_t j = 0; j < modeCount; ++j)
-			{
-				const VkDisplayModePropertiesKHR* mode = &pModeProperties[j];
+        for (uint32_t i = 0; i < displayPropertyCount; ++i)
+        {
+            display = pDisplayProperties[i].display;
+            uint32_t modeCount;
+            vkGetDisplayModePropertiesKHR(physicalDevice, display, &modeCount, NULL);
+            pModeProperties = new VkDisplayModePropertiesKHR[modeCount];
+            vkGetDisplayModePropertiesKHR(physicalDevice, display, &modeCount, pModeProperties);
 
-				if (mode->parameters.visibleRegion.width == width && mode->parameters.visibleRegion.height == height)
-				{
-					displayMode = mode->displayMode;
-					foundMode = true;
-					break;
-				}
-			}
-			if (foundMode)
-			{
-				break;
-			}
-			delete [] pModeProperties;
-		}
+            for (uint32_t j = 0; j < modeCount; ++j)
+            {
+                const VkDisplayModePropertiesKHR* mode = &pModeProperties[j];
 
-		if(!foundMode)
-		{
-			vks::tools::exitFatal("Can't find a display and a display mode!", -1);
-			return;
-		}
+                if (mode->parameters.visibleRegion.width == width && mode->parameters.visibleRegion.height == height)
+                {
+                    displayMode = mode->displayMode;
+                    foundMode = true;
+                    break;
+                }
+            }
+            if (foundMode)
+            {
+                break;
+            }
+            delete[] pModeProperties;
+        }
 
-		// Search for a best plane we can use
-		uint32_t bestPlaneIndex = UINT32_MAX;
-		VkDisplayKHR* pDisplays = NULL;
-		for(uint32_t i = 0; i < planePropertyCount; i++)
-		{
-			uint32_t planeIndex=i;
-			uint32_t displayCount;
-			vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, &displayCount, NULL);
-			if (pDisplays)
-			{
-				delete [] pDisplays;
-			}
-			pDisplays = new VkDisplayKHR[displayCount];
-			vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, &displayCount, pDisplays);
+        if (!foundMode)
+        {
+            vks::tools::exitFatal("Can't find a display and a display mode!", -1);
+            return;
+        }
 
-			// Find a display that matches the current plane
-			bestPlaneIndex = UINT32_MAX;
-			for(uint32_t j = 0; j < displayCount; j++)
-			{
-				if(display == pDisplays[j])
-				{
-					bestPlaneIndex = i;
-					break;
-				}
-			}
-			if(bestPlaneIndex != UINT32_MAX)
-			{
-				break;
-			}
-		}
+        // Search for a best plane we can use
+        uint32_t bestPlaneIndex = UINT32_MAX;
+        VkDisplayKHR* pDisplays = NULL;
+        for (uint32_t i = 0; i < planePropertyCount; i++)
+        {
+            uint32_t planeIndex = i;
+            uint32_t displayCount;
+            vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, &displayCount, NULL);
+            if (pDisplays)
+            {
+                delete[] pDisplays;
+            }
+            pDisplays = new VkDisplayKHR[displayCount];
+            vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, &displayCount, pDisplays);
 
-		if(bestPlaneIndex == UINT32_MAX)
-		{
-			vks::tools::exitFatal("Can't find a plane for displaying!", -1);
-			return;
-		}
+            // Find a display that matches the current plane
+            bestPlaneIndex = UINT32_MAX;
+            for (uint32_t j = 0; j < displayCount; j++)
+            {
+                if (display == pDisplays[j])
+                {
+                    bestPlaneIndex = i;
+                    break;
+                }
+            }
+            if (bestPlaneIndex != UINT32_MAX)
+            {
+                break;
+            }
+        }
 
-		VkDisplayPlaneCapabilitiesKHR planeCap;
-		vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, displayMode, bestPlaneIndex, &planeCap);
-		VkDisplayPlaneAlphaFlagBitsKHR alphaMode = (VkDisplayPlaneAlphaFlagBitsKHR)0;
+        if (bestPlaneIndex == UINT32_MAX)
+        {
+            vks::tools::exitFatal("Can't find a plane for displaying!", -1);
+            return;
+        }
 
-		if (planeCap.supportedAlpha & VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR)
-		{
-			alphaMode = VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR;
-		}
-		else if (planeCap.supportedAlpha & VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR)
-		{
-			alphaMode = VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR;
-		}
-		else if (planeCap.supportedAlpha & VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR)
-		{
-			alphaMode = VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR;
-		}
-		else if (planeCap.supportedAlpha & VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR)
-		{
-			alphaMode = VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR;
-		}
+        VkDisplayPlaneCapabilitiesKHR planeCap;
+        vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, displayMode, bestPlaneIndex, &planeCap);
+        VkDisplayPlaneAlphaFlagBitsKHR alphaMode = (VkDisplayPlaneAlphaFlagBitsKHR)0;
 
-		VkDisplaySurfaceCreateInfoKHR surfaceInfo{};
-		surfaceInfo.sType = VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR;
-		surfaceInfo.pNext = NULL;
-		surfaceInfo.flags = 0;
-		surfaceInfo.displayMode = displayMode;
-		surfaceInfo.planeIndex = bestPlaneIndex;
-		surfaceInfo.planeStackIndex = pPlaneProperties[bestPlaneIndex].currentStackIndex;
-		surfaceInfo.transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
-		surfaceInfo.globalAlpha = 1.0;
-		surfaceInfo.alphaMode = alphaMode;
-		surfaceInfo.imageExtent.width = width;
-		surfaceInfo.imageExtent.height = height;
+        if (planeCap.supportedAlpha & VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR)
+        {
+            alphaMode = VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR;
+        }
+        else if (planeCap.supportedAlpha & VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR)
+        {
+            alphaMode = VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR;
+        }
+        else if (planeCap.supportedAlpha & VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR)
+        {
+            alphaMode = VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR;
+        }
+        else if (planeCap.supportedAlpha & VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR)
+        {
+            alphaMode = VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR;
+        }
 
-		VkResult result = vkCreateDisplayPlaneSurfaceKHR(instance, &surfaceInfo, NULL, &surface);
-		if (result !=VK_SUCCESS) {
-			vks::tools::exitFatal("Failed to create surface!", result);
-		}
+        VkDisplaySurfaceCreateInfoKHR surfaceInfo{};
+        surfaceInfo.sType = VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR;
+        surfaceInfo.pNext = NULL;
+        surfaceInfo.flags = 0;
+        surfaceInfo.displayMode = displayMode;
+        surfaceInfo.planeIndex = bestPlaneIndex;
+        surfaceInfo.planeStackIndex = pPlaneProperties[bestPlaneIndex].currentStackIndex;
+        surfaceInfo.transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+        surfaceInfo.globalAlpha = 1.0;
+        surfaceInfo.alphaMode = alphaMode;
+        surfaceInfo.imageExtent.width = width;
+        surfaceInfo.imageExtent.height = height;
 
-		delete[] pDisplays;
-		delete[] pModeProperties;
-		delete[] pDisplayProperties;
-		delete[] pPlaneProperties;
-	}
-#endif 
+        VkResult result = vkCreateDisplayPlaneSurfaceKHR(instance, &surfaceInfo, NULL, &surface);
+        if (result != VK_SUCCESS)
+        {
+            vks::tools::exitFatal("Failed to create surface!", result);
+        }
+
+        delete[] pDisplays;
+        delete[] pModeProperties;
+        delete[] pDisplayProperties;
+        delete[] pPlaneProperties;
+    }
+#endif
 };

--- a/base/VulkanTexture.hpp
+++ b/base/VulkanTexture.hpp
@@ -28,67 +28,77 @@
 
 namespace vks
 {
-	/** @brief Vulkan texture base class */
-	class Texture {
-	public:
-		vks::VulkanDevice *device;
-		VkImage image;
-		VkImageLayout imageLayout;
-		VkDeviceMemory deviceMemory;
-		VkImageView view;
-		uint32_t width, height;
-		uint32_t mipLevels;
-		uint32_t layerCount;
-		VkDescriptorImageInfo descriptor;
-		VkSampler sampler;
+    /** @brief Vulkan texture base class */
+    class Texture
+    {
+    public:
+        vks::VulkanDevice* device;
+        VkImage image;
+        VkImageLayout imageLayout;
+        VkDeviceMemory deviceMemory;
+        VkImageView view;
+        uint32_t width, height;
+        uint32_t mipLevels;
+        uint32_t layerCount;
+        VkDescriptorImageInfo descriptor;
+        VkSampler sampler;
 
-		void updateDescriptor()
-		{
-			descriptor.sampler = sampler;
-			descriptor.imageView = view;
-			descriptor.imageLayout = imageLayout;
-		}
+        void updateDescriptor()
+        {
+            descriptor.sampler = sampler;
+            descriptor.imageView = view;
+            descriptor.imageLayout = imageLayout;
+        }
 
-		void destroy()
-		{
-			vkDestroyImageView(device->logicalDevice, view, nullptr);
-			vkDestroyImage(device->logicalDevice, image, nullptr);
-			if (sampler)
-			{
-				vkDestroySampler(device->logicalDevice, sampler, nullptr);
-			}
-			vkFreeMemory(device->logicalDevice, deviceMemory, nullptr);
-		}
+        void destroy()
+        {
+            vkDestroyImageView(device->logicalDevice, view, nullptr);
+            vkDestroyImage(device->logicalDevice, image, nullptr);
+            if (sampler)
+            {
+                vkDestroySampler(device->logicalDevice, sampler, nullptr);
+            }
+            vkFreeMemory(device->logicalDevice, deviceMemory, nullptr);
+        }
 
-		ktxResult loadKTXFile(std::string filename, ktxTexture **target)
-		{
-			ktxResult result = KTX_SUCCESS;
+        ktxResult loadKTXFile(std::string filename, ktxTexture** target)
+        {
+            ktxResult result = KTX_SUCCESS;
 #if defined(__ANDROID__)
-			AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, filename.c_str(), AASSET_MODE_STREAMING);
-			if (!asset) {
-				vks::tools::exitFatal("Could not load texture from " + filename + "\n\nThe file may be part of the additional asset pack.\n\nRun \"download_assets.py\" in the repository root to download the latest version.", -1);
-			}
-			size_t size = AAsset_getLength(asset);
-			assert(size > 0);
-			ktx_uint8_t *textureData = new ktx_uint8_t[size];
-			AAsset_read(asset, textureData, size);
-			AAsset_close(asset);
-			result = ktxTexture_CreateFromMemory(textureData, size, KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, target);
-			delete[] textureData;
+            AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, filename.c_str(), AASSET_MODE_STREAMING);
+            if (!asset)
+            {
+                vks::tools::exitFatal("Could not load texture from " + filename +
+                                          "\n\nThe file may be part of the additional asset pack.\n\nRun \"download_assets.py\" in the repository root to "
+                                          "download the latest version.",
+                                      -1);
+            }
+            size_t size = AAsset_getLength(asset);
+            assert(size > 0);
+            ktx_uint8_t* textureData = new ktx_uint8_t[size];
+            AAsset_read(asset, textureData, size);
+            AAsset_close(asset);
+            result = ktxTexture_CreateFromMemory(textureData, size, KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, target);
+            delete[] textureData;
 #else
-			if (!vks::tools::fileExists(filename)) {
-				vks::tools::exitFatal("Could not load texture from " + filename + "\n\nThe file may be part of the additional asset pack.\n\nRun \"download_assets.py\" in the repository root to download the latest version.", -1);
-			}
-			result = ktxTexture_CreateFromNamedFile(filename.c_str(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, target);			
-#endif		
-			return result;
-		}
-	};
+            if (!vks::tools::fileExists(filename))
+            {
+                vks::tools::exitFatal("Could not load texture from " + filename +
+                                          "\n\nThe file may be part of the additional asset pack.\n\nRun \"download_assets.py\" in the repository root to "
+                                          "download the latest version.",
+                                      -1);
+            }
+            result = ktxTexture_CreateFromNamedFile(filename.c_str(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, target);
+#endif
+            return result;
+        }
+    };
 
-	/** @brief 2D texture */
-	class Texture2D : public Texture {
-	public:
-		/**
+    /** @brief 2D texture */
+    class Texture2D : public Texture
+    {
+    public:
+        /**
 		* Load a 2D texture including all mip levels
 		*
 		* @param filename File to load (supports .ktx)
@@ -100,281 +110,266 @@ namespace vks
 		* @param (Optional) forceLinear Force linear tiling (not advised, defaults to false)
 		*
 		*/
-		void loadFromFile(
-			std::string filename, 
-			VkFormat format,
-			vks::VulkanDevice *device,
-			VkQueue copyQueue,
-			VkImageUsageFlags imageUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT,
-			VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 
-			bool forceLinear = false)
-		{
-			ktxTexture* ktxTexture;
-			ktxResult result = loadKTXFile(filename, &ktxTexture);
-			assert(result == KTX_SUCCESS);
+        void loadFromFile(std::string filename,
+                          VkFormat format,
+                          vks::VulkanDevice* device,
+                          VkQueue copyQueue,
+                          VkImageUsageFlags imageUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT,
+                          VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                          bool forceLinear = false)
+        {
+            ktxTexture* ktxTexture;
+            ktxResult result = loadKTXFile(filename, &ktxTexture);
+            assert(result == KTX_SUCCESS);
 
-			this->device = device;
-			width = ktxTexture->baseWidth;
-			height = ktxTexture->baseHeight;
-			mipLevels = ktxTexture->numLevels;
+            this->device = device;
+            width = ktxTexture->baseWidth;
+            height = ktxTexture->baseHeight;
+            mipLevels = ktxTexture->numLevels;
 
-			ktx_uint8_t *ktxTextureData = ktxTexture_GetData(ktxTexture);
-			ktx_size_t ktxTextureSize = ktxTexture_GetSize(ktxTexture);
+            ktx_uint8_t* ktxTextureData = ktxTexture_GetData(ktxTexture);
+            ktx_size_t ktxTextureSize = ktxTexture_GetSize(ktxTexture);
 
-			// Get device properites for the requested texture format
-			VkFormatProperties formatProperties;
-			vkGetPhysicalDeviceFormatProperties(device->physicalDevice, format, &formatProperties);
+            // Get device properites for the requested texture format
+            VkFormatProperties formatProperties;
+            vkGetPhysicalDeviceFormatProperties(device->physicalDevice, format, &formatProperties);
 
-			// Only use linear tiling if requested (and supported by the device)
-			// Support for linear tiling is mostly limited, so prefer to use
-			// optimal tiling instead
-			// On most implementations linear tiling will only support a very
-			// limited amount of formats and features (mip maps, cubemaps, arrays, etc.)
-			VkBool32 useStaging = !forceLinear;
+            // Only use linear tiling if requested (and supported by the device)
+            // Support for linear tiling is mostly limited, so prefer to use
+            // optimal tiling instead
+            // On most implementations linear tiling will only support a very
+            // limited amount of formats and features (mip maps, cubemaps, arrays, etc.)
+            VkBool32 useStaging = !forceLinear;
 
-			VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
-			VkMemoryRequirements memReqs;
+            VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
+            VkMemoryRequirements memReqs;
 
-			// Use a separate command buffer for texture loading
-			VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+            // Use a separate command buffer for texture loading
+            VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-			if (useStaging)
-			{
-				// Create a host-visible staging buffer that contains the raw image data
-				VkBuffer stagingBuffer;
-				VkDeviceMemory stagingMemory;
+            if (useStaging)
+            {
+                // Create a host-visible staging buffer that contains the raw image data
+                VkBuffer stagingBuffer;
+                VkDeviceMemory stagingMemory;
 
-				VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo();
-				bufferCreateInfo.size = ktxTextureSize;
-				// This buffer is used as a transfer source for the buffer copy
-				bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-				bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+                VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo();
+                bufferCreateInfo.size = ktxTextureSize;
+                // This buffer is used as a transfer source for the buffer copy
+                bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+                bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-				VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
+                VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
 
-				// Get memory requirements for the staging buffer (alignment, memory type bits)
-				vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
+                // Get memory requirements for the staging buffer (alignment, memory type bits)
+                vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
 
-				memAllocInfo.allocationSize = memReqs.size;
-				// Get memory type index for a host visible buffer
-				memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                memAllocInfo.allocationSize = memReqs.size;
+                // Get memory type index for a host visible buffer
+                memAllocInfo.memoryTypeIndex =
+                    device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-				VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
-				VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
+                VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
+                VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
 
-				// Copy texture data into staging buffer
-				uint8_t *data;
-				VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void **)&data));
-				memcpy(data, ktxTextureData, ktxTextureSize);
-				vkUnmapMemory(device->logicalDevice, stagingMemory);
+                // Copy texture data into staging buffer
+                uint8_t* data;
+                VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void**)&data));
+                memcpy(data, ktxTextureData, ktxTextureSize);
+                vkUnmapMemory(device->logicalDevice, stagingMemory);
 
-				// Setup buffer copy regions for each mip level
-				std::vector<VkBufferImageCopy> bufferCopyRegions;
+                // Setup buffer copy regions for each mip level
+                std::vector<VkBufferImageCopy> bufferCopyRegions;
 
-				for (uint32_t i = 0; i < mipLevels; i++)
-				{
-					ktx_size_t offset;
-					KTX_error_code result = ktxTexture_GetImageOffset(ktxTexture, i, 0, 0, &offset);
-					assert(result == KTX_SUCCESS);
+                for (uint32_t i = 0; i < mipLevels; i++)
+                {
+                    ktx_size_t offset;
+                    KTX_error_code result = ktxTexture_GetImageOffset(ktxTexture, i, 0, 0, &offset);
+                    assert(result == KTX_SUCCESS);
 
-					VkBufferImageCopy bufferCopyRegion = {};
-					bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-					bufferCopyRegion.imageSubresource.mipLevel = i;
-					bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
-					bufferCopyRegion.imageSubresource.layerCount = 1;
-					bufferCopyRegion.imageExtent.width = ktxTexture->baseWidth >> i;
-					bufferCopyRegion.imageExtent.height = ktxTexture->baseHeight >> i;
-					bufferCopyRegion.imageExtent.depth = 1;
-					bufferCopyRegion.bufferOffset = offset;
+                    VkBufferImageCopy bufferCopyRegion = {};
+                    bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                    bufferCopyRegion.imageSubresource.mipLevel = i;
+                    bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
+                    bufferCopyRegion.imageSubresource.layerCount = 1;
+                    bufferCopyRegion.imageExtent.width = ktxTexture->baseWidth >> i;
+                    bufferCopyRegion.imageExtent.height = ktxTexture->baseHeight >> i;
+                    bufferCopyRegion.imageExtent.depth = 1;
+                    bufferCopyRegion.bufferOffset = offset;
 
-					bufferCopyRegions.push_back(bufferCopyRegion);
-				}
+                    bufferCopyRegions.push_back(bufferCopyRegion);
+                }
 
-				// Create optimal tiled target image
-				VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
-				imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-				imageCreateInfo.format = format;
-				imageCreateInfo.mipLevels = mipLevels;
-				imageCreateInfo.arrayLayers = 1;
-				imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-				imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-				imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-				imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-				imageCreateInfo.extent = { width, height, 1 };
-				imageCreateInfo.usage = imageUsageFlags;
-				// Ensure that the TRANSFER_DST bit is set for staging
-				if (!(imageCreateInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
-				{
-					imageCreateInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-				}
-				VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
+                // Create optimal tiled target image
+                VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
+                imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+                imageCreateInfo.format = format;
+                imageCreateInfo.mipLevels = mipLevels;
+                imageCreateInfo.arrayLayers = 1;
+                imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+                imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+                imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+                imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                imageCreateInfo.extent = { width, height, 1 };
+                imageCreateInfo.usage = imageUsageFlags;
+                // Ensure that the TRANSFER_DST bit is set for staging
+                if (!(imageCreateInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+                {
+                    imageCreateInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+                }
+                VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
 
-				vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
+                vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
 
-				memAllocInfo.allocationSize = memReqs.size;
+                memAllocInfo.allocationSize = memReqs.size;
 
-				memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-				VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
-				VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
+                memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+                VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
+                VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
 
-				VkImageSubresourceRange subresourceRange = {};
-				subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-				subresourceRange.baseMipLevel = 0;
-				subresourceRange.levelCount = mipLevels;
-				subresourceRange.layerCount = 1;
+                VkImageSubresourceRange subresourceRange = {};
+                subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                subresourceRange.baseMipLevel = 0;
+                subresourceRange.levelCount = mipLevels;
+                subresourceRange.layerCount = 1;
 
-				// Image barrier for optimal image (target)
-				// Optimal image will be used as destination for the copy
-				vks::tools::setImageLayout(
-					copyCmd,
-					image,
-					VK_IMAGE_LAYOUT_UNDEFINED,
-					VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-					subresourceRange);
+                // Image barrier for optimal image (target)
+                // Optimal image will be used as destination for the copy
+                vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresourceRange);
 
-				// Copy mip levels from staging buffer
-				vkCmdCopyBufferToImage(
-					copyCmd,
-					stagingBuffer,
-					image,
-					VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-					static_cast<uint32_t>(bufferCopyRegions.size()),
-					bufferCopyRegions.data()
-				);
+                // Copy mip levels from staging buffer
+                vkCmdCopyBufferToImage(copyCmd, stagingBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, static_cast<uint32_t>(bufferCopyRegions.size()),
+                                       bufferCopyRegions.data());
 
-				// Change texture image layout to shader read after all mip levels have been copied
-				this->imageLayout = imageLayout;
-				vks::tools::setImageLayout(
-					copyCmd,
-					image,
-					VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-					imageLayout,
-					subresourceRange);
+                // Change texture image layout to shader read after all mip levels have been copied
+                this->imageLayout = imageLayout;
+                vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, imageLayout, subresourceRange);
 
-				device->flushCommandBuffer(copyCmd, copyQueue);
+                device->flushCommandBuffer(copyCmd, copyQueue);
 
-				// Clean up staging resources
-				vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
-				vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
-			}
-			else
-			{
-				// Prefer using optimal tiling, as linear tiling 
-				// may support only a small set of features 
-				// depending on implementation (e.g. no mip maps, only one layer, etc.)
+                // Clean up staging resources
+                vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
+                vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
+            }
+            else
+            {
+                // Prefer using optimal tiling, as linear tiling
+                // may support only a small set of features
+                // depending on implementation (e.g. no mip maps, only one layer, etc.)
 
-				// Check if this support is supported for linear tiling
-				assert(formatProperties.linearTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT);
+                // Check if this support is supported for linear tiling
+                assert(formatProperties.linearTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT);
 
-				VkImage mappableImage;
-				VkDeviceMemory mappableMemory;
+                VkImage mappableImage;
+                VkDeviceMemory mappableMemory;
 
-				VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
-				imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-				imageCreateInfo.format = format;
-				imageCreateInfo.extent = { width, height, 1 };
-				imageCreateInfo.mipLevels = 1;
-				imageCreateInfo.arrayLayers = 1;
-				imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-				imageCreateInfo.tiling = VK_IMAGE_TILING_LINEAR;
-				imageCreateInfo.usage = imageUsageFlags;
-				imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-				imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
+                imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+                imageCreateInfo.format = format;
+                imageCreateInfo.extent = { width, height, 1 };
+                imageCreateInfo.mipLevels = 1;
+                imageCreateInfo.arrayLayers = 1;
+                imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+                imageCreateInfo.tiling = VK_IMAGE_TILING_LINEAR;
+                imageCreateInfo.usage = imageUsageFlags;
+                imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+                imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-				// Load mip map level 0 to linear tiling image
-				VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &mappableImage));
+                // Load mip map level 0 to linear tiling image
+                VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &mappableImage));
 
-				// Get memory requirements for this image 
-				// like size and alignment
-				vkGetImageMemoryRequirements(device->logicalDevice, mappableImage, &memReqs);
-				// Set memory allocation size to required memory size
-				memAllocInfo.allocationSize = memReqs.size;
+                // Get memory requirements for this image
+                // like size and alignment
+                vkGetImageMemoryRequirements(device->logicalDevice, mappableImage, &memReqs);
+                // Set memory allocation size to required memory size
+                memAllocInfo.allocationSize = memReqs.size;
 
-				// Get memory type that can be mapped to host memory
-				memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                // Get memory type that can be mapped to host memory
+                memAllocInfo.memoryTypeIndex =
+                    device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-				// Allocate host memory
-				VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &mappableMemory));
+                // Allocate host memory
+                VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &mappableMemory));
 
-				// Bind allocated image for use
-				VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, mappableImage, mappableMemory, 0));
+                // Bind allocated image for use
+                VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, mappableImage, mappableMemory, 0));
 
-				// Get sub resource layout
-				// Mip map count, array layer, etc.
-				VkImageSubresource subRes = {};
-				subRes.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-				subRes.mipLevel = 0;
+                // Get sub resource layout
+                // Mip map count, array layer, etc.
+                VkImageSubresource subRes = {};
+                subRes.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                subRes.mipLevel = 0;
 
-				VkSubresourceLayout subResLayout;
-				void *data;
+                VkSubresourceLayout subResLayout;
+                void* data;
 
-				// Get sub resources layout 
-				// Includes row pitch, size offsets, etc.
-				vkGetImageSubresourceLayout(device->logicalDevice, mappableImage, &subRes, &subResLayout);
+                // Get sub resources layout
+                // Includes row pitch, size offsets, etc.
+                vkGetImageSubresourceLayout(device->logicalDevice, mappableImage, &subRes, &subResLayout);
 
-				// Map image memory
-				VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, mappableMemory, 0, memReqs.size, 0, &data));
+                // Map image memory
+                VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, mappableMemory, 0, memReqs.size, 0, &data));
 
-				// Copy image data into memory
-				memcpy(data, ktxTextureData, memReqs.size);
+                // Copy image data into memory
+                memcpy(data, ktxTextureData, memReqs.size);
 
-				vkUnmapMemory(device->logicalDevice, mappableMemory);
+                vkUnmapMemory(device->logicalDevice, mappableMemory);
 
-				// Linear tiled images don't need to be staged
-				// and can be directly used as textures
-				image = mappableImage;
-				deviceMemory = mappableMemory;
-				this->imageLayout = imageLayout;
+                // Linear tiled images don't need to be staged
+                // and can be directly used as textures
+                image = mappableImage;
+                deviceMemory = mappableMemory;
+                this->imageLayout = imageLayout;
 
-				// Setup image memory barrier
-				vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, imageLayout);
+                // Setup image memory barrier
+                vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, imageLayout);
 
-				device->flushCommandBuffer(copyCmd, copyQueue);
-			}
+                device->flushCommandBuffer(copyCmd, copyQueue);
+            }
 
-			ktxTexture_Destroy(ktxTexture);
+            ktxTexture_Destroy(ktxTexture);
 
-			// Create a defaultsampler
-			VkSamplerCreateInfo samplerCreateInfo = {};
-			samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-			samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
-			samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
-			samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-			samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-			samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-			samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-			samplerCreateInfo.mipLodBias = 0.0f;
-			samplerCreateInfo.compareOp = VK_COMPARE_OP_NEVER;
-			samplerCreateInfo.minLod = 0.0f;
-			// Max level-of-detail should match mip level count
-			samplerCreateInfo.maxLod = (useStaging) ? (float)mipLevels : 0.0f;
-			// Only enable anisotropic filtering if enabled on the devicec
-			samplerCreateInfo.maxAnisotropy = device->enabledFeatures.samplerAnisotropy ? device->properties.limits.maxSamplerAnisotropy : 1.0f;
-			samplerCreateInfo.anisotropyEnable = device->enabledFeatures.samplerAnisotropy;
-			samplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-			VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerCreateInfo, nullptr, &sampler));
+            // Create a defaultsampler
+            VkSamplerCreateInfo samplerCreateInfo = {};
+            samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+            samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
+            samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
+            samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerCreateInfo.mipLodBias = 0.0f;
+            samplerCreateInfo.compareOp = VK_COMPARE_OP_NEVER;
+            samplerCreateInfo.minLod = 0.0f;
+            // Max level-of-detail should match mip level count
+            samplerCreateInfo.maxLod = (useStaging) ? (float)mipLevels : 0.0f;
+            // Only enable anisotropic filtering if enabled on the devicec
+            samplerCreateInfo.maxAnisotropy = device->enabledFeatures.samplerAnisotropy ? device->properties.limits.maxSamplerAnisotropy : 1.0f;
+            samplerCreateInfo.anisotropyEnable = device->enabledFeatures.samplerAnisotropy;
+            samplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+            VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerCreateInfo, nullptr, &sampler));
 
-			// Create image view
-			// Textures are not directly accessed by the shaders and
-			// are abstracted by image views containing additional
-			// information and sub resource ranges
-			VkImageViewCreateInfo viewCreateInfo = {};
-			viewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-			viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-			viewCreateInfo.format = format;
-			viewCreateInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
-			viewCreateInfo.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
-			// Linear tiling usually won't support mip maps
-			// Only set mip map count if optimal tiling is used
-			viewCreateInfo.subresourceRange.levelCount = (useStaging) ? mipLevels : 1;
-			viewCreateInfo.image = image;
-			VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewCreateInfo, nullptr, &view));
+            // Create image view
+            // Textures are not directly accessed by the shaders and
+            // are abstracted by image views containing additional
+            // information and sub resource ranges
+            VkImageViewCreateInfo viewCreateInfo = {};
+            viewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            viewCreateInfo.format = format;
+            viewCreateInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
+            viewCreateInfo.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+            // Linear tiling usually won't support mip maps
+            // Only set mip map count if optimal tiling is used
+            viewCreateInfo.subresourceRange.levelCount = (useStaging) ? mipLevels : 1;
+            viewCreateInfo.image = image;
+            VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewCreateInfo, nullptr, &view));
 
-			// Update descriptor image info member that can be used for setting up descriptor sets
-			updateDescriptor();
-		}
+            // Update descriptor image info member that can be used for setting up descriptor sets
+            updateDescriptor();
+        }
 
-		/**
+        /**
 		* Creates a 2D texture from a buffer
 		*
 		* @param buffer Buffer containing texture data to upload
@@ -388,174 +383,157 @@ namespace vks
 		* @param (Optional) imageUsageFlags Usage flags for the texture's image (defaults to VK_IMAGE_USAGE_SAMPLED_BIT)
 		* @param (Optional) imageLayout Usage layout for the texture (defaults VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
 		*/
-		void fromBuffer(
-			void* buffer,
-			VkDeviceSize bufferSize,
-			VkFormat format,
-			uint32_t texWidth,
-			uint32_t texHeight,
-			vks::VulkanDevice *device,
-			VkQueue copyQueue,
-			VkFilter filter = VK_FILTER_LINEAR,
-			VkImageUsageFlags imageUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT,
-			VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-		{
-			assert(buffer);
+        void fromBuffer(void* buffer,
+                        VkDeviceSize bufferSize,
+                        VkFormat format,
+                        uint32_t texWidth,
+                        uint32_t texHeight,
+                        vks::VulkanDevice* device,
+                        VkQueue copyQueue,
+                        VkFilter filter = VK_FILTER_LINEAR,
+                        VkImageUsageFlags imageUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT,
+                        VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+        {
+            assert(buffer);
 
-			this->device = device;
-			width = texWidth;
-			height = texHeight;
-			mipLevels = 1;
+            this->device = device;
+            width = texWidth;
+            height = texHeight;
+            mipLevels = 1;
 
-			VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
-			VkMemoryRequirements memReqs;
+            VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
+            VkMemoryRequirements memReqs;
 
-			// Use a separate command buffer for texture loading
-			VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+            // Use a separate command buffer for texture loading
+            VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-			// Create a host-visible staging buffer that contains the raw image data
-			VkBuffer stagingBuffer;
-			VkDeviceMemory stagingMemory;
+            // Create a host-visible staging buffer that contains the raw image data
+            VkBuffer stagingBuffer;
+            VkDeviceMemory stagingMemory;
 
-			VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo();
-			bufferCreateInfo.size = bufferSize;
-			// This buffer is used as a transfer source for the buffer copy
-			bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-			bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo();
+            bufferCreateInfo.size = bufferSize;
+            // This buffer is used as a transfer source for the buffer copy
+            bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-			VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
+            VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
 
-			// Get memory requirements for the staging buffer (alignment, memory type bits)
-			vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
+            // Get memory requirements for the staging buffer (alignment, memory type bits)
+            vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
 
-			memAllocInfo.allocationSize = memReqs.size;
-			// Get memory type index for a host visible buffer
-			memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            memAllocInfo.allocationSize = memReqs.size;
+            // Get memory type index for a host visible buffer
+            memAllocInfo.memoryTypeIndex =
+                device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-			VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
-			VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
+            VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
+            VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
 
-			// Copy texture data into staging buffer
-			uint8_t *data;
-			VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void **)&data));
-			memcpy(data, buffer, bufferSize);
-			vkUnmapMemory(device->logicalDevice, stagingMemory);
+            // Copy texture data into staging buffer
+            uint8_t* data;
+            VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void**)&data));
+            memcpy(data, buffer, bufferSize);
+            vkUnmapMemory(device->logicalDevice, stagingMemory);
 
-			VkBufferImageCopy bufferCopyRegion = {};
-			bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			bufferCopyRegion.imageSubresource.mipLevel = 0;
-			bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
-			bufferCopyRegion.imageSubresource.layerCount = 1;
-			bufferCopyRegion.imageExtent.width = width;
-			bufferCopyRegion.imageExtent.height = height;
-			bufferCopyRegion.imageExtent.depth = 1;
-			bufferCopyRegion.bufferOffset = 0;
+            VkBufferImageCopy bufferCopyRegion = {};
+            bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            bufferCopyRegion.imageSubresource.mipLevel = 0;
+            bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
+            bufferCopyRegion.imageSubresource.layerCount = 1;
+            bufferCopyRegion.imageExtent.width = width;
+            bufferCopyRegion.imageExtent.height = height;
+            bufferCopyRegion.imageExtent.depth = 1;
+            bufferCopyRegion.bufferOffset = 0;
 
-			// Create optimal tiled target image
-			VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
-			imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-			imageCreateInfo.format = format;
-			imageCreateInfo.mipLevels = mipLevels;
-			imageCreateInfo.arrayLayers = 1;
-			imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-			imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-			imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-			imageCreateInfo.extent = { width, height, 1 };
-			imageCreateInfo.usage = imageUsageFlags;
-			// Ensure that the TRANSFER_DST bit is set for staging
-			if (!(imageCreateInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
-			{
-				imageCreateInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-			}
-			VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
+            // Create optimal tiled target image
+            VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
+            imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+            imageCreateInfo.format = format;
+            imageCreateInfo.mipLevels = mipLevels;
+            imageCreateInfo.arrayLayers = 1;
+            imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+            imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+            imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            imageCreateInfo.extent = { width, height, 1 };
+            imageCreateInfo.usage = imageUsageFlags;
+            // Ensure that the TRANSFER_DST bit is set for staging
+            if (!(imageCreateInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+            {
+                imageCreateInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            }
+            VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
 
-			vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
+            vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
 
-			memAllocInfo.allocationSize = memReqs.size;
+            memAllocInfo.allocationSize = memReqs.size;
 
-			memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-			VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
-			VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
+            memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
+            VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
 
-			VkImageSubresourceRange subresourceRange = {};
-			subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			subresourceRange.baseMipLevel = 0;
-			subresourceRange.levelCount = mipLevels;
-			subresourceRange.layerCount = 1;
+            VkImageSubresourceRange subresourceRange = {};
+            subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            subresourceRange.baseMipLevel = 0;
+            subresourceRange.levelCount = mipLevels;
+            subresourceRange.layerCount = 1;
 
-			// Image barrier for optimal image (target)
-			// Optimal image will be used as destination for the copy
-			vks::tools::setImageLayout(
-				copyCmd,
-				image,
-				VK_IMAGE_LAYOUT_UNDEFINED,
-				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				subresourceRange);
+            // Image barrier for optimal image (target)
+            // Optimal image will be used as destination for the copy
+            vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresourceRange);
 
-			// Copy mip levels from staging buffer
-			vkCmdCopyBufferToImage(
-				copyCmd,
-				stagingBuffer,
-				image,
-				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				1,
-				&bufferCopyRegion
-			);
+            // Copy mip levels from staging buffer
+            vkCmdCopyBufferToImage(copyCmd, stagingBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &bufferCopyRegion);
 
-			// Change texture image layout to shader read after all mip levels have been copied
-			this->imageLayout = imageLayout;
-			vks::tools::setImageLayout(
-				copyCmd,
-				image,
-				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				imageLayout,
-				subresourceRange);
+            // Change texture image layout to shader read after all mip levels have been copied
+            this->imageLayout = imageLayout;
+            vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, imageLayout, subresourceRange);
 
-			device->flushCommandBuffer(copyCmd, copyQueue);
+            device->flushCommandBuffer(copyCmd, copyQueue);
 
-			// Clean up staging resources
-			vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
-			vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
+            // Clean up staging resources
+            vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
+            vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
 
-			// Create sampler
-			VkSamplerCreateInfo samplerCreateInfo = {};
-			samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-			samplerCreateInfo.magFilter = filter;
-			samplerCreateInfo.minFilter = filter;
-			samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-			samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-			samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-			samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-			samplerCreateInfo.mipLodBias = 0.0f;
-			samplerCreateInfo.compareOp = VK_COMPARE_OP_NEVER;
-			samplerCreateInfo.minLod = 0.0f;
-			samplerCreateInfo.maxLod = 0.0f;
-			samplerCreateInfo.maxAnisotropy = 1.0f;
-			VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerCreateInfo, nullptr, &sampler));
+            // Create sampler
+            VkSamplerCreateInfo samplerCreateInfo = {};
+            samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+            samplerCreateInfo.magFilter = filter;
+            samplerCreateInfo.minFilter = filter;
+            samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerCreateInfo.mipLodBias = 0.0f;
+            samplerCreateInfo.compareOp = VK_COMPARE_OP_NEVER;
+            samplerCreateInfo.minLod = 0.0f;
+            samplerCreateInfo.maxLod = 0.0f;
+            samplerCreateInfo.maxAnisotropy = 1.0f;
+            VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerCreateInfo, nullptr, &sampler));
 
-			// Create image view
-			VkImageViewCreateInfo viewCreateInfo = {};
-			viewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-			viewCreateInfo.pNext = NULL;
-			viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-			viewCreateInfo.format = format;
-			viewCreateInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
-			viewCreateInfo.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
-			viewCreateInfo.subresourceRange.levelCount = 1;
-			viewCreateInfo.image = image;
-			VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewCreateInfo, nullptr, &view));
+            // Create image view
+            VkImageViewCreateInfo viewCreateInfo = {};
+            viewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            viewCreateInfo.pNext = NULL;
+            viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            viewCreateInfo.format = format;
+            viewCreateInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
+            viewCreateInfo.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+            viewCreateInfo.subresourceRange.levelCount = 1;
+            viewCreateInfo.image = image;
+            VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewCreateInfo, nullptr, &view));
 
-			// Update descriptor image info member that can be used for setting up descriptor sets
-			updateDescriptor();
-		}
+            // Update descriptor image info member that can be used for setting up descriptor sets
+            updateDescriptor();
+        }
+    };
 
-	};
-
-	/** @brief 2D array texture */
-	class Texture2DArray : public Texture {
-	public:
-		/**
+    /** @brief 2D array texture */
+    class Texture2DArray : public Texture
+    {
+    public:
+        /**
 		* Load a 2D texture array including all mip levels
 		*
 		* @param filename File to load (supports .ktx)
@@ -566,191 +544,177 @@ namespace vks
 		* @param (Optional) imageLayout Usage layout for the texture (defaults VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
 		*
 		*/
-		void loadFromFile(
-			std::string filename,
-			VkFormat format,
-			vks::VulkanDevice *device,
-			VkQueue copyQueue,
-			VkImageUsageFlags imageUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT,
-			VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-		{
-			ktxTexture* ktxTexture;
-			ktxResult result = loadKTXFile(filename, &ktxTexture);
-			assert(result == KTX_SUCCESS);
+        void loadFromFile(std::string filename,
+                          VkFormat format,
+                          vks::VulkanDevice* device,
+                          VkQueue copyQueue,
+                          VkImageUsageFlags imageUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT,
+                          VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+        {
+            ktxTexture* ktxTexture;
+            ktxResult result = loadKTXFile(filename, &ktxTexture);
+            assert(result == KTX_SUCCESS);
 
-			this->device = device;
-			width = ktxTexture->baseWidth;
-			height = ktxTexture->baseHeight;
-			layerCount = ktxTexture->numLayers;
-			mipLevels = ktxTexture->numLevels;
+            this->device = device;
+            width = ktxTexture->baseWidth;
+            height = ktxTexture->baseHeight;
+            layerCount = ktxTexture->numLayers;
+            mipLevels = ktxTexture->numLevels;
 
-			ktx_uint8_t *ktxTextureData = ktxTexture_GetData(ktxTexture);
-			ktx_size_t ktxTextureSize = ktxTexture_GetSize(ktxTexture);
+            ktx_uint8_t* ktxTextureData = ktxTexture_GetData(ktxTexture);
+            ktx_size_t ktxTextureSize = ktxTexture_GetSize(ktxTexture);
 
-			VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
-			VkMemoryRequirements memReqs;
+            VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
+            VkMemoryRequirements memReqs;
 
-			// Create a host-visible staging buffer that contains the raw image data
-			VkBuffer stagingBuffer;
-			VkDeviceMemory stagingMemory;
+            // Create a host-visible staging buffer that contains the raw image data
+            VkBuffer stagingBuffer;
+            VkDeviceMemory stagingMemory;
 
-			VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo();
-			bufferCreateInfo.size = ktxTextureSize;
-			// This buffer is used as a transfer source for the buffer copy
-			bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-			bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo();
+            bufferCreateInfo.size = ktxTextureSize;
+            // This buffer is used as a transfer source for the buffer copy
+            bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-			VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
+            VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
 
-			// Get memory requirements for the staging buffer (alignment, memory type bits)
-			vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
+            // Get memory requirements for the staging buffer (alignment, memory type bits)
+            vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
 
-			memAllocInfo.allocationSize = memReqs.size;
-			// Get memory type index for a host visible buffer
-			memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            memAllocInfo.allocationSize = memReqs.size;
+            // Get memory type index for a host visible buffer
+            memAllocInfo.memoryTypeIndex =
+                device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-			VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
-			VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
+            VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
+            VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
 
-			// Copy texture data into staging buffer
-			uint8_t *data;
-			VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void **)&data));
-			memcpy(data, ktxTextureData, ktxTextureSize);
-			vkUnmapMemory(device->logicalDevice, stagingMemory);
+            // Copy texture data into staging buffer
+            uint8_t* data;
+            VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void**)&data));
+            memcpy(data, ktxTextureData, ktxTextureSize);
+            vkUnmapMemory(device->logicalDevice, stagingMemory);
 
-			// Setup buffer copy regions for each layer including all of it's miplevels
-			std::vector<VkBufferImageCopy> bufferCopyRegions;
+            // Setup buffer copy regions for each layer including all of it's miplevels
+            std::vector<VkBufferImageCopy> bufferCopyRegions;
 
-			for (uint32_t layer = 0; layer < layerCount; layer++)
-			{
-				for (uint32_t level = 0; level < mipLevels; level++)
-				{
-					ktx_size_t offset;
-					KTX_error_code result = ktxTexture_GetImageOffset(ktxTexture, level, layer, 0, &offset);
-					assert(result == KTX_SUCCESS);
+            for (uint32_t layer = 0; layer < layerCount; layer++)
+            {
+                for (uint32_t level = 0; level < mipLevels; level++)
+                {
+                    ktx_size_t offset;
+                    KTX_error_code result = ktxTexture_GetImageOffset(ktxTexture, level, layer, 0, &offset);
+                    assert(result == KTX_SUCCESS);
 
-					VkBufferImageCopy bufferCopyRegion = {};
-					bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-					bufferCopyRegion.imageSubresource.mipLevel = level;
-					bufferCopyRegion.imageSubresource.baseArrayLayer = layer;
-					bufferCopyRegion.imageSubresource.layerCount = 1;
-					bufferCopyRegion.imageExtent.width = ktxTexture->baseWidth >> level;
-					bufferCopyRegion.imageExtent.height = ktxTexture->baseHeight >> level;
-					bufferCopyRegion.imageExtent.depth = 1;
-					bufferCopyRegion.bufferOffset = offset;
+                    VkBufferImageCopy bufferCopyRegion = {};
+                    bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                    bufferCopyRegion.imageSubresource.mipLevel = level;
+                    bufferCopyRegion.imageSubresource.baseArrayLayer = layer;
+                    bufferCopyRegion.imageSubresource.layerCount = 1;
+                    bufferCopyRegion.imageExtent.width = ktxTexture->baseWidth >> level;
+                    bufferCopyRegion.imageExtent.height = ktxTexture->baseHeight >> level;
+                    bufferCopyRegion.imageExtent.depth = 1;
+                    bufferCopyRegion.bufferOffset = offset;
 
-					bufferCopyRegions.push_back(bufferCopyRegion);
-				}
-			}
+                    bufferCopyRegions.push_back(bufferCopyRegion);
+                }
+            }
 
-			// Create optimal tiled target image
-			VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
-			imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-			imageCreateInfo.format = format;
-			imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-			imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-			imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-			imageCreateInfo.extent = { width, height, 1 };
-			imageCreateInfo.usage = imageUsageFlags;
-			// Ensure that the TRANSFER_DST bit is set for staging
-			if (!(imageCreateInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
-			{
-				imageCreateInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-			}
-			imageCreateInfo.arrayLayers = layerCount;
-			imageCreateInfo.mipLevels = mipLevels;
+            // Create optimal tiled target image
+            VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
+            imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+            imageCreateInfo.format = format;
+            imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+            imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+            imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            imageCreateInfo.extent = { width, height, 1 };
+            imageCreateInfo.usage = imageUsageFlags;
+            // Ensure that the TRANSFER_DST bit is set for staging
+            if (!(imageCreateInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+            {
+                imageCreateInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            }
+            imageCreateInfo.arrayLayers = layerCount;
+            imageCreateInfo.mipLevels = mipLevels;
 
-			VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
+            VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
 
-			vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
+            vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
 
-			memAllocInfo.allocationSize = memReqs.size;
-			memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            memAllocInfo.allocationSize = memReqs.size;
+            memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-			VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
-			VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
+            VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
+            VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
 
-			// Use a separate command buffer for texture loading
-			VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+            // Use a separate command buffer for texture loading
+            VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-			// Image barrier for optimal image (target)
-			// Set initial layout for all array layers (faces) of the optimal (target) tiled texture
-			VkImageSubresourceRange subresourceRange = {};
-			subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			subresourceRange.baseMipLevel = 0;
-			subresourceRange.levelCount = mipLevels;
-			subresourceRange.layerCount = layerCount;
+            // Image barrier for optimal image (target)
+            // Set initial layout for all array layers (faces) of the optimal (target) tiled texture
+            VkImageSubresourceRange subresourceRange = {};
+            subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            subresourceRange.baseMipLevel = 0;
+            subresourceRange.levelCount = mipLevels;
+            subresourceRange.layerCount = layerCount;
 
-			vks::tools::setImageLayout(
-				copyCmd,
-				image,
-				VK_IMAGE_LAYOUT_UNDEFINED,
-				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				subresourceRange);
+            vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresourceRange);
 
-			// Copy the layers and mip levels from the staging buffer to the optimal tiled image
-			vkCmdCopyBufferToImage(
-				copyCmd,
-				stagingBuffer,
-				image,
-				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				static_cast<uint32_t>(bufferCopyRegions.size()),
-				bufferCopyRegions.data());
+            // Copy the layers and mip levels from the staging buffer to the optimal tiled image
+            vkCmdCopyBufferToImage(copyCmd, stagingBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, static_cast<uint32_t>(bufferCopyRegions.size()),
+                                   bufferCopyRegions.data());
 
-			// Change texture image layout to shader read after all faces have been copied
-			this->imageLayout = imageLayout;
-			vks::tools::setImageLayout(
-				copyCmd,
-				image,
-				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				imageLayout,
-				subresourceRange);
+            // Change texture image layout to shader read after all faces have been copied
+            this->imageLayout = imageLayout;
+            vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, imageLayout, subresourceRange);
 
-			device->flushCommandBuffer(copyCmd, copyQueue);
+            device->flushCommandBuffer(copyCmd, copyQueue);
 
-			// Create sampler
-			VkSamplerCreateInfo samplerCreateInfo = vks::initializers::samplerCreateInfo();
-			samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
-			samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
-			samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-			samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-			samplerCreateInfo.addressModeV = samplerCreateInfo.addressModeU;
-			samplerCreateInfo.addressModeW = samplerCreateInfo.addressModeU;
-			samplerCreateInfo.mipLodBias = 0.0f;
-			samplerCreateInfo.maxAnisotropy = device->enabledFeatures.samplerAnisotropy ? device->properties.limits.maxSamplerAnisotropy : 1.0f;
-			samplerCreateInfo.anisotropyEnable = device->enabledFeatures.samplerAnisotropy;
-			samplerCreateInfo.compareOp = VK_COMPARE_OP_NEVER;
-			samplerCreateInfo.minLod = 0.0f;
-			samplerCreateInfo.maxLod = (float)mipLevels;
-			samplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-			VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerCreateInfo, nullptr, &sampler));
+            // Create sampler
+            VkSamplerCreateInfo samplerCreateInfo = vks::initializers::samplerCreateInfo();
+            samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
+            samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
+            samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+            samplerCreateInfo.addressModeV = samplerCreateInfo.addressModeU;
+            samplerCreateInfo.addressModeW = samplerCreateInfo.addressModeU;
+            samplerCreateInfo.mipLodBias = 0.0f;
+            samplerCreateInfo.maxAnisotropy = device->enabledFeatures.samplerAnisotropy ? device->properties.limits.maxSamplerAnisotropy : 1.0f;
+            samplerCreateInfo.anisotropyEnable = device->enabledFeatures.samplerAnisotropy;
+            samplerCreateInfo.compareOp = VK_COMPARE_OP_NEVER;
+            samplerCreateInfo.minLod = 0.0f;
+            samplerCreateInfo.maxLod = (float)mipLevels;
+            samplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+            VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerCreateInfo, nullptr, &sampler));
 
-			// Create image view
-			VkImageViewCreateInfo viewCreateInfo = vks::initializers::imageViewCreateInfo();
-			viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-			viewCreateInfo.format = format;
-			viewCreateInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
-			viewCreateInfo.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
-			viewCreateInfo.subresourceRange.layerCount = layerCount;
-			viewCreateInfo.subresourceRange.levelCount = mipLevels;
-			viewCreateInfo.image = image;
-			VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewCreateInfo, nullptr, &view));
+            // Create image view
+            VkImageViewCreateInfo viewCreateInfo = vks::initializers::imageViewCreateInfo();
+            viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+            viewCreateInfo.format = format;
+            viewCreateInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
+            viewCreateInfo.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+            viewCreateInfo.subresourceRange.layerCount = layerCount;
+            viewCreateInfo.subresourceRange.levelCount = mipLevels;
+            viewCreateInfo.image = image;
+            VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewCreateInfo, nullptr, &view));
 
-			// Clean up staging resources
-			ktxTexture_Destroy(ktxTexture);
-			vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
-			vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
+            // Clean up staging resources
+            ktxTexture_Destroy(ktxTexture);
+            vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
+            vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
 
-			// Update descriptor image info member that can be used for setting up descriptor sets
-			updateDescriptor();
-		}
-	};
+            // Update descriptor image info member that can be used for setting up descriptor sets
+            updateDescriptor();
+        }
+    };
 
-	/** @brief Cube map texture */
-	class TextureCubeMap : public Texture {
-	public:
-		/**
+    /** @brief Cube map texture */
+    class TextureCubeMap : public Texture
+    {
+    public:
+        /**
 		* Load a cubemap texture including all mip levels from a single file
 		*
 		* @param filename File to load (supports .ktx)
@@ -761,188 +725,172 @@ namespace vks
 		* @param (Optional) imageLayout Usage layout for the texture (defaults VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
 		*
 		*/
-		void loadFromFile(
-			std::string filename,
-			VkFormat format,
-			vks::VulkanDevice *device,
-			VkQueue copyQueue,
-			VkImageUsageFlags imageUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT,
-			VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-		{
-			ktxTexture* ktxTexture;
-			ktxResult result = loadKTXFile(filename, &ktxTexture);
-			assert(result == KTX_SUCCESS);
+        void loadFromFile(std::string filename,
+                          VkFormat format,
+                          vks::VulkanDevice* device,
+                          VkQueue copyQueue,
+                          VkImageUsageFlags imageUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT,
+                          VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+        {
+            ktxTexture* ktxTexture;
+            ktxResult result = loadKTXFile(filename, &ktxTexture);
+            assert(result == KTX_SUCCESS);
 
-			this->device = device;
-			width = ktxTexture->baseWidth;
-			height = ktxTexture->baseHeight;
-			mipLevels = ktxTexture->numLevels;
+            this->device = device;
+            width = ktxTexture->baseWidth;
+            height = ktxTexture->baseHeight;
+            mipLevels = ktxTexture->numLevels;
 
-			ktx_uint8_t *ktxTextureData = ktxTexture_GetData(ktxTexture);
-			ktx_size_t ktxTextureSize = ktxTexture_GetSize(ktxTexture);
+            ktx_uint8_t* ktxTextureData = ktxTexture_GetData(ktxTexture);
+            ktx_size_t ktxTextureSize = ktxTexture_GetSize(ktxTexture);
 
-			VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
-			VkMemoryRequirements memReqs;
+            VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
+            VkMemoryRequirements memReqs;
 
-			// Create a host-visible staging buffer that contains the raw image data
-			VkBuffer stagingBuffer;
-			VkDeviceMemory stagingMemory;
+            // Create a host-visible staging buffer that contains the raw image data
+            VkBuffer stagingBuffer;
+            VkDeviceMemory stagingMemory;
 
-			VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo();
-			bufferCreateInfo.size = ktxTextureSize;
-			// This buffer is used as a transfer source for the buffer copy
-			bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-			bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            VkBufferCreateInfo bufferCreateInfo = vks::initializers::bufferCreateInfo();
+            bufferCreateInfo.size = ktxTextureSize;
+            // This buffer is used as a transfer source for the buffer copy
+            bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-			VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
+            VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
 
-			// Get memory requirements for the staging buffer (alignment, memory type bits)
-			vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
+            // Get memory requirements for the staging buffer (alignment, memory type bits)
+            vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
 
-			memAllocInfo.allocationSize = memReqs.size;
-			// Get memory type index for a host visible buffer
-			memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            memAllocInfo.allocationSize = memReqs.size;
+            // Get memory type index for a host visible buffer
+            memAllocInfo.memoryTypeIndex =
+                device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-			VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
-			VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
+            VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
+            VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
 
-			// Copy texture data into staging buffer
-			uint8_t *data;
-			VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void **)&data));
-			memcpy(data, ktxTextureData, ktxTextureSize);
-			vkUnmapMemory(device->logicalDevice, stagingMemory);
+            // Copy texture data into staging buffer
+            uint8_t* data;
+            VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void**)&data));
+            memcpy(data, ktxTextureData, ktxTextureSize);
+            vkUnmapMemory(device->logicalDevice, stagingMemory);
 
-			// Setup buffer copy regions for each face including all of it's miplevels
-			std::vector<VkBufferImageCopy> bufferCopyRegions;
+            // Setup buffer copy regions for each face including all of it's miplevels
+            std::vector<VkBufferImageCopy> bufferCopyRegions;
 
-			for (uint32_t face = 0; face < 6; face++)
-			{
-				for (uint32_t level = 0; level < mipLevels; level++)
-				{
-					ktx_size_t offset;
-					KTX_error_code result = ktxTexture_GetImageOffset(ktxTexture, level, 0, face, &offset);
-					assert(result == KTX_SUCCESS);
+            for (uint32_t face = 0; face < 6; face++)
+            {
+                for (uint32_t level = 0; level < mipLevels; level++)
+                {
+                    ktx_size_t offset;
+                    KTX_error_code result = ktxTexture_GetImageOffset(ktxTexture, level, 0, face, &offset);
+                    assert(result == KTX_SUCCESS);
 
-					VkBufferImageCopy bufferCopyRegion = {};
-					bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-					bufferCopyRegion.imageSubresource.mipLevel = level;
-					bufferCopyRegion.imageSubresource.baseArrayLayer = face;
-					bufferCopyRegion.imageSubresource.layerCount = 1;
-					bufferCopyRegion.imageExtent.width = ktxTexture->baseWidth >> level;
-					bufferCopyRegion.imageExtent.height = ktxTexture->baseHeight >> level;
-					bufferCopyRegion.imageExtent.depth = 1;
-					bufferCopyRegion.bufferOffset = offset;
+                    VkBufferImageCopy bufferCopyRegion = {};
+                    bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                    bufferCopyRegion.imageSubresource.mipLevel = level;
+                    bufferCopyRegion.imageSubresource.baseArrayLayer = face;
+                    bufferCopyRegion.imageSubresource.layerCount = 1;
+                    bufferCopyRegion.imageExtent.width = ktxTexture->baseWidth >> level;
+                    bufferCopyRegion.imageExtent.height = ktxTexture->baseHeight >> level;
+                    bufferCopyRegion.imageExtent.depth = 1;
+                    bufferCopyRegion.bufferOffset = offset;
 
-					bufferCopyRegions.push_back(bufferCopyRegion);
-				}
-			}
+                    bufferCopyRegions.push_back(bufferCopyRegion);
+                }
+            }
 
-			// Create optimal tiled target image
-			VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
-			imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-			imageCreateInfo.format = format;
-			imageCreateInfo.mipLevels = mipLevels;
-			imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-			imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-			imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-			imageCreateInfo.extent = { width, height, 1 };
-			imageCreateInfo.usage = imageUsageFlags;
-			// Ensure that the TRANSFER_DST bit is set for staging
-			if (!(imageCreateInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
-			{
-				imageCreateInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-			}
-			// Cube faces count as array layers in Vulkan
-			imageCreateInfo.arrayLayers = 6;
-			// This flag is required for cube map images
-			imageCreateInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
+            // Create optimal tiled target image
+            VkImageCreateInfo imageCreateInfo = vks::initializers::imageCreateInfo();
+            imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+            imageCreateInfo.format = format;
+            imageCreateInfo.mipLevels = mipLevels;
+            imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+            imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+            imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            imageCreateInfo.extent = { width, height, 1 };
+            imageCreateInfo.usage = imageUsageFlags;
+            // Ensure that the TRANSFER_DST bit is set for staging
+            if (!(imageCreateInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+            {
+                imageCreateInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            }
+            // Cube faces count as array layers in Vulkan
+            imageCreateInfo.arrayLayers = 6;
+            // This flag is required for cube map images
+            imageCreateInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
 
+            VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
 
-			VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
+            vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
 
-			vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
+            memAllocInfo.allocationSize = memReqs.size;
+            memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-			memAllocInfo.allocationSize = memReqs.size;
-			memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
+            VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
 
-			VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
-			VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
+            // Use a separate command buffer for texture loading
+            VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-			// Use a separate command buffer for texture loading
-			VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+            // Image barrier for optimal image (target)
+            // Set initial layout for all array layers (faces) of the optimal (target) tiled texture
+            VkImageSubresourceRange subresourceRange = {};
+            subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            subresourceRange.baseMipLevel = 0;
+            subresourceRange.levelCount = mipLevels;
+            subresourceRange.layerCount = 6;
 
-			// Image barrier for optimal image (target)
-			// Set initial layout for all array layers (faces) of the optimal (target) tiled texture
-			VkImageSubresourceRange subresourceRange = {};
-			subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			subresourceRange.baseMipLevel = 0;
-			subresourceRange.levelCount = mipLevels;
-			subresourceRange.layerCount = 6;
+            vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresourceRange);
 
-			vks::tools::setImageLayout(
-				copyCmd,
-				image,
-				VK_IMAGE_LAYOUT_UNDEFINED,
-				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				subresourceRange);
+            // Copy the cube map faces from the staging buffer to the optimal tiled image
+            vkCmdCopyBufferToImage(copyCmd, stagingBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, static_cast<uint32_t>(bufferCopyRegions.size()),
+                                   bufferCopyRegions.data());
 
-			// Copy the cube map faces from the staging buffer to the optimal tiled image
-			vkCmdCopyBufferToImage(
-				copyCmd,
-				stagingBuffer,
-				image,
-				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				static_cast<uint32_t>(bufferCopyRegions.size()),
-				bufferCopyRegions.data());
+            // Change texture image layout to shader read after all faces have been copied
+            this->imageLayout = imageLayout;
+            vks::tools::setImageLayout(copyCmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, imageLayout, subresourceRange);
 
-			// Change texture image layout to shader read after all faces have been copied
-			this->imageLayout = imageLayout;
-			vks::tools::setImageLayout(
-				copyCmd,
-				image,
-				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				imageLayout,
-				subresourceRange);
+            device->flushCommandBuffer(copyCmd, copyQueue);
 
-			device->flushCommandBuffer(copyCmd, copyQueue);
+            // Create sampler
+            VkSamplerCreateInfo samplerCreateInfo = vks::initializers::samplerCreateInfo();
+            samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
+            samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
+            samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+            samplerCreateInfo.addressModeV = samplerCreateInfo.addressModeU;
+            samplerCreateInfo.addressModeW = samplerCreateInfo.addressModeU;
+            samplerCreateInfo.mipLodBias = 0.0f;
+            samplerCreateInfo.maxAnisotropy = device->enabledFeatures.samplerAnisotropy ? device->properties.limits.maxSamplerAnisotropy : 1.0f;
+            samplerCreateInfo.anisotropyEnable = device->enabledFeatures.samplerAnisotropy;
+            samplerCreateInfo.compareOp = VK_COMPARE_OP_NEVER;
+            samplerCreateInfo.minLod = 0.0f;
+            samplerCreateInfo.maxLod = (float)mipLevels;
+            samplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+            VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerCreateInfo, nullptr, &sampler));
 
-			// Create sampler
-			VkSamplerCreateInfo samplerCreateInfo = vks::initializers::samplerCreateInfo();
-			samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
-			samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
-			samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-			samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-			samplerCreateInfo.addressModeV = samplerCreateInfo.addressModeU;
-			samplerCreateInfo.addressModeW = samplerCreateInfo.addressModeU;
-			samplerCreateInfo.mipLodBias = 0.0f;
-			samplerCreateInfo.maxAnisotropy = device->enabledFeatures.samplerAnisotropy ? device->properties.limits.maxSamplerAnisotropy : 1.0f;
-			samplerCreateInfo.anisotropyEnable = device->enabledFeatures.samplerAnisotropy;
-			samplerCreateInfo.compareOp = VK_COMPARE_OP_NEVER;
-			samplerCreateInfo.minLod = 0.0f;
-			samplerCreateInfo.maxLod = (float)mipLevels;
-			samplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-			VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerCreateInfo, nullptr, &sampler));
+            // Create image view
+            VkImageViewCreateInfo viewCreateInfo = vks::initializers::imageViewCreateInfo();
+            viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
+            viewCreateInfo.format = format;
+            viewCreateInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
+            viewCreateInfo.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+            viewCreateInfo.subresourceRange.layerCount = 6;
+            viewCreateInfo.subresourceRange.levelCount = mipLevels;
+            viewCreateInfo.image = image;
+            VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewCreateInfo, nullptr, &view));
 
-			// Create image view
-			VkImageViewCreateInfo viewCreateInfo = vks::initializers::imageViewCreateInfo();
-			viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
-			viewCreateInfo.format = format;
-			viewCreateInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
-			viewCreateInfo.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
-			viewCreateInfo.subresourceRange.layerCount = 6;
-			viewCreateInfo.subresourceRange.levelCount = mipLevels;
-			viewCreateInfo.image = image;
-			VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewCreateInfo, nullptr, &view));
+            // Clean up staging resources
+            ktxTexture_Destroy(ktxTexture);
+            vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
+            vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
 
-			// Clean up staging resources
-			ktxTexture_Destroy(ktxTexture);
-			vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
-			vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
+            // Update descriptor image info member that can be used for setting up descriptor sets
+            updateDescriptor();
+        }
+    };
 
-			// Update descriptor image info member that can be used for setting up descriptor sets
-			updateDescriptor();
-		}
-	};
-
-}
+}  // namespace vks

--- a/base/VulkanTools.cpp
+++ b/base/VulkanTools.cpp
@@ -10,364 +10,350 @@
 
 namespace vks
 {
-	namespace tools
-	{
-		bool errorModeSilent = false;
+    namespace tools
+    {
+        bool errorModeSilent = false;
 
-		std::string errorString(VkResult errorCode)
-		{
-			switch (errorCode)
-			{
-#define STR(r) case VK_ ##r: return #r
-				STR(NOT_READY);
-				STR(TIMEOUT);
-				STR(EVENT_SET);
-				STR(EVENT_RESET);
-				STR(INCOMPLETE);
-				STR(ERROR_OUT_OF_HOST_MEMORY);
-				STR(ERROR_OUT_OF_DEVICE_MEMORY);
-				STR(ERROR_INITIALIZATION_FAILED);
-				STR(ERROR_DEVICE_LOST);
-				STR(ERROR_MEMORY_MAP_FAILED);
-				STR(ERROR_LAYER_NOT_PRESENT);
-				STR(ERROR_EXTENSION_NOT_PRESENT);
-				STR(ERROR_FEATURE_NOT_PRESENT);
-				STR(ERROR_INCOMPATIBLE_DRIVER);
-				STR(ERROR_TOO_MANY_OBJECTS);
-				STR(ERROR_FORMAT_NOT_SUPPORTED);
-				STR(ERROR_SURFACE_LOST_KHR);
-				STR(ERROR_NATIVE_WINDOW_IN_USE_KHR);
-				STR(SUBOPTIMAL_KHR);
-				STR(ERROR_OUT_OF_DATE_KHR);
-				STR(ERROR_INCOMPATIBLE_DISPLAY_KHR);
-				STR(ERROR_VALIDATION_FAILED_EXT);
-				STR(ERROR_INVALID_SHADER_NV);
+        std::string errorString(VkResult errorCode)
+        {
+            switch (errorCode)
+            {
+#define STR(r)   \
+    case VK_##r: \
+        return #r
+                STR(NOT_READY);
+                STR(TIMEOUT);
+                STR(EVENT_SET);
+                STR(EVENT_RESET);
+                STR(INCOMPLETE);
+                STR(ERROR_OUT_OF_HOST_MEMORY);
+                STR(ERROR_OUT_OF_DEVICE_MEMORY);
+                STR(ERROR_INITIALIZATION_FAILED);
+                STR(ERROR_DEVICE_LOST);
+                STR(ERROR_MEMORY_MAP_FAILED);
+                STR(ERROR_LAYER_NOT_PRESENT);
+                STR(ERROR_EXTENSION_NOT_PRESENT);
+                STR(ERROR_FEATURE_NOT_PRESENT);
+                STR(ERROR_INCOMPATIBLE_DRIVER);
+                STR(ERROR_TOO_MANY_OBJECTS);
+                STR(ERROR_FORMAT_NOT_SUPPORTED);
+                STR(ERROR_SURFACE_LOST_KHR);
+                STR(ERROR_NATIVE_WINDOW_IN_USE_KHR);
+                STR(SUBOPTIMAL_KHR);
+                STR(ERROR_OUT_OF_DATE_KHR);
+                STR(ERROR_INCOMPATIBLE_DISPLAY_KHR);
+                STR(ERROR_VALIDATION_FAILED_EXT);
+                STR(ERROR_INVALID_SHADER_NV);
 #undef STR
-			default:
-				return "UNKNOWN_ERROR";
-			}
-		}
+                default:
+                    return "UNKNOWN_ERROR";
+            }
+        }
 
-		std::string physicalDeviceTypeString(VkPhysicalDeviceType type)
-		{
-			switch (type)
-			{
-#define STR(r) case VK_PHYSICAL_DEVICE_TYPE_ ##r: return #r
-				STR(OTHER);
-				STR(INTEGRATED_GPU);
-				STR(DISCRETE_GPU);
-				STR(VIRTUAL_GPU);
+        std::string physicalDeviceTypeString(VkPhysicalDeviceType type)
+        {
+            switch (type)
+            {
+#define STR(r)                        \
+    case VK_PHYSICAL_DEVICE_TYPE_##r: \
+        return #r
+                STR(OTHER);
+                STR(INTEGRATED_GPU);
+                STR(DISCRETE_GPU);
+                STR(VIRTUAL_GPU);
 #undef STR
-			default: return "UNKNOWN_DEVICE_TYPE";
-			}
-		}
+                default:
+                    return "UNKNOWN_DEVICE_TYPE";
+            }
+        }
 
-		VkBool32 getSupportedDepthFormat(VkPhysicalDevice physicalDevice, VkFormat *depthFormat)
-		{
-			// Since all depth formats may be optional, we need to find a suitable depth format to use
-			// Start with the highest precision packed format
-			std::vector<VkFormat> depthFormats = {
-				VK_FORMAT_D32_SFLOAT_S8_UINT,
-				VK_FORMAT_D32_SFLOAT,
-				VK_FORMAT_D24_UNORM_S8_UINT,
-				VK_FORMAT_D16_UNORM_S8_UINT,
-				VK_FORMAT_D16_UNORM
-			};
+        VkBool32 getSupportedDepthFormat(VkPhysicalDevice physicalDevice, VkFormat* depthFormat)
+        {
+            // Since all depth formats may be optional, we need to find a suitable depth format to use
+            // Start with the highest precision packed format
+            std::vector<VkFormat> depthFormats = { VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D32_SFLOAT, VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D16_UNORM_S8_UINT,
+                                                   VK_FORMAT_D16_UNORM };
 
-			for (auto& format : depthFormats)
-			{
-				VkFormatProperties formatProps;
-				vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProps);
-				// Format must support depth stencil attachment for optimal tiling
-				if (formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
-				{
-					*depthFormat = format;
-					return true;
-				}
-			}
+            for (auto& format : depthFormats)
+            {
+                VkFormatProperties formatProps;
+                vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &formatProps);
+                // Format must support depth stencil attachment for optimal tiling
+                if (formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
+                {
+                    *depthFormat = format;
+                    return true;
+                }
+            }
 
-			return false;
-		}
+            return false;
+        }
 
-		// Create an image memory barrier for changing the layout of
-		// an image and put it into an active command buffer
-		// See chapter 11.4 "Image Layout" for details
+        // Create an image memory barrier for changing the layout of
+        // an image and put it into an active command buffer
+        // See chapter 11.4 "Image Layout" for details
 
-		void setImageLayout(
-			VkCommandBuffer cmdbuffer,
-			VkImage image,
-			VkImageLayout oldImageLayout,
-			VkImageLayout newImageLayout,
-			VkImageSubresourceRange subresourceRange,
-			VkPipelineStageFlags srcStageMask,
-			VkPipelineStageFlags dstStageMask)
-		{
-			// Create an image barrier object
-			VkImageMemoryBarrier imageMemoryBarrier = vks::initializers::imageMemoryBarrier();
-			imageMemoryBarrier.oldLayout = oldImageLayout;
-			imageMemoryBarrier.newLayout = newImageLayout;
-			imageMemoryBarrier.image = image;
-			imageMemoryBarrier.subresourceRange = subresourceRange;
+        void setImageLayout(VkCommandBuffer cmdbuffer,
+                            VkImage image,
+                            VkImageLayout oldImageLayout,
+                            VkImageLayout newImageLayout,
+                            VkImageSubresourceRange subresourceRange,
+                            VkPipelineStageFlags srcStageMask,
+                            VkPipelineStageFlags dstStageMask)
+        {
+            // Create an image barrier object
+            VkImageMemoryBarrier imageMemoryBarrier = vks::initializers::imageMemoryBarrier();
+            imageMemoryBarrier.oldLayout = oldImageLayout;
+            imageMemoryBarrier.newLayout = newImageLayout;
+            imageMemoryBarrier.image = image;
+            imageMemoryBarrier.subresourceRange = subresourceRange;
 
-			// Source layouts (old)
-			// Source access mask controls actions that have to be finished on the old layout
-			// before it will be transitioned to the new layout
-			switch (oldImageLayout)
-			{
-			case VK_IMAGE_LAYOUT_UNDEFINED:
-				// Image layout is undefined (or does not matter)
-				// Only valid as initial layout
-				// No flags required, listed only for completeness
-				imageMemoryBarrier.srcAccessMask = 0;
-				break;
+            // Source layouts (old)
+            // Source access mask controls actions that have to be finished on the old layout
+            // before it will be transitioned to the new layout
+            switch (oldImageLayout)
+            {
+                case VK_IMAGE_LAYOUT_UNDEFINED:
+                    // Image layout is undefined (or does not matter)
+                    // Only valid as initial layout
+                    // No flags required, listed only for completeness
+                    imageMemoryBarrier.srcAccessMask = 0;
+                    break;
 
-			case VK_IMAGE_LAYOUT_PREINITIALIZED:
-				// Image is preinitialized
-				// Only valid as initial layout for linear images, preserves memory contents
-				// Make sure host writes have been finished
-				imageMemoryBarrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
-				break;
+                case VK_IMAGE_LAYOUT_PREINITIALIZED:
+                    // Image is preinitialized
+                    // Only valid as initial layout for linear images, preserves memory contents
+                    // Make sure host writes have been finished
+                    imageMemoryBarrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
+                    break;
 
-			case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
-				// Image is a color attachment
-				// Make sure any writes to the color buffer have been finished
-				imageMemoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-				break;
+                case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+                    // Image is a color attachment
+                    // Make sure any writes to the color buffer have been finished
+                    imageMemoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+                    break;
 
-			case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
-				// Image is a depth/stencil attachment
-				// Make sure any writes to the depth/stencil buffer have been finished
-				imageMemoryBarrier.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-				break;
+                case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+                    // Image is a depth/stencil attachment
+                    // Make sure any writes to the depth/stencil buffer have been finished
+                    imageMemoryBarrier.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+                    break;
 
-			case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
-				// Image is a transfer source 
-				// Make sure any reads from the image have been finished
-				imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-				break;
+                case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+                    // Image is a transfer source
+                    // Make sure any reads from the image have been finished
+                    imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                    break;
 
-			case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
-				// Image is a transfer destination
-				// Make sure any writes to the image have been finished
-				imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-				break;
+                case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+                    // Image is a transfer destination
+                    // Make sure any writes to the image have been finished
+                    imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                    break;
 
-			case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
-				// Image is read by a shader
-				// Make sure any shader reads from the image have been finished
-				imageMemoryBarrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
-				break;
-			default:
-				// Other source layouts aren't handled (yet)
-				break;
-			}
+                case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+                    // Image is read by a shader
+                    // Make sure any shader reads from the image have been finished
+                    imageMemoryBarrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                    break;
+                default:
+                    // Other source layouts aren't handled (yet)
+                    break;
+            }
 
-			// Target layouts (new)
-			// Destination access mask controls the dependency for the new image layout
-			switch (newImageLayout)
-			{
-			case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
-				// Image will be used as a transfer destination
-				// Make sure any writes to the image have been finished
-				imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-				break;
+            // Target layouts (new)
+            // Destination access mask controls the dependency for the new image layout
+            switch (newImageLayout)
+            {
+                case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+                    // Image will be used as a transfer destination
+                    // Make sure any writes to the image have been finished
+                    imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                    break;
 
-			case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
-				// Image will be used as a transfer source
-				// Make sure any reads from the image have been finished
-				imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-				break;
+                case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+                    // Image will be used as a transfer source
+                    // Make sure any reads from the image have been finished
+                    imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                    break;
 
-			case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
-				// Image will be used as a color attachment
-				// Make sure any writes to the color buffer have been finished
-				imageMemoryBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-				break;
+                case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+                    // Image will be used as a color attachment
+                    // Make sure any writes to the color buffer have been finished
+                    imageMemoryBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+                    break;
 
-			case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
-				// Image layout will be used as a depth/stencil attachment
-				// Make sure any writes to depth/stencil buffer have been finished
-				imageMemoryBarrier.dstAccessMask = imageMemoryBarrier.dstAccessMask | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-				break;
+                case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+                    // Image layout will be used as a depth/stencil attachment
+                    // Make sure any writes to depth/stencil buffer have been finished
+                    imageMemoryBarrier.dstAccessMask = imageMemoryBarrier.dstAccessMask | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+                    break;
 
-			case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
-				// Image will be read in a shader (sampler, input attachment)
-				// Make sure any writes to the image have been finished
-				if (imageMemoryBarrier.srcAccessMask == 0)
-				{
-					imageMemoryBarrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
-				}
-				imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-				break;
-			default:
-				// Other source layouts aren't handled (yet)
-				break;
-			}
+                case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+                    // Image will be read in a shader (sampler, input attachment)
+                    // Make sure any writes to the image have been finished
+                    if (imageMemoryBarrier.srcAccessMask == 0)
+                    {
+                        imageMemoryBarrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+                    }
+                    imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                    break;
+                default:
+                    // Other source layouts aren't handled (yet)
+                    break;
+            }
 
-			// Put barrier inside setup command buffer
-			vkCmdPipelineBarrier(
-				cmdbuffer,
-				srcStageMask,
-				dstStageMask,
-				0,
-				0, nullptr,
-				0, nullptr,
-				1, &imageMemoryBarrier);
-		}
+            // Put barrier inside setup command buffer
+            vkCmdPipelineBarrier(cmdbuffer, srcStageMask, dstStageMask, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
+        }
 
-		// Fixed sub resource on first mip level and layer
-		void setImageLayout(
-			VkCommandBuffer cmdbuffer,
-			VkImage image,
-			VkImageAspectFlags aspectMask,
-			VkImageLayout oldImageLayout,
-			VkImageLayout newImageLayout,
-			VkPipelineStageFlags srcStageMask,
-			VkPipelineStageFlags dstStageMask)
-		{
-			VkImageSubresourceRange subresourceRange = {};
-			subresourceRange.aspectMask = aspectMask;
-			subresourceRange.baseMipLevel = 0;
-			subresourceRange.levelCount = 1;
-			subresourceRange.layerCount = 1;
-			setImageLayout(cmdbuffer, image, oldImageLayout, newImageLayout, subresourceRange, srcStageMask, dstStageMask);
-		}
+        // Fixed sub resource on first mip level and layer
+        void setImageLayout(VkCommandBuffer cmdbuffer,
+                            VkImage image,
+                            VkImageAspectFlags aspectMask,
+                            VkImageLayout oldImageLayout,
+                            VkImageLayout newImageLayout,
+                            VkPipelineStageFlags srcStageMask,
+                            VkPipelineStageFlags dstStageMask)
+        {
+            VkImageSubresourceRange subresourceRange = {};
+            subresourceRange.aspectMask = aspectMask;
+            subresourceRange.baseMipLevel = 0;
+            subresourceRange.levelCount = 1;
+            subresourceRange.layerCount = 1;
+            setImageLayout(cmdbuffer, image, oldImageLayout, newImageLayout, subresourceRange, srcStageMask, dstStageMask);
+        }
 
-		void insertImageMemoryBarrier(
-			VkCommandBuffer cmdbuffer,
-			VkImage image,
-			VkAccessFlags srcAccessMask,
-			VkAccessFlags dstAccessMask,
-			VkImageLayout oldImageLayout,
-			VkImageLayout newImageLayout,
-			VkPipelineStageFlags srcStageMask,
-			VkPipelineStageFlags dstStageMask,
-			VkImageSubresourceRange subresourceRange)
-		{
-			VkImageMemoryBarrier imageMemoryBarrier = vks::initializers::imageMemoryBarrier();
-			imageMemoryBarrier.srcAccessMask = srcAccessMask;
-			imageMemoryBarrier.dstAccessMask = dstAccessMask;
-			imageMemoryBarrier.oldLayout = oldImageLayout;
-			imageMemoryBarrier.newLayout = newImageLayout;
-			imageMemoryBarrier.image = image;
-			imageMemoryBarrier.subresourceRange = subresourceRange;
+        void insertImageMemoryBarrier(VkCommandBuffer cmdbuffer,
+                                      VkImage image,
+                                      VkAccessFlags srcAccessMask,
+                                      VkAccessFlags dstAccessMask,
+                                      VkImageLayout oldImageLayout,
+                                      VkImageLayout newImageLayout,
+                                      VkPipelineStageFlags srcStageMask,
+                                      VkPipelineStageFlags dstStageMask,
+                                      VkImageSubresourceRange subresourceRange)
+        {
+            VkImageMemoryBarrier imageMemoryBarrier = vks::initializers::imageMemoryBarrier();
+            imageMemoryBarrier.srcAccessMask = srcAccessMask;
+            imageMemoryBarrier.dstAccessMask = dstAccessMask;
+            imageMemoryBarrier.oldLayout = oldImageLayout;
+            imageMemoryBarrier.newLayout = newImageLayout;
+            imageMemoryBarrier.image = image;
+            imageMemoryBarrier.subresourceRange = subresourceRange;
 
-			vkCmdPipelineBarrier(
-				cmdbuffer,
-				srcStageMask,
-				dstStageMask,
-				0,
-				0, nullptr,
-				0, nullptr,
-				1, &imageMemoryBarrier);
-		}
+            vkCmdPipelineBarrier(cmdbuffer, srcStageMask, dstStageMask, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
+        }
 
-		void exitFatal(std::string message, int32_t exitCode)
-		{
+        void exitFatal(std::string message, int32_t exitCode)
+        {
 #if defined(_WIN32)
-			if (!errorModeSilent) {
-				MessageBox(NULL, message.c_str(), NULL, MB_OK | MB_ICONERROR);
-			}
+            if (!errorModeSilent)
+            {
+                MessageBox(NULL, message.c_str(), NULL, MB_OK | MB_ICONERROR);
+            }
 #elif defined(__ANDROID__)
             LOGE("Fatal error: %s", message.c_str());
-			vks::android::showAlert(message.c_str());
+            vks::android::showAlert(message.c_str());
 #endif
-			std::cerr << message << "\n";
+            std::cerr << message << "\n";
 #if !defined(__ANDROID__)
-			exit(exitCode);
+            exit(exitCode);
 #endif
-		}
+        }
 
-		void exitFatal(std::string message, VkResult resultCode)
-		{
-			exitFatal(message, (int32_t)resultCode);
-		}
+        void exitFatal(std::string message, VkResult resultCode)
+        {
+            exitFatal(message, (int32_t)resultCode);
+        }
 
-		std::string readTextFile(const char *fileName)
-		{
-			std::string fileContent;
-			std::ifstream fileStream(fileName, std::ios::in);
-			if (!fileStream.is_open()) {
-				printf("File %s not found\n", fileName);
-				return "";
-			}
-			std::string line = "";
-			while (!fileStream.eof()) {
-				getline(fileStream, line);
-				fileContent.append(line + "\n");
-			}
-			fileStream.close();
-			return fileContent;
-		}
+        std::string readTextFile(const char* fileName)
+        {
+            std::string fileContent;
+            std::ifstream fileStream(fileName, std::ios::in);
+            if (!fileStream.is_open())
+            {
+                printf("File %s not found\n", fileName);
+                return "";
+            }
+            std::string line = "";
+            while (!fileStream.eof())
+            {
+                getline(fileStream, line);
+                fileContent.append(line + "\n");
+            }
+            fileStream.close();
+            return fileContent;
+        }
 
 #if defined(__ANDROID__)
-		// Android shaders are stored as assets in the apk
-		// So they need to be loaded via the asset manager
-		VkShaderModule loadShader(AAssetManager* assetManager, const char *fileName, VkDevice device)
-		{
-			// Load shader from compressed asset
-			AAsset* asset = AAssetManager_open(assetManager, fileName, AASSET_MODE_STREAMING);
-			assert(asset);
-			size_t size = AAsset_getLength(asset);
-			assert(size > 0);
+        // Android shaders are stored as assets in the apk
+        // So they need to be loaded via the asset manager
+        VkShaderModule loadShader(AAssetManager* assetManager, const char* fileName, VkDevice device)
+        {
+            // Load shader from compressed asset
+            AAsset* asset = AAssetManager_open(assetManager, fileName, AASSET_MODE_STREAMING);
+            assert(asset);
+            size_t size = AAsset_getLength(asset);
+            assert(size > 0);
 
-			char *shaderCode = new char[size];
-			AAsset_read(asset, shaderCode, size);
-			AAsset_close(asset);
+            char* shaderCode = new char[size];
+            AAsset_read(asset, shaderCode, size);
+            AAsset_close(asset);
 
-			VkShaderModule shaderModule;
-			VkShaderModuleCreateInfo moduleCreateInfo;
-			moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-			moduleCreateInfo.pNext = NULL;
-			moduleCreateInfo.codeSize = size;
-			moduleCreateInfo.pCode = (uint32_t*)shaderCode;
-			moduleCreateInfo.flags = 0;
+            VkShaderModule shaderModule;
+            VkShaderModuleCreateInfo moduleCreateInfo;
+            moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+            moduleCreateInfo.pNext = NULL;
+            moduleCreateInfo.codeSize = size;
+            moduleCreateInfo.pCode = (uint32_t*)shaderCode;
+            moduleCreateInfo.flags = 0;
 
-			VK_CHECK_RESULT(vkCreateShaderModule(device, &moduleCreateInfo, NULL, &shaderModule));
+            VK_CHECK_RESULT(vkCreateShaderModule(device, &moduleCreateInfo, NULL, &shaderModule));
 
-			delete[] shaderCode;
+            delete[] shaderCode;
 
-			return shaderModule;
-		}
+            return shaderModule;
+        }
 #else
-		VkShaderModule loadShader(const char *fileName, VkDevice device)
-		{
-			std::ifstream is(fileName, std::ios::binary | std::ios::in | std::ios::ate);
+        VkShaderModule loadShader(const char* fileName, VkDevice device)
+        {
+            std::ifstream is(fileName, std::ios::binary | std::ios::in | std::ios::ate);
 
-			if (is.is_open())
-			{
-				size_t size = is.tellg();
-				is.seekg(0, std::ios::beg);
-				char* shaderCode = new char[size];
-				is.read(shaderCode, size);
-				is.close();
+            if (is.is_open())
+            {
+                size_t size = is.tellg();
+                is.seekg(0, std::ios::beg);
+                char* shaderCode = new char[size];
+                is.read(shaderCode, size);
+                is.close();
 
-				assert(size > 0);
+                assert(size > 0);
 
-				VkShaderModule shaderModule;
-				VkShaderModuleCreateInfo moduleCreateInfo{};
-				moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-				moduleCreateInfo.codeSize = size;
-				moduleCreateInfo.pCode = (uint32_t*)shaderCode;
+                VkShaderModule shaderModule;
+                VkShaderModuleCreateInfo moduleCreateInfo{};
+                moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+                moduleCreateInfo.codeSize = size;
+                moduleCreateInfo.pCode = (uint32_t*)shaderCode;
 
-				VK_CHECK_RESULT(vkCreateShaderModule(device, &moduleCreateInfo, NULL, &shaderModule));
+                VK_CHECK_RESULT(vkCreateShaderModule(device, &moduleCreateInfo, NULL, &shaderModule));
 
-				delete[] shaderCode;
+                delete[] shaderCode;
 
-				return shaderModule;
-			}
-			else
-			{
-				std::cerr << "Error: Could not open shader file \"" << fileName << "\"" << std::endl;
-				return VK_NULL_HANDLE;
-			}
-		}
+                return shaderModule;
+            }
+            else
+            {
+                std::cerr << "Error: Could not open shader file \"" << fileName << "\"" << std::endl;
+                return VK_NULL_HANDLE;
+            }
+        }
 #endif
 
-		bool fileExists(const std::string &filename)
-		{
-			std::ifstream f(filename.c_str());
-			return !f.fail();
-		}
-	}
-}
+        bool fileExists(const std::string& filename)
+        {
+            std::ifstream f(filename.c_str());
+            return !f.fail();
+        }
+    }  // namespace tools
+}  // namespace vks

--- a/base/VulkanTools.h
+++ b/base/VulkanTools.h
@@ -38,25 +38,25 @@
 
 // Macro to check and display Vulkan return results
 #if defined(__ANDROID__)
-#define VK_CHECK_RESULT(f)																				\
-{																										\
-	VkResult res = (f);																					\
-	if (res != VK_SUCCESS)																				\
-	{																									\
-		LOGE("Fatal : VkResult is \" %s \" in %s at line %d", vks::tools::errorString(res).c_str(), __FILE__, __LINE__); \
-		assert(res == VK_SUCCESS);																		\
-	}																									\
-}
+#define VK_CHECK_RESULT(f)                                                                                                   \
+    {                                                                                                                        \
+        VkResult res = (f);                                                                                                  \
+        if (res != VK_SUCCESS)                                                                                               \
+        {                                                                                                                    \
+            LOGE("Fatal : VkResult is \" %s \" in %s at line %d", vks::tools::errorString(res).c_str(), __FILE__, __LINE__); \
+            assert(res == VK_SUCCESS);                                                                                       \
+        }                                                                                                                    \
+    }
 #else
-#define VK_CHECK_RESULT(f)																				\
-{																										\
-	VkResult res = (f);																					\
-	if (res != VK_SUCCESS)																				\
-	{																									\
-		std::cout << "Fatal : VkResult is \"" << vks::tools::errorString(res) << "\" in " << __FILE__ << " at line " << __LINE__ << std::endl; \
-		assert(res == VK_SUCCESS);																		\
-	}																									\
-}
+#define VK_CHECK_RESULT(f)                                                                                                                         \
+    {                                                                                                                                              \
+        VkResult res = (f);                                                                                                                        \
+        if (res != VK_SUCCESS)                                                                                                                     \
+        {                                                                                                                                          \
+            std::cout << "Fatal : VkResult is \"" << vks::tools::errorString(res) << "\" in " << __FILE__ << " at line " << __LINE__ << std::endl; \
+            assert(res == VK_SUCCESS);                                                                                                             \
+        }                                                                                                                                          \
+    }
 #endif
 
 #if defined(__ANDROID__)
@@ -67,64 +67,61 @@
 
 namespace vks
 {
-	namespace tools
-	{
-		/** @brief Disable message boxes on fatal errors */
-		extern bool errorModeSilent;
+    namespace tools
+    {
+        /** @brief Disable message boxes on fatal errors */
+        extern bool errorModeSilent;
 
-		/** @brief Returns an error code as a string */
-		std::string errorString(VkResult errorCode);
+        /** @brief Returns an error code as a string */
+        std::string errorString(VkResult errorCode);
 
-		/** @brief Returns the device type as a string */
-		std::string physicalDeviceTypeString(VkPhysicalDeviceType type);
+        /** @brief Returns the device type as a string */
+        std::string physicalDeviceTypeString(VkPhysicalDeviceType type);
 
-		// Selected a suitable supported depth format starting with 32 bit down to 16 bit
-		// Returns false if none of the depth formats in the list is supported by the device
-		VkBool32 getSupportedDepthFormat(VkPhysicalDevice physicalDevice, VkFormat *depthFormat);
+        // Selected a suitable supported depth format starting with 32 bit down to 16 bit
+        // Returns false if none of the depth formats in the list is supported by the device
+        VkBool32 getSupportedDepthFormat(VkPhysicalDevice physicalDevice, VkFormat* depthFormat);
 
-		// Put an image memory barrier for setting an image layout on the sub resource into the given command buffer
-		void setImageLayout(
-			VkCommandBuffer cmdbuffer,
-			VkImage image,
-			VkImageLayout oldImageLayout,
-			VkImageLayout newImageLayout,
-			VkImageSubresourceRange subresourceRange,
-			VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-			VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
-		// Uses a fixed sub resource layout with first mip level and layer
-		void setImageLayout(
-			VkCommandBuffer cmdbuffer,
-			VkImage image,
-			VkImageAspectFlags aspectMask,
-			VkImageLayout oldImageLayout,
-			VkImageLayout newImageLayout,
-			VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-			VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+        // Put an image memory barrier for setting an image layout on the sub resource into the given command buffer
+        void setImageLayout(VkCommandBuffer cmdbuffer,
+                            VkImage image,
+                            VkImageLayout oldImageLayout,
+                            VkImageLayout newImageLayout,
+                            VkImageSubresourceRange subresourceRange,
+                            VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                            VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+        // Uses a fixed sub resource layout with first mip level and layer
+        void setImageLayout(VkCommandBuffer cmdbuffer,
+                            VkImage image,
+                            VkImageAspectFlags aspectMask,
+                            VkImageLayout oldImageLayout,
+                            VkImageLayout newImageLayout,
+                            VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                            VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
-		/** @brief Inser an image memory barrier into the command buffer */
-		void insertImageMemoryBarrier(
-			VkCommandBuffer cmdbuffer,
-			VkImage image,
-			VkAccessFlags srcAccessMask,
-			VkAccessFlags dstAccessMask,
-			VkImageLayout oldImageLayout,
-			VkImageLayout newImageLayout,
-			VkPipelineStageFlags srcStageMask,
-			VkPipelineStageFlags dstStageMask,
-			VkImageSubresourceRange subresourceRange);
+        /** @brief Inser an image memory barrier into the command buffer */
+        void insertImageMemoryBarrier(VkCommandBuffer cmdbuffer,
+                                      VkImage image,
+                                      VkAccessFlags srcAccessMask,
+                                      VkAccessFlags dstAccessMask,
+                                      VkImageLayout oldImageLayout,
+                                      VkImageLayout newImageLayout,
+                                      VkPipelineStageFlags srcStageMask,
+                                      VkPipelineStageFlags dstStageMask,
+                                      VkImageSubresourceRange subresourceRange);
 
-		// Display error message and exit on fatal error
-		void exitFatal(std::string message, int32_t exitCode);
-		void exitFatal(std::string message, VkResult resultCode);
+        // Display error message and exit on fatal error
+        void exitFatal(std::string message, int32_t exitCode);
+        void exitFatal(std::string message, VkResult resultCode);
 
-		// Load a SPIR-V shader (binary) 
+        // Load a SPIR-V shader (binary)
 #if defined(__ANDROID__)
-		VkShaderModule loadShader(AAssetManager* assetManager, const char *fileName, VkDevice device);
+        VkShaderModule loadShader(AAssetManager* assetManager, const char* fileName, VkDevice device);
 #else
-		VkShaderModule loadShader(const char *fileName, VkDevice device);
+        VkShaderModule loadShader(const char* fileName, VkDevice device);
 #endif
 
-		/** @brief Checks if a file exists */
-		bool fileExists(const std::string &filename);
-	}
-}
+        /** @brief Checks if a file exists */
+        bool fileExists(const std::string& filename);
+    }  // namespace tools
+}  // namespace vks

--- a/base/VulkanUIOverlay.cpp
+++ b/base/VulkanUIOverlay.cpp
@@ -8,476 +8,477 @@
 
 #include "VulkanUIOverlay.h"
 
-namespace vks 
+namespace vks
 {
-	UIOverlay::UIOverlay()
-	{
-#if defined(__ANDROID__)		
-		if (vks::android::screenDensity >= ACONFIGURATION_DENSITY_XXHIGH) {
-			scale = 3.5f;
-		}
-		else if (vks::android::screenDensity >= ACONFIGURATION_DENSITY_XHIGH) {
-			scale = 2.5f;
-		}
-		else if (vks::android::screenDensity >= ACONFIGURATION_DENSITY_HIGH) {
-			scale = 2.0f;
-		};
+    UIOverlay::UIOverlay()
+    {
+#if defined(__ANDROID__)
+        if (vks::android::screenDensity >= ACONFIGURATION_DENSITY_XXHIGH)
+        {
+            scale = 3.5f;
+        }
+        else if (vks::android::screenDensity >= ACONFIGURATION_DENSITY_XHIGH)
+        {
+            scale = 2.5f;
+        }
+        else if (vks::android::screenDensity >= ACONFIGURATION_DENSITY_HIGH)
+        {
+            scale = 2.0f;
+        };
 #endif
 
-		// Init ImGui
-		ImGui::CreateContext();
-		// Color scheme
-		ImGuiStyle& style = ImGui::GetStyle();
-		style.Colors[ImGuiCol_TitleBg] = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
-		style.Colors[ImGuiCol_TitleBgActive] = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
-		style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(1.0f, 0.0f, 0.0f, 0.1f);
-		style.Colors[ImGuiCol_MenuBarBg] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
-		style.Colors[ImGuiCol_Header] = ImVec4(0.8f, 0.0f, 0.0f, 0.4f);
-		style.Colors[ImGuiCol_HeaderActive] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
-		style.Colors[ImGuiCol_HeaderHovered] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
-		style.Colors[ImGuiCol_FrameBg] = ImVec4(0.0f, 0.0f, 0.0f, 0.8f);
-		style.Colors[ImGuiCol_CheckMark] = ImVec4(1.0f, 0.0f, 0.0f, 0.8f);
-		style.Colors[ImGuiCol_SliderGrab] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
-		style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(1.0f, 0.0f, 0.0f, 0.8f);
-		style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(1.0f, 1.0f, 1.0f, 0.1f);
-		style.Colors[ImGuiCol_FrameBgActive] = ImVec4(1.0f, 1.0f, 1.0f, 0.2f);
-		style.Colors[ImGuiCol_Button] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
-		style.Colors[ImGuiCol_ButtonHovered] = ImVec4(1.0f, 0.0f, 0.0f, 0.6f);
-		style.Colors[ImGuiCol_ButtonActive] = ImVec4(1.0f, 0.0f, 0.0f, 0.8f);
-		// Dimensions
-		ImGuiIO& io = ImGui::GetIO();
-		io.FontGlobalScale = scale;
-	}
+        // Init ImGui
+        ImGui::CreateContext();
+        // Color scheme
+        ImGuiStyle& style = ImGui::GetStyle();
+        style.Colors[ImGuiCol_TitleBg] = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
+        style.Colors[ImGuiCol_TitleBgActive] = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
+        style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(1.0f, 0.0f, 0.0f, 0.1f);
+        style.Colors[ImGuiCol_MenuBarBg] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
+        style.Colors[ImGuiCol_Header] = ImVec4(0.8f, 0.0f, 0.0f, 0.4f);
+        style.Colors[ImGuiCol_HeaderActive] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
+        style.Colors[ImGuiCol_HeaderHovered] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
+        style.Colors[ImGuiCol_FrameBg] = ImVec4(0.0f, 0.0f, 0.0f, 0.8f);
+        style.Colors[ImGuiCol_CheckMark] = ImVec4(1.0f, 0.0f, 0.0f, 0.8f);
+        style.Colors[ImGuiCol_SliderGrab] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
+        style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(1.0f, 0.0f, 0.0f, 0.8f);
+        style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(1.0f, 1.0f, 1.0f, 0.1f);
+        style.Colors[ImGuiCol_FrameBgActive] = ImVec4(1.0f, 1.0f, 1.0f, 0.2f);
+        style.Colors[ImGuiCol_Button] = ImVec4(1.0f, 0.0f, 0.0f, 0.4f);
+        style.Colors[ImGuiCol_ButtonHovered] = ImVec4(1.0f, 0.0f, 0.0f, 0.6f);
+        style.Colors[ImGuiCol_ButtonActive] = ImVec4(1.0f, 0.0f, 0.0f, 0.8f);
+        // Dimensions
+        ImGuiIO& io = ImGui::GetIO();
+        io.FontGlobalScale = scale;
+    }
 
-	UIOverlay::~UIOverlay()	{ }
+    UIOverlay::~UIOverlay()
+    {}
 
-	/** Prepare all vulkan resources required to render the UI overlay */
-	void UIOverlay::prepareResources()
-	{
-		ImGuiIO& io = ImGui::GetIO();
+    /** Prepare all vulkan resources required to render the UI overlay */
+    void UIOverlay::prepareResources()
+    {
+        ImGuiIO& io = ImGui::GetIO();
 
-		// Create font texture
-		unsigned char* fontData;
-		int texWidth, texHeight;
+        // Create font texture
+        unsigned char* fontData;
+        int texWidth, texHeight;
 #if defined(__ANDROID__)
-		float scale = (float)vks::android::screenDensity / (float)ACONFIGURATION_DENSITY_MEDIUM;
-		AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, "Roboto-Medium.ttf", AASSET_MODE_STREAMING);
-		if (asset) {
-			size_t size = AAsset_getLength(asset);
-			assert(size > 0);
-			char *fontAsset = new char[size];
-			AAsset_read(asset, fontAsset, size);
-			AAsset_close(asset);
-			io.Fonts->AddFontFromMemoryTTF(fontAsset, size, 14.0f * scale);
-			delete[] fontAsset;
-		}
+        float scale = (float)vks::android::screenDensity / (float)ACONFIGURATION_DENSITY_MEDIUM;
+        AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, "Roboto-Medium.ttf", AASSET_MODE_STREAMING);
+        if (asset)
+        {
+            size_t size = AAsset_getLength(asset);
+            assert(size > 0);
+            char* fontAsset = new char[size];
+            AAsset_read(asset, fontAsset, size);
+            AAsset_close(asset);
+            io.Fonts->AddFontFromMemoryTTF(fontAsset, size, 14.0f * scale);
+            delete[] fontAsset;
+        }
 #else
-		io.Fonts->AddFontFromFileTTF("./../data/Roboto-Medium.ttf", 16.0f);
-#endif		
-		io.Fonts->GetTexDataAsRGBA32(&fontData, &texWidth, &texHeight);
-		VkDeviceSize uploadSize = texWidth*texHeight * 4 * sizeof(char);
+        io.Fonts->AddFontFromFileTTF("./../data/Roboto-Medium.ttf", 16.0f);
+#endif
+        io.Fonts->GetTexDataAsRGBA32(&fontData, &texWidth, &texHeight);
+        VkDeviceSize uploadSize = texWidth * texHeight * 4 * sizeof(char);
 
-		// Create target image for copy
-		VkImageCreateInfo imageInfo = vks::initializers::imageCreateInfo();
-		imageInfo.imageType = VK_IMAGE_TYPE_2D;
-		imageInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
-		imageInfo.extent.width = texWidth;
-		imageInfo.extent.height = texHeight;
-		imageInfo.extent.depth = 1;
-		imageInfo.mipLevels = 1;
-		imageInfo.arrayLayers = 1;
-		imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-		imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-		imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-		imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-		imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-		VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageInfo, nullptr, &fontImage));
-		VkMemoryRequirements memReqs;
-		vkGetImageMemoryRequirements(device->logicalDevice, fontImage, &memReqs);
-		VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
-		memAllocInfo.allocationSize = memReqs.size;
-		memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-		VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &fontMemory));
-		VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, fontImage, fontMemory, 0));
+        // Create target image for copy
+        VkImageCreateInfo imageInfo = vks::initializers::imageCreateInfo();
+        imageInfo.imageType = VK_IMAGE_TYPE_2D;
+        imageInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+        imageInfo.extent.width = texWidth;
+        imageInfo.extent.height = texHeight;
+        imageInfo.extent.depth = 1;
+        imageInfo.mipLevels = 1;
+        imageInfo.arrayLayers = 1;
+        imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+        imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+        imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageInfo, nullptr, &fontImage));
+        VkMemoryRequirements memReqs;
+        vkGetImageMemoryRequirements(device->logicalDevice, fontImage, &memReqs);
+        VkMemoryAllocateInfo memAllocInfo = vks::initializers::memoryAllocateInfo();
+        memAllocInfo.allocationSize = memReqs.size;
+        memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &fontMemory));
+        VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, fontImage, fontMemory, 0));
 
-		// Image view
-		VkImageViewCreateInfo viewInfo = vks::initializers::imageViewCreateInfo();
-		viewInfo.image = fontImage;
-		viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-		viewInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
-		viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-		viewInfo.subresourceRange.levelCount = 1;
-		viewInfo.subresourceRange.layerCount = 1;
-		VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewInfo, nullptr, &fontView));
+        // Image view
+        VkImageViewCreateInfo viewInfo = vks::initializers::imageViewCreateInfo();
+        viewInfo.image = fontImage;
+        viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        viewInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+        viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        viewInfo.subresourceRange.levelCount = 1;
+        viewInfo.subresourceRange.layerCount = 1;
+        VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewInfo, nullptr, &fontView));
 
-		// Staging buffers for font data upload
-		vks::Buffer stagingBuffer;
+        // Staging buffers for font data upload
+        vks::Buffer stagingBuffer;
 
-		VK_CHECK_RESULT(device->createBuffer(
-			VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-			&stagingBuffer,
-			uploadSize));
+        VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                                             &stagingBuffer, uploadSize));
 
-		stagingBuffer.map();
-		memcpy(stagingBuffer.mapped, fontData, uploadSize);
-		stagingBuffer.unmap();
+        stagingBuffer.map();
+        memcpy(stagingBuffer.mapped, fontData, uploadSize);
+        stagingBuffer.unmap();
 
-		// Copy buffer data to font image
-		VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+        // Copy buffer data to font image
+        VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-		// Prepare for transfer
-		vks::tools::setImageLayout(
-			copyCmd,
-			fontImage,
-			VK_IMAGE_ASPECT_COLOR_BIT,
-			VK_IMAGE_LAYOUT_UNDEFINED,
-			VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-			VK_PIPELINE_STAGE_HOST_BIT,
-			VK_PIPELINE_STAGE_TRANSFER_BIT);
+        // Prepare for transfer
+        vks::tools::setImageLayout(copyCmd, fontImage, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                   VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
 
-		// Copy
-		VkBufferImageCopy bufferCopyRegion = {};
-		bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-		bufferCopyRegion.imageSubresource.layerCount = 1;
-		bufferCopyRegion.imageExtent.width = texWidth;
-		bufferCopyRegion.imageExtent.height = texHeight;
-		bufferCopyRegion.imageExtent.depth = 1;
+        // Copy
+        VkBufferImageCopy bufferCopyRegion = {};
+        bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        bufferCopyRegion.imageSubresource.layerCount = 1;
+        bufferCopyRegion.imageExtent.width = texWidth;
+        bufferCopyRegion.imageExtent.height = texHeight;
+        bufferCopyRegion.imageExtent.depth = 1;
 
-		vkCmdCopyBufferToImage(
-			copyCmd,
-			stagingBuffer.buffer,
-			fontImage,
-			VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-			1,
-			&bufferCopyRegion
-		);
+        vkCmdCopyBufferToImage(copyCmd, stagingBuffer.buffer, fontImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &bufferCopyRegion);
 
-		// Prepare for shader read
-		vks::tools::setImageLayout(
-			copyCmd,
-			fontImage,
-			VK_IMAGE_ASPECT_COLOR_BIT,
-			VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-			VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-			VK_PIPELINE_STAGE_TRANSFER_BIT,
-			VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+        // Prepare for shader read
+        vks::tools::setImageLayout(copyCmd, fontImage, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
 
-		device->flushCommandBuffer(copyCmd, queue, true);
+        device->flushCommandBuffer(copyCmd, queue, true);
 
-		stagingBuffer.destroy();
+        stagingBuffer.destroy();
 
-		// Font texture Sampler
-		VkSamplerCreateInfo samplerInfo = vks::initializers::samplerCreateInfo();
-		samplerInfo.magFilter = VK_FILTER_LINEAR;
-		samplerInfo.minFilter = VK_FILTER_LINEAR;
-		samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-		samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-		samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-		samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-		samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-		VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerInfo, nullptr, &sampler));
+        // Font texture Sampler
+        VkSamplerCreateInfo samplerInfo = vks::initializers::samplerCreateInfo();
+        samplerInfo.magFilter = VK_FILTER_LINEAR;
+        samplerInfo.minFilter = VK_FILTER_LINEAR;
+        samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+        samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+        VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerInfo, nullptr, &sampler));
 
-		// Descriptor pool
-		std::vector<VkDescriptorPoolSize> poolSizes = {
-			vks::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1)
-		};
-		VkDescriptorPoolCreateInfo descriptorPoolInfo = vks::initializers::descriptorPoolCreateInfo(poolSizes, 2);
-		VK_CHECK_RESULT(vkCreateDescriptorPool(device->logicalDevice, &descriptorPoolInfo, nullptr, &descriptorPool));
+        // Descriptor pool
+        std::vector<VkDescriptorPoolSize> poolSizes = { vks::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1) };
+        VkDescriptorPoolCreateInfo descriptorPoolInfo = vks::initializers::descriptorPoolCreateInfo(poolSizes, 2);
+        VK_CHECK_RESULT(vkCreateDescriptorPool(device->logicalDevice, &descriptorPoolInfo, nullptr, &descriptorPool));
 
-		// Descriptor set layout
-		std::vector<VkDescriptorSetLayoutBinding> setLayoutBindings = {
-			vks::initializers::descriptorSetLayoutBinding(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT, 0),
-		};
-		VkDescriptorSetLayoutCreateInfo descriptorLayout = vks::initializers::descriptorSetLayoutCreateInfo(setLayoutBindings);
-		VK_CHECK_RESULT(vkCreateDescriptorSetLayout(device->logicalDevice, &descriptorLayout, nullptr, &descriptorSetLayout));
+        // Descriptor set layout
+        std::vector<VkDescriptorSetLayoutBinding> setLayoutBindings = {
+            vks::initializers::descriptorSetLayoutBinding(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT, 0),
+        };
+        VkDescriptorSetLayoutCreateInfo descriptorLayout = vks::initializers::descriptorSetLayoutCreateInfo(setLayoutBindings);
+        VK_CHECK_RESULT(vkCreateDescriptorSetLayout(device->logicalDevice, &descriptorLayout, nullptr, &descriptorSetLayout));
 
-		// Descriptor set
-		VkDescriptorSetAllocateInfo allocInfo = vks::initializers::descriptorSetAllocateInfo(descriptorPool, &descriptorSetLayout, 1);
-		VK_CHECK_RESULT(vkAllocateDescriptorSets(device->logicalDevice, &allocInfo, &descriptorSet));
-		VkDescriptorImageInfo fontDescriptor = vks::initializers::descriptorImageInfo(
-			sampler,
-			fontView,
-			VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
-		);
-		std::vector<VkWriteDescriptorSet> writeDescriptorSets = {
-			vks::initializers::writeDescriptorSet(descriptorSet, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 0, &fontDescriptor)
-		};
-		vkUpdateDescriptorSets(device->logicalDevice, static_cast<uint32_t>(writeDescriptorSets.size()), writeDescriptorSets.data(), 0, nullptr);
-	}
+        // Descriptor set
+        VkDescriptorSetAllocateInfo allocInfo = vks::initializers::descriptorSetAllocateInfo(descriptorPool, &descriptorSetLayout, 1);
+        VK_CHECK_RESULT(vkAllocateDescriptorSets(device->logicalDevice, &allocInfo, &descriptorSet));
+        VkDescriptorImageInfo fontDescriptor = vks::initializers::descriptorImageInfo(sampler, fontView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        std::vector<VkWriteDescriptorSet> writeDescriptorSets = {
+            vks::initializers::writeDescriptorSet(descriptorSet, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 0, &fontDescriptor)
+        };
+        vkUpdateDescriptorSets(device->logicalDevice, static_cast<uint32_t>(writeDescriptorSets.size()), writeDescriptorSets.data(), 0, nullptr);
+    }
 
-	/** Prepare a separate pipeline for the UI overlay rendering decoupled from the main application */
-	void UIOverlay::preparePipeline(const VkPipelineCache pipelineCache, const VkRenderPass renderPass)
-	{
-		// Pipeline layout
-		// Push constants for UI rendering parameters
-		VkPushConstantRange pushConstantRange = vks::initializers::pushConstantRange(VK_SHADER_STAGE_VERTEX_BIT, sizeof(PushConstBlock), 0);
-		VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = vks::initializers::pipelineLayoutCreateInfo(&descriptorSetLayout, 1);
-		pipelineLayoutCreateInfo.pushConstantRangeCount = 1;
-		pipelineLayoutCreateInfo.pPushConstantRanges = &pushConstantRange;
-		VK_CHECK_RESULT(vkCreatePipelineLayout(device->logicalDevice, &pipelineLayoutCreateInfo, nullptr, &pipelineLayout));
+    /** Prepare a separate pipeline for the UI overlay rendering decoupled from the main application */
+    void UIOverlay::preparePipeline(const VkPipelineCache pipelineCache, const VkRenderPass renderPass)
+    {
+        // Pipeline layout
+        // Push constants for UI rendering parameters
+        VkPushConstantRange pushConstantRange = vks::initializers::pushConstantRange(VK_SHADER_STAGE_VERTEX_BIT, sizeof(PushConstBlock), 0);
+        VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = vks::initializers::pipelineLayoutCreateInfo(&descriptorSetLayout, 1);
+        pipelineLayoutCreateInfo.pushConstantRangeCount = 1;
+        pipelineLayoutCreateInfo.pPushConstantRanges = &pushConstantRange;
+        VK_CHECK_RESULT(vkCreatePipelineLayout(device->logicalDevice, &pipelineLayoutCreateInfo, nullptr, &pipelineLayout));
 
-		// Setup graphics pipeline for UI rendering
-		VkPipelineInputAssemblyStateCreateInfo inputAssemblyState =
-			vks::initializers::pipelineInputAssemblyStateCreateInfo(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, 0, VK_FALSE);
+        // Setup graphics pipeline for UI rendering
+        VkPipelineInputAssemblyStateCreateInfo inputAssemblyState =
+            vks::initializers::pipelineInputAssemblyStateCreateInfo(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, 0, VK_FALSE);
 
-		VkPipelineRasterizationStateCreateInfo rasterizationState =
-			vks::initializers::pipelineRasterizationStateCreateInfo(VK_POLYGON_MODE_FILL, VK_CULL_MODE_NONE, VK_FRONT_FACE_COUNTER_CLOCKWISE);
+        VkPipelineRasterizationStateCreateInfo rasterizationState =
+            vks::initializers::pipelineRasterizationStateCreateInfo(VK_POLYGON_MODE_FILL, VK_CULL_MODE_NONE, VK_FRONT_FACE_COUNTER_CLOCKWISE);
 
-		// Enable blending
-		VkPipelineColorBlendAttachmentState blendAttachmentState{};
-		blendAttachmentState.blendEnable = VK_TRUE;
-		blendAttachmentState.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-		blendAttachmentState.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
-		blendAttachmentState.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-		blendAttachmentState.colorBlendOp = VK_BLEND_OP_ADD;
-		blendAttachmentState.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-		blendAttachmentState.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-		blendAttachmentState.alphaBlendOp = VK_BLEND_OP_ADD;
+        // Enable blending
+        VkPipelineColorBlendAttachmentState blendAttachmentState{};
+        blendAttachmentState.blendEnable = VK_TRUE;
+        blendAttachmentState.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+        blendAttachmentState.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+        blendAttachmentState.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+        blendAttachmentState.colorBlendOp = VK_BLEND_OP_ADD;
+        blendAttachmentState.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+        blendAttachmentState.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+        blendAttachmentState.alphaBlendOp = VK_BLEND_OP_ADD;
 
-		VkPipelineColorBlendStateCreateInfo colorBlendState =
-			vks::initializers::pipelineColorBlendStateCreateInfo(1, &blendAttachmentState);
+        VkPipelineColorBlendStateCreateInfo colorBlendState = vks::initializers::pipelineColorBlendStateCreateInfo(1, &blendAttachmentState);
 
-		VkPipelineDepthStencilStateCreateInfo depthStencilState =
-			vks::initializers::pipelineDepthStencilStateCreateInfo(VK_FALSE, VK_FALSE, VK_COMPARE_OP_ALWAYS);
+        VkPipelineDepthStencilStateCreateInfo depthStencilState =
+            vks::initializers::pipelineDepthStencilStateCreateInfo(VK_FALSE, VK_FALSE, VK_COMPARE_OP_ALWAYS);
 
-		VkPipelineViewportStateCreateInfo viewportState =
-			vks::initializers::pipelineViewportStateCreateInfo(1, 1, 0);
+        VkPipelineViewportStateCreateInfo viewportState = vks::initializers::pipelineViewportStateCreateInfo(1, 1, 0);
 
-		VkPipelineMultisampleStateCreateInfo multisampleState =
-			vks::initializers::pipelineMultisampleStateCreateInfo(rasterizationSamples);
+        VkPipelineMultisampleStateCreateInfo multisampleState = vks::initializers::pipelineMultisampleStateCreateInfo(rasterizationSamples);
 
-		std::vector<VkDynamicState> dynamicStateEnables = {
-			VK_DYNAMIC_STATE_VIEWPORT,
-			VK_DYNAMIC_STATE_SCISSOR
-		};
-		VkPipelineDynamicStateCreateInfo dynamicState =
-			vks::initializers::pipelineDynamicStateCreateInfo(dynamicStateEnables);
+        std::vector<VkDynamicState> dynamicStateEnables = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+        VkPipelineDynamicStateCreateInfo dynamicState = vks::initializers::pipelineDynamicStateCreateInfo(dynamicStateEnables);
 
-		VkGraphicsPipelineCreateInfo pipelineCreateInfo = vks::initializers::pipelineCreateInfo(pipelineLayout, renderPass);
+        VkGraphicsPipelineCreateInfo pipelineCreateInfo = vks::initializers::pipelineCreateInfo(pipelineLayout, renderPass);
 
-		pipelineCreateInfo.pInputAssemblyState = &inputAssemblyState;
-		pipelineCreateInfo.pRasterizationState = &rasterizationState;
-		pipelineCreateInfo.pColorBlendState = &colorBlendState;
-		pipelineCreateInfo.pMultisampleState = &multisampleState;
-		pipelineCreateInfo.pViewportState = &viewportState;
-		pipelineCreateInfo.pDepthStencilState = &depthStencilState;
-		pipelineCreateInfo.pDynamicState = &dynamicState;
-		pipelineCreateInfo.stageCount = static_cast<uint32_t>(shaders.size());
-		pipelineCreateInfo.pStages = shaders.data();
-		pipelineCreateInfo.subpass = subpass;
+        pipelineCreateInfo.pInputAssemblyState = &inputAssemblyState;
+        pipelineCreateInfo.pRasterizationState = &rasterizationState;
+        pipelineCreateInfo.pColorBlendState = &colorBlendState;
+        pipelineCreateInfo.pMultisampleState = &multisampleState;
+        pipelineCreateInfo.pViewportState = &viewportState;
+        pipelineCreateInfo.pDepthStencilState = &depthStencilState;
+        pipelineCreateInfo.pDynamicState = &dynamicState;
+        pipelineCreateInfo.stageCount = static_cast<uint32_t>(shaders.size());
+        pipelineCreateInfo.pStages = shaders.data();
+        pipelineCreateInfo.subpass = subpass;
 
-		// Vertex bindings an attributes based on ImGui vertex definition
-		std::vector<VkVertexInputBindingDescription> vertexInputBindings = {
-			vks::initializers::vertexInputBindingDescription(0, sizeof(ImDrawVert), VK_VERTEX_INPUT_RATE_VERTEX),
-		};
-		std::vector<VkVertexInputAttributeDescription> vertexInputAttributes = {
-			vks::initializers::vertexInputAttributeDescription(0, 0, VK_FORMAT_R32G32_SFLOAT, offsetof(ImDrawVert, pos)),	// Location 0: Position
-			vks::initializers::vertexInputAttributeDescription(0, 1, VK_FORMAT_R32G32_SFLOAT, offsetof(ImDrawVert, uv)),	// Location 1: UV
-			vks::initializers::vertexInputAttributeDescription(0, 2, VK_FORMAT_R8G8B8A8_UNORM, offsetof(ImDrawVert, col)),	// Location 0: Color
-		};
-		VkPipelineVertexInputStateCreateInfo vertexInputState = vks::initializers::pipelineVertexInputStateCreateInfo();
-		vertexInputState.vertexBindingDescriptionCount = static_cast<uint32_t>(vertexInputBindings.size());
-		vertexInputState.pVertexBindingDescriptions = vertexInputBindings.data();
-		vertexInputState.vertexAttributeDescriptionCount = static_cast<uint32_t>(vertexInputAttributes.size());
-		vertexInputState.pVertexAttributeDescriptions = vertexInputAttributes.data();
+        // Vertex bindings an attributes based on ImGui vertex definition
+        std::vector<VkVertexInputBindingDescription> vertexInputBindings = {
+            vks::initializers::vertexInputBindingDescription(0, sizeof(ImDrawVert), VK_VERTEX_INPUT_RATE_VERTEX),
+        };
+        std::vector<VkVertexInputAttributeDescription> vertexInputAttributes = {
+            vks::initializers::vertexInputAttributeDescription(0, 0, VK_FORMAT_R32G32_SFLOAT, offsetof(ImDrawVert, pos)),   // Location 0: Position
+            vks::initializers::vertexInputAttributeDescription(0, 1, VK_FORMAT_R32G32_SFLOAT, offsetof(ImDrawVert, uv)),    // Location 1: UV
+            vks::initializers::vertexInputAttributeDescription(0, 2, VK_FORMAT_R8G8B8A8_UNORM, offsetof(ImDrawVert, col)),  // Location 0: Color
+        };
+        VkPipelineVertexInputStateCreateInfo vertexInputState = vks::initializers::pipelineVertexInputStateCreateInfo();
+        vertexInputState.vertexBindingDescriptionCount = static_cast<uint32_t>(vertexInputBindings.size());
+        vertexInputState.pVertexBindingDescriptions = vertexInputBindings.data();
+        vertexInputState.vertexAttributeDescriptionCount = static_cast<uint32_t>(vertexInputAttributes.size());
+        vertexInputState.pVertexAttributeDescriptions = vertexInputAttributes.data();
 
-		pipelineCreateInfo.pVertexInputState = &vertexInputState;
+        pipelineCreateInfo.pVertexInputState = &vertexInputState;
 
-		VK_CHECK_RESULT(vkCreateGraphicsPipelines(device->logicalDevice, pipelineCache, 1, &pipelineCreateInfo, nullptr, &pipeline));
-	}
+        VK_CHECK_RESULT(vkCreateGraphicsPipelines(device->logicalDevice, pipelineCache, 1, &pipelineCreateInfo, nullptr, &pipeline));
+    }
 
-	/** Update vertex and index buffer containing the imGui elements when required */
-	bool UIOverlay::update()
-	{
-		ImDrawData* imDrawData = ImGui::GetDrawData();
-		bool updateCmdBuffers = false;
+    /** Update vertex and index buffer containing the imGui elements when required */
+    bool UIOverlay::update()
+    {
+        ImDrawData* imDrawData = ImGui::GetDrawData();
+        bool updateCmdBuffers = false;
 
-		if (!imDrawData) { return false; };
+        if (!imDrawData)
+        {
+            return false;
+        };
 
-		// Note: Alignment is done inside buffer creation
-		VkDeviceSize vertexBufferSize = imDrawData->TotalVtxCount * sizeof(ImDrawVert);
-		VkDeviceSize indexBufferSize = imDrawData->TotalIdxCount * sizeof(ImDrawIdx);
+        // Note: Alignment is done inside buffer creation
+        VkDeviceSize vertexBufferSize = imDrawData->TotalVtxCount * sizeof(ImDrawVert);
+        VkDeviceSize indexBufferSize = imDrawData->TotalIdxCount * sizeof(ImDrawIdx);
 
-		// Update buffers only if vertex or index count has been changed compared to current buffer size
-		if ((vertexBufferSize == 0) || (indexBufferSize == 0)) {
-			return false;
-		}
+        // Update buffers only if vertex or index count has been changed compared to current buffer size
+        if ((vertexBufferSize == 0) || (indexBufferSize == 0))
+        {
+            return false;
+        }
 
-		// Vertex buffer
-		if ((vertexBuffer.buffer == VK_NULL_HANDLE) || (vertexCount != imDrawData->TotalVtxCount)) {
-			vertexBuffer.unmap();
-			vertexBuffer.destroy();
-			VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &vertexBuffer, vertexBufferSize));
-			vertexCount = imDrawData->TotalVtxCount;
-			vertexBuffer.unmap();
-			vertexBuffer.map();
-			updateCmdBuffers = true;
-		}
+        // Vertex buffer
+        if ((vertexBuffer.buffer == VK_NULL_HANDLE) || (vertexCount != imDrawData->TotalVtxCount))
+        {
+            vertexBuffer.unmap();
+            vertexBuffer.destroy();
+            VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &vertexBuffer, vertexBufferSize));
+            vertexCount = imDrawData->TotalVtxCount;
+            vertexBuffer.unmap();
+            vertexBuffer.map();
+            updateCmdBuffers = true;
+        }
 
-		// Index buffer
-		VkDeviceSize indexSize = imDrawData->TotalIdxCount * sizeof(ImDrawIdx);
-		if ((indexBuffer.buffer == VK_NULL_HANDLE) || (indexCount < imDrawData->TotalIdxCount)) {
-			indexBuffer.unmap();
-			indexBuffer.destroy();
-			VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &indexBuffer, indexBufferSize));
-			indexCount = imDrawData->TotalIdxCount;
-			indexBuffer.map();
-			updateCmdBuffers = true;
-		}
+        // Index buffer
+        VkDeviceSize indexSize = imDrawData->TotalIdxCount * sizeof(ImDrawIdx);
+        if ((indexBuffer.buffer == VK_NULL_HANDLE) || (indexCount < imDrawData->TotalIdxCount))
+        {
+            indexBuffer.unmap();
+            indexBuffer.destroy();
+            VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &indexBuffer, indexBufferSize));
+            indexCount = imDrawData->TotalIdxCount;
+            indexBuffer.map();
+            updateCmdBuffers = true;
+        }
 
-		// Upload data
-		ImDrawVert* vtxDst = (ImDrawVert*)vertexBuffer.mapped;
-		ImDrawIdx* idxDst = (ImDrawIdx*)indexBuffer.mapped;
+        // Upload data
+        ImDrawVert* vtxDst = (ImDrawVert*)vertexBuffer.mapped;
+        ImDrawIdx* idxDst = (ImDrawIdx*)indexBuffer.mapped;
 
-		for (int n = 0; n < imDrawData->CmdListsCount; n++) {
-			const ImDrawList* cmd_list = imDrawData->CmdLists[n];
-			memcpy(vtxDst, cmd_list->VtxBuffer.Data, cmd_list->VtxBuffer.Size * sizeof(ImDrawVert));
-			memcpy(idxDst, cmd_list->IdxBuffer.Data, cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx));
-			vtxDst += cmd_list->VtxBuffer.Size;
-			idxDst += cmd_list->IdxBuffer.Size;
-		}
+        for (int n = 0; n < imDrawData->CmdListsCount; n++)
+        {
+            const ImDrawList* cmd_list = imDrawData->CmdLists[n];
+            memcpy(vtxDst, cmd_list->VtxBuffer.Data, cmd_list->VtxBuffer.Size * sizeof(ImDrawVert));
+            memcpy(idxDst, cmd_list->IdxBuffer.Data, cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx));
+            vtxDst += cmd_list->VtxBuffer.Size;
+            idxDst += cmd_list->IdxBuffer.Size;
+        }
 
-		// Flush to make writes visible to GPU
-		vertexBuffer.flush();
-		indexBuffer.flush();
+        // Flush to make writes visible to GPU
+        vertexBuffer.flush();
+        indexBuffer.flush();
 
-		return updateCmdBuffers;
-	}
+        return updateCmdBuffers;
+    }
 
-	void UIOverlay::draw(const VkCommandBuffer commandBuffer)
-	{
-		ImDrawData* imDrawData = ImGui::GetDrawData();
-		int32_t vertexOffset = 0;
-		int32_t indexOffset = 0;
+    void UIOverlay::draw(const VkCommandBuffer commandBuffer)
+    {
+        ImDrawData* imDrawData = ImGui::GetDrawData();
+        int32_t vertexOffset = 0;
+        int32_t indexOffset = 0;
 
-		if ((!imDrawData) || (imDrawData->CmdListsCount == 0)) {
-			return;
-		}
+        if ((!imDrawData) || (imDrawData->CmdListsCount == 0))
+        {
+            return;
+        }
 
-		ImGuiIO& io = ImGui::GetIO();
+        ImGuiIO& io = ImGui::GetIO();
 
-		vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
-		vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &descriptorSet, 0, NULL);
+        vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+        vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &descriptorSet, 0, NULL);
 
-		pushConstBlock.scale = glm::vec2(2.0f / io.DisplaySize.x, 2.0f / io.DisplaySize.y);
-		pushConstBlock.translate = glm::vec2(-1.0f);
-		vkCmdPushConstants(commandBuffer, pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(PushConstBlock), &pushConstBlock);
+        pushConstBlock.scale = glm::vec2(2.0f / io.DisplaySize.x, 2.0f / io.DisplaySize.y);
+        pushConstBlock.translate = glm::vec2(-1.0f);
+        vkCmdPushConstants(commandBuffer, pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(PushConstBlock), &pushConstBlock);
 
-		VkDeviceSize offsets[1] = { 0 };
-		vkCmdBindVertexBuffers(commandBuffer, 0, 1, &vertexBuffer.buffer, offsets);
-		vkCmdBindIndexBuffer(commandBuffer, indexBuffer.buffer, 0, VK_INDEX_TYPE_UINT16);
+        VkDeviceSize offsets[1] = { 0 };
+        vkCmdBindVertexBuffers(commandBuffer, 0, 1, &vertexBuffer.buffer, offsets);
+        vkCmdBindIndexBuffer(commandBuffer, indexBuffer.buffer, 0, VK_INDEX_TYPE_UINT16);
 
-		for (int32_t i = 0; i < imDrawData->CmdListsCount; i++)
-		{
-			const ImDrawList* cmd_list = imDrawData->CmdLists[i];
-			for (int32_t j = 0; j < cmd_list->CmdBuffer.Size; j++)
-			{
-				const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[j];
-				VkRect2D scissorRect;
-				scissorRect.offset.x = std::max((int32_t)(pcmd->ClipRect.x), 0);
-				scissorRect.offset.y = std::max((int32_t)(pcmd->ClipRect.y), 0);
-				scissorRect.extent.width = (uint32_t)(pcmd->ClipRect.z - pcmd->ClipRect.x);
-				scissorRect.extent.height = (uint32_t)(pcmd->ClipRect.w - pcmd->ClipRect.y);
-				vkCmdSetScissor(commandBuffer, 0, 1, &scissorRect);
-				vkCmdDrawIndexed(commandBuffer, pcmd->ElemCount, 1, indexOffset, vertexOffset, 0);
-				indexOffset += pcmd->ElemCount;
-			}
-			vertexOffset += cmd_list->VtxBuffer.Size;
-		}
-	}
+        for (int32_t i = 0; i < imDrawData->CmdListsCount; i++)
+        {
+            const ImDrawList* cmd_list = imDrawData->CmdLists[i];
+            for (int32_t j = 0; j < cmd_list->CmdBuffer.Size; j++)
+            {
+                const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[j];
+                VkRect2D scissorRect;
+                scissorRect.offset.x = std::max((int32_t)(pcmd->ClipRect.x), 0);
+                scissorRect.offset.y = std::max((int32_t)(pcmd->ClipRect.y), 0);
+                scissorRect.extent.width = (uint32_t)(pcmd->ClipRect.z - pcmd->ClipRect.x);
+                scissorRect.extent.height = (uint32_t)(pcmd->ClipRect.w - pcmd->ClipRect.y);
+                vkCmdSetScissor(commandBuffer, 0, 1, &scissorRect);
+                vkCmdDrawIndexed(commandBuffer, pcmd->ElemCount, 1, indexOffset, vertexOffset, 0);
+                indexOffset += pcmd->ElemCount;
+            }
+            vertexOffset += cmd_list->VtxBuffer.Size;
+        }
+    }
 
-	void UIOverlay::resize(uint32_t width, uint32_t height)
-	{
-		ImGuiIO& io = ImGui::GetIO();
-		io.DisplaySize = ImVec2((float)(width), (float)(height));
-	}
+    void UIOverlay::resize(uint32_t width, uint32_t height)
+    {
+        ImGuiIO& io = ImGui::GetIO();
+        io.DisplaySize = ImVec2((float)(width), (float)(height));
+    }
 
-	void UIOverlay::freeResources()
-	{
-		ImGui::DestroyContext();
-		vertexBuffer.destroy();
-		indexBuffer.destroy();
-		vkDestroyImageView(device->logicalDevice, fontView, nullptr);
-		vkDestroyImage(device->logicalDevice, fontImage, nullptr);
-		vkFreeMemory(device->logicalDevice, fontMemory, nullptr);
-		vkDestroySampler(device->logicalDevice, sampler, nullptr);
-		vkDestroyDescriptorSetLayout(device->logicalDevice, descriptorSetLayout, nullptr);
-		vkDestroyDescriptorPool(device->logicalDevice, descriptorPool, nullptr);
-		vkDestroyPipelineLayout(device->logicalDevice, pipelineLayout, nullptr);
-		vkDestroyPipeline(device->logicalDevice, pipeline, nullptr);
-	}
+    void UIOverlay::freeResources()
+    {
+        ImGui::DestroyContext();
+        vertexBuffer.destroy();
+        indexBuffer.destroy();
+        vkDestroyImageView(device->logicalDevice, fontView, nullptr);
+        vkDestroyImage(device->logicalDevice, fontImage, nullptr);
+        vkFreeMemory(device->logicalDevice, fontMemory, nullptr);
+        vkDestroySampler(device->logicalDevice, sampler, nullptr);
+        vkDestroyDescriptorSetLayout(device->logicalDevice, descriptorSetLayout, nullptr);
+        vkDestroyDescriptorPool(device->logicalDevice, descriptorPool, nullptr);
+        vkDestroyPipelineLayout(device->logicalDevice, pipelineLayout, nullptr);
+        vkDestroyPipeline(device->logicalDevice, pipeline, nullptr);
+    }
 
-	bool UIOverlay::header(const char *caption)
-	{
-		return ImGui::CollapsingHeader(caption, ImGuiTreeNodeFlags_DefaultOpen);
-	}
+    bool UIOverlay::header(const char* caption)
+    {
+        return ImGui::CollapsingHeader(caption, ImGuiTreeNodeFlags_DefaultOpen);
+    }
 
-	bool UIOverlay::checkBox(const char *caption, bool *value)
-	{
-		bool res = ImGui::Checkbox(caption, value);
-		if (res) { updated = true; };
-		return res;
-	}
+    bool UIOverlay::checkBox(const char* caption, bool* value)
+    {
+        bool res = ImGui::Checkbox(caption, value);
+        if (res)
+        {
+            updated = true;
+        };
+        return res;
+    }
 
-	bool UIOverlay::checkBox(const char *caption, int32_t *value)
-	{
-		bool val = (*value == 1);
-		bool res = ImGui::Checkbox(caption, &val);
-		*value = val;
-		if (res) { updated = true; };
-		return res;
-	}
+    bool UIOverlay::checkBox(const char* caption, int32_t* value)
+    {
+        bool val = (*value == 1);
+        bool res = ImGui::Checkbox(caption, &val);
+        *value = val;
+        if (res)
+        {
+            updated = true;
+        };
+        return res;
+    }
 
-	bool UIOverlay::inputFloat(const char *caption, float *value, float step, uint32_t precision)
-	{
-		bool res = ImGui::InputFloat(caption, value, step, step * 10.0f, precision);
-		if (res) { updated = true; };
-		return res;
-	}
+    bool UIOverlay::inputFloat(const char* caption, float* value, float step, uint32_t precision)
+    {
+        bool res = ImGui::InputFloat(caption, value, step, step * 10.0f, precision);
+        if (res)
+        {
+            updated = true;
+        };
+        return res;
+    }
 
-	bool UIOverlay::sliderFloat(const char* caption, float* value, float min, float max)
-	{
-		bool res = ImGui::SliderFloat(caption, value, min, max);
-		if (res) { updated = true; };
-		return res;
-	}
+    bool UIOverlay::sliderFloat(const char* caption, float* value, float min, float max)
+    {
+        bool res = ImGui::SliderFloat(caption, value, min, max);
+        if (res)
+        {
+            updated = true;
+        };
+        return res;
+    }
 
-	bool UIOverlay::sliderInt(const char* caption, int32_t* value, int32_t min, int32_t max)
-	{
-		bool res = ImGui::SliderInt(caption, value, min, max);
-		if (res) { updated = true; };
-		return res;
-	}
+    bool UIOverlay::sliderInt(const char* caption, int32_t* value, int32_t min, int32_t max)
+    {
+        bool res = ImGui::SliderInt(caption, value, min, max);
+        if (res)
+        {
+            updated = true;
+        };
+        return res;
+    }
 
-	bool UIOverlay::comboBox(const char *caption, int32_t *itemindex, std::vector<std::string> items)
-	{
-		if (items.empty()) {
-			return false;
-		}
-		std::vector<const char*> charitems;
-		charitems.reserve(items.size());
-		for (size_t i = 0; i < items.size(); i++) {
-			charitems.push_back(items[i].c_str());
-		}
-		uint32_t itemCount = static_cast<uint32_t>(charitems.size());
-		bool res = ImGui::Combo(caption, itemindex, &charitems[0], itemCount, itemCount);
-		if (res) { updated = true; };
-		return res;
-	}
+    bool UIOverlay::comboBox(const char* caption, int32_t* itemindex, std::vector<std::string> items)
+    {
+        if (items.empty())
+        {
+            return false;
+        }
+        std::vector<const char*> charitems;
+        charitems.reserve(items.size());
+        for (size_t i = 0; i < items.size(); i++)
+        {
+            charitems.push_back(items[i].c_str());
+        }
+        uint32_t itemCount = static_cast<uint32_t>(charitems.size());
+        bool res = ImGui::Combo(caption, itemindex, &charitems[0], itemCount, itemCount);
+        if (res)
+        {
+            updated = true;
+        };
+        return res;
+    }
 
-	bool UIOverlay::button(const char *caption)
-	{
-		bool res = ImGui::Button(caption);
-		if (res) { updated = true; };
-		return res;
-	}
+    bool UIOverlay::button(const char* caption)
+    {
+        bool res = ImGui::Button(caption);
+        if (res)
+        {
+            updated = true;
+        };
+        return res;
+    }
 
-	void UIOverlay::text(const char *formatstr, ...)
-	{
-		va_list args;
-		va_start(args, formatstr);
-		ImGui::TextV(formatstr, args);
-		va_end(args);
-	}
-}
+    void UIOverlay::text(const char* formatstr, ...)
+    {
+        va_list args;
+        va_start(args, formatstr);
+        ImGui::TextV(formatstr, args);
+        va_end(args);
+    }
+}  // namespace vks

--- a/base/VulkanUIOverlay.h
+++ b/base/VulkanUIOverlay.h
@@ -28,64 +28,65 @@
 #include "VulkanAndroid.h"
 #endif
 
-namespace vks 
+namespace vks
 {
-	class UIOverlay 
-	{
-	public:
-		vks::VulkanDevice *device;
-		VkQueue queue;
+    class UIOverlay
+    {
+    public:
+        vks::VulkanDevice* device;
+        VkQueue queue;
 
-		VkSampleCountFlagBits rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-		uint32_t subpass = 0;
+        VkSampleCountFlagBits rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+        uint32_t subpass = 0;
 
-		vks::Buffer vertexBuffer;
-		vks::Buffer indexBuffer;
-		int32_t vertexCount = 0;
-		int32_t indexCount = 0;
+        vks::Buffer vertexBuffer;
+        vks::Buffer indexBuffer;
+        int32_t vertexCount = 0;
+        int32_t indexCount = 0;
 
-		std::vector<VkPipelineShaderStageCreateInfo> shaders;
+        std::vector<VkPipelineShaderStageCreateInfo> shaders;
 
-		VkDescriptorPool descriptorPool;
-		VkDescriptorSetLayout descriptorSetLayout;
-		VkDescriptorSet descriptorSet;
-		VkPipelineLayout pipelineLayout;
-		VkPipeline pipeline;
+        VkDescriptorPool descriptorPool;
+        VkDescriptorSetLayout descriptorSetLayout;
+        VkDescriptorSet descriptorSet;
+        VkPipelineLayout pipelineLayout;
+        VkPipeline pipeline;
 
-		VkDeviceMemory fontMemory = VK_NULL_HANDLE;
-		VkImage fontImage = VK_NULL_HANDLE;
-		VkImageView fontView = VK_NULL_HANDLE;
-		VkSampler sampler;
+        VkDeviceMemory fontMemory = VK_NULL_HANDLE;
+        VkImage fontImage = VK_NULL_HANDLE;
+        VkImageView fontView = VK_NULL_HANDLE;
+        VkSampler sampler;
 
-		struct PushConstBlock {
-			glm::vec2 scale;
-			glm::vec2 translate;
-		} pushConstBlock;
+        struct PushConstBlock
+        {
+            glm::vec2 scale;
+            glm::vec2 translate;
+        } pushConstBlock;
 
-		bool visible = true;
-		bool updated = false;
-		float scale = 1.0f;
+        bool visible = true;
+        bool updated = false;
+        float scale = 1.0f;
 
-		UIOverlay();
-		~UIOverlay();
+        UIOverlay();
+        ~UIOverlay();
 
-		void preparePipeline(const VkPipelineCache pipelineCache, const VkRenderPass renderPass);
-		void prepareResources();
+        void preparePipeline(const VkPipelineCache pipelineCache, const VkRenderPass renderPass);
+        void prepareResources();
 
-		bool update();
-		void draw(const VkCommandBuffer commandBuffer);
-		void resize(uint32_t width, uint32_t height);
+        bool update();
+        void draw(const VkCommandBuffer commandBuffer);
+        void resize(uint32_t width, uint32_t height);
 
-		void freeResources();
+        void freeResources();
 
-		bool header(const char* caption);
-		bool checkBox(const char* caption, bool* value);
-		bool checkBox(const char* caption, int32_t* value);
-		bool inputFloat(const char* caption, float* value, float step, uint32_t precision);
-		bool sliderFloat(const char* caption, float* value, float min, float max);
-		bool sliderInt(const char* caption, int32_t* value, int32_t min, int32_t max);
-		bool comboBox(const char* caption, int32_t* itemindex, std::vector<std::string> items);
-		bool button(const char* caption);
-		void text(const char* formatstr, ...);
-	};
-}
+        bool header(const char* caption);
+        bool checkBox(const char* caption, bool* value);
+        bool checkBox(const char* caption, int32_t* value);
+        bool inputFloat(const char* caption, float* value, float step, uint32_t precision);
+        bool sliderFloat(const char* caption, float* value, float min, float max);
+        bool sliderInt(const char* caption, int32_t* value, int32_t min, int32_t max);
+        bool comboBox(const char* caption, int32_t* itemindex, std::vector<std::string> items);
+        bool button(const char* caption);
+        void text(const char* formatstr, ...);
+    };
+}  // namespace vks

--- a/base/VulkanglTFModel.hpp
+++ b/base/VulkanglTFModel.hpp
@@ -33,1215 +33,1367 @@
 
 namespace vkglTF
 {
-	struct Node;
+    struct Node;
 
-	/*
+    /*
 		glTF texture loading class
 	*/
-	struct Texture {
-		vks::VulkanDevice *device;
-		VkImage image;
-		VkImageLayout imageLayout;
-		VkDeviceMemory deviceMemory;
-		VkImageView view;
-		uint32_t width, height;
-		uint32_t mipLevels;
-		uint32_t layerCount;
-		VkDescriptorImageInfo descriptor;
-		VkSampler sampler;
+    struct Texture
+    {
+        vks::VulkanDevice* device;
+        VkImage image;
+        VkImageLayout imageLayout;
+        VkDeviceMemory deviceMemory;
+        VkImageView view;
+        uint32_t width, height;
+        uint32_t mipLevels;
+        uint32_t layerCount;
+        VkDescriptorImageInfo descriptor;
+        VkSampler sampler;
 
-		void updateDescriptor()
-		{
-			descriptor.sampler = sampler;
-			descriptor.imageView = view;
-			descriptor.imageLayout = imageLayout;
-		}
+        void updateDescriptor()
+        {
+            descriptor.sampler = sampler;
+            descriptor.imageView = view;
+            descriptor.imageLayout = imageLayout;
+        }
 
-		void destroy()
-		{
-			vkDestroyImageView(device->logicalDevice, view, nullptr);
-			vkDestroyImage(device->logicalDevice, image, nullptr);
-			vkFreeMemory(device->logicalDevice, deviceMemory, nullptr);
-			vkDestroySampler(device->logicalDevice, sampler, nullptr);
-		}
+        void destroy()
+        {
+            vkDestroyImageView(device->logicalDevice, view, nullptr);
+            vkDestroyImage(device->logicalDevice, image, nullptr);
+            vkFreeMemory(device->logicalDevice, deviceMemory, nullptr);
+            vkDestroySampler(device->logicalDevice, sampler, nullptr);
+        }
 
-		/*
+        /*
 			Load a texture from a glTF image (stored as vector of chars loaded via stb_image)
 			Also generates the mip chain as glTF images are stored as jpg or png without any mips
 		*/
-		void fromglTfImage(tinygltf::Image &gltfimage, vks::VulkanDevice *device, VkQueue copyQueue)
-		{
-			this->device = device;
+        void fromglTfImage(tinygltf::Image& gltfimage, vks::VulkanDevice* device, VkQueue copyQueue)
+        {
+            this->device = device;
 
-			unsigned char* buffer = nullptr;
-			VkDeviceSize bufferSize = 0;
-			bool deleteBuffer = false;
-			if (gltfimage.component == 3) {
-				// Most devices don't support RGB only on Vulkan so convert if necessary
-				// TODO: Check actual format support and transform only if required
-				bufferSize = gltfimage.width * gltfimage.height * 4;
-				buffer = new unsigned char[bufferSize];
-				unsigned char* rgba = buffer;
-				unsigned char* rgb = &gltfimage.image[0];
-				for (size_t i = 0; i< gltfimage.width * gltfimage.height; ++i) {
-					for (int32_t j = 0; j < 3; ++j) {
-						rgba[j] = rgb[j];
-					}
-					rgba += 4;
-					rgb += 3;
-				}
-				deleteBuffer = true;
-			}
-			else {
-				buffer = &gltfimage.image[0];
-				bufferSize = gltfimage.image.size();
-			}
+            unsigned char* buffer = nullptr;
+            VkDeviceSize bufferSize = 0;
+            bool deleteBuffer = false;
+            if (gltfimage.component == 3)
+            {
+                // Most devices don't support RGB only on Vulkan so convert if necessary
+                // TODO: Check actual format support and transform only if required
+                bufferSize = gltfimage.width * gltfimage.height * 4;
+                buffer = new unsigned char[bufferSize];
+                unsigned char* rgba = buffer;
+                unsigned char* rgb = &gltfimage.image[0];
+                for (size_t i = 0; i < gltfimage.width * gltfimage.height; ++i)
+                {
+                    for (int32_t j = 0; j < 3; ++j)
+                    {
+                        rgba[j] = rgb[j];
+                    }
+                    rgba += 4;
+                    rgb += 3;
+                }
+                deleteBuffer = true;
+            }
+            else
+            {
+                buffer = &gltfimage.image[0];
+                bufferSize = gltfimage.image.size();
+            }
 
-			VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+            VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
 
-			VkFormatProperties formatProperties;
+            VkFormatProperties formatProperties;
 
-			width = gltfimage.width;
-			height = gltfimage.height;
-			mipLevels = static_cast<uint32_t>(floor(log2(std::max(width, height))) + 1.0);
+            width = gltfimage.width;
+            height = gltfimage.height;
+            mipLevels = static_cast<uint32_t>(floor(log2(std::max(width, height))) + 1.0);
 
-			vkGetPhysicalDeviceFormatProperties(device->physicalDevice, format, &formatProperties);
-			assert(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT);
-			assert(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT);
+            vkGetPhysicalDeviceFormatProperties(device->physicalDevice, format, &formatProperties);
+            assert(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT);
+            assert(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT);
 
-			VkMemoryAllocateInfo memAllocInfo{};
-			memAllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-			VkMemoryRequirements memReqs{};
+            VkMemoryAllocateInfo memAllocInfo{};
+            memAllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            VkMemoryRequirements memReqs{};
 
-			VkBuffer stagingBuffer;
-			VkDeviceMemory stagingMemory;
+            VkBuffer stagingBuffer;
+            VkDeviceMemory stagingMemory;
 
-			VkBufferCreateInfo bufferCreateInfo{};
-			bufferCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-			bufferCreateInfo.size = bufferSize;
-			bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-			bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
-			vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
-			memAllocInfo.allocationSize = memReqs.size;
-			memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-			VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
-			VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
+            VkBufferCreateInfo bufferCreateInfo{};
+            bufferCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bufferCreateInfo.size = bufferSize;
+            bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            VK_CHECK_RESULT(vkCreateBuffer(device->logicalDevice, &bufferCreateInfo, nullptr, &stagingBuffer));
+            vkGetBufferMemoryRequirements(device->logicalDevice, stagingBuffer, &memReqs);
+            memAllocInfo.allocationSize = memReqs.size;
+            memAllocInfo.memoryTypeIndex =
+                device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &stagingMemory));
+            VK_CHECK_RESULT(vkBindBufferMemory(device->logicalDevice, stagingBuffer, stagingMemory, 0));
 
-			uint8_t *data;
-			VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void **)&data));
-			memcpy(data, buffer, bufferSize);
-			vkUnmapMemory(device->logicalDevice, stagingMemory);
+            uint8_t* data;
+            VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, stagingMemory, 0, memReqs.size, 0, (void**)&data));
+            memcpy(data, buffer, bufferSize);
+            vkUnmapMemory(device->logicalDevice, stagingMemory);
 
-			VkImageCreateInfo imageCreateInfo{};
-			imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-			imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-			imageCreateInfo.format = format;
-			imageCreateInfo.mipLevels = mipLevels;
-			imageCreateInfo.arrayLayers = 1;
-			imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-			imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-			imageCreateInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-			imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-			imageCreateInfo.extent = { width, height, 1 };
-			imageCreateInfo.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-			VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
-			vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
-			memAllocInfo.allocationSize = memReqs.size;
-			memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-			VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
-			VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
+            VkImageCreateInfo imageCreateInfo{};
+            imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+            imageCreateInfo.format = format;
+            imageCreateInfo.mipLevels = mipLevels;
+            imageCreateInfo.arrayLayers = 1;
+            imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+            imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+            imageCreateInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+            imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            imageCreateInfo.extent = { width, height, 1 };
+            imageCreateInfo.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+            VK_CHECK_RESULT(vkCreateImage(device->logicalDevice, &imageCreateInfo, nullptr, &image));
+            vkGetImageMemoryRequirements(device->logicalDevice, image, &memReqs);
+            memAllocInfo.allocationSize = memReqs.size;
+            memAllocInfo.memoryTypeIndex = device->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            VK_CHECK_RESULT(vkAllocateMemory(device->logicalDevice, &memAllocInfo, nullptr, &deviceMemory));
+            VK_CHECK_RESULT(vkBindImageMemory(device->logicalDevice, image, deviceMemory, 0));
 
-			VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+            VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-			VkImageSubresourceRange subresourceRange = {};
-			subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			subresourceRange.levelCount = 1;
-			subresourceRange.layerCount = 1;
+            VkImageSubresourceRange subresourceRange = {};
+            subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            subresourceRange.levelCount = 1;
+            subresourceRange.layerCount = 1;
 
-			{
-				VkImageMemoryBarrier imageMemoryBarrier{};
-				imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-				imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-				imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-				imageMemoryBarrier.srcAccessMask = 0;
-				imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-				imageMemoryBarrier.image = image;
-				imageMemoryBarrier.subresourceRange = subresourceRange;
-				vkCmdPipelineBarrier(copyCmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
-			}
+            {
+                VkImageMemoryBarrier imageMemoryBarrier{};
+                imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                imageMemoryBarrier.srcAccessMask = 0;
+                imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                imageMemoryBarrier.image = image;
+                imageMemoryBarrier.subresourceRange = subresourceRange;
+                vkCmdPipelineBarrier(copyCmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr, 1,
+                                     &imageMemoryBarrier);
+            }
 
-			VkBufferImageCopy bufferCopyRegion = {};
-			bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			bufferCopyRegion.imageSubresource.mipLevel = 0;
-			bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
-			bufferCopyRegion.imageSubresource.layerCount = 1;
-			bufferCopyRegion.imageExtent.width = width;
-			bufferCopyRegion.imageExtent.height = height;
-			bufferCopyRegion.imageExtent.depth = 1;
+            VkBufferImageCopy bufferCopyRegion = {};
+            bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            bufferCopyRegion.imageSubresource.mipLevel = 0;
+            bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
+            bufferCopyRegion.imageSubresource.layerCount = 1;
+            bufferCopyRegion.imageExtent.width = width;
+            bufferCopyRegion.imageExtent.height = height;
+            bufferCopyRegion.imageExtent.depth = 1;
 
-			vkCmdCopyBufferToImage(copyCmd, stagingBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &bufferCopyRegion);
+            vkCmdCopyBufferToImage(copyCmd, stagingBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &bufferCopyRegion);
 
-			{
-				VkImageMemoryBarrier imageMemoryBarrier{};
-				imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-				imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-				imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-				imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-				imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-				imageMemoryBarrier.image = image;
-				imageMemoryBarrier.subresourceRange = subresourceRange;
-				vkCmdPipelineBarrier(copyCmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
-			}
+            {
+                VkImageMemoryBarrier imageMemoryBarrier{};
+                imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                imageMemoryBarrier.image = image;
+                imageMemoryBarrier.subresourceRange = subresourceRange;
+                vkCmdPipelineBarrier(copyCmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr, 1,
+                                     &imageMemoryBarrier);
+            }
 
-			device->flushCommandBuffer(copyCmd, copyQueue, true);
+            device->flushCommandBuffer(copyCmd, copyQueue, true);
 
-			vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
-			vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
+            vkFreeMemory(device->logicalDevice, stagingMemory, nullptr);
+            vkDestroyBuffer(device->logicalDevice, stagingBuffer, nullptr);
 
-			// Generate the mip chain (glTF uses jpg and png, so we need to create this manually)
-			VkCommandBuffer blitCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
-			for (uint32_t i = 1; i < mipLevels; i++) {
-				VkImageBlit imageBlit{};
+            // Generate the mip chain (glTF uses jpg and png, so we need to create this manually)
+            VkCommandBuffer blitCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+            for (uint32_t i = 1; i < mipLevels; i++)
+            {
+                VkImageBlit imageBlit{};
 
-				imageBlit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-				imageBlit.srcSubresource.layerCount = 1;
-				imageBlit.srcSubresource.mipLevel = i - 1;
-				imageBlit.srcOffsets[1].x = int32_t(width >> (i - 1));
-				imageBlit.srcOffsets[1].y = int32_t(height >> (i - 1));
-				imageBlit.srcOffsets[1].z = 1;
+                imageBlit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                imageBlit.srcSubresource.layerCount = 1;
+                imageBlit.srcSubresource.mipLevel = i - 1;
+                imageBlit.srcOffsets[1].x = int32_t(width >> (i - 1));
+                imageBlit.srcOffsets[1].y = int32_t(height >> (i - 1));
+                imageBlit.srcOffsets[1].z = 1;
 
-				imageBlit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-				imageBlit.dstSubresource.layerCount = 1;
-				imageBlit.dstSubresource.mipLevel = i;
-				imageBlit.dstOffsets[1].x = int32_t(width >> i);
-				imageBlit.dstOffsets[1].y = int32_t(height >> i);
-				imageBlit.dstOffsets[1].z = 1;
+                imageBlit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                imageBlit.dstSubresource.layerCount = 1;
+                imageBlit.dstSubresource.mipLevel = i;
+                imageBlit.dstOffsets[1].x = int32_t(width >> i);
+                imageBlit.dstOffsets[1].y = int32_t(height >> i);
+                imageBlit.dstOffsets[1].z = 1;
 
-				VkImageSubresourceRange mipSubRange = {};
-				mipSubRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-				mipSubRange.baseMipLevel = i;
-				mipSubRange.levelCount = 1;
-				mipSubRange.layerCount = 1;
+                VkImageSubresourceRange mipSubRange = {};
+                mipSubRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                mipSubRange.baseMipLevel = i;
+                mipSubRange.levelCount = 1;
+                mipSubRange.layerCount = 1;
 
-				{
-					VkImageMemoryBarrier imageMemoryBarrier{};
-					imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-					imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-					imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-					imageMemoryBarrier.srcAccessMask = 0;
-					imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-					imageMemoryBarrier.image = image;
-					imageMemoryBarrier.subresourceRange = mipSubRange;
-					vkCmdPipelineBarrier(blitCmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
-				}
+                {
+                    VkImageMemoryBarrier imageMemoryBarrier{};
+                    imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                    imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                    imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                    imageMemoryBarrier.srcAccessMask = 0;
+                    imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                    imageMemoryBarrier.image = image;
+                    imageMemoryBarrier.subresourceRange = mipSubRange;
+                    vkCmdPipelineBarrier(blitCmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1,
+                                         &imageMemoryBarrier);
+                }
 
-				vkCmdBlitImage(blitCmd, image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &imageBlit, VK_FILTER_LINEAR);
+                vkCmdBlitImage(blitCmd, image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &imageBlit,
+                               VK_FILTER_LINEAR);
 
-				{
-					VkImageMemoryBarrier imageMemoryBarrier{};
-					imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-					imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-					imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-					imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-					imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-					imageMemoryBarrier.image = image;
-					imageMemoryBarrier.subresourceRange = mipSubRange;
-					vkCmdPipelineBarrier(blitCmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
-				}
-			}
+                {
+                    VkImageMemoryBarrier imageMemoryBarrier{};
+                    imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                    imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                    imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                    imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                    imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                    imageMemoryBarrier.image = image;
+                    imageMemoryBarrier.subresourceRange = mipSubRange;
+                    vkCmdPipelineBarrier(blitCmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1,
+                                         &imageMemoryBarrier);
+                }
+            }
 
-			subresourceRange.levelCount = mipLevels;
-			imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            subresourceRange.levelCount = mipLevels;
+            imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-			{
-				VkImageMemoryBarrier imageMemoryBarrier{};
-				imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-				imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-				imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-				imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-				imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-				imageMemoryBarrier.image = image;
-				imageMemoryBarrier.subresourceRange = subresourceRange;
-				vkCmdPipelineBarrier(blitCmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
-			}
+            {
+                VkImageMemoryBarrier imageMemoryBarrier{};
+                imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                imageMemoryBarrier.image = image;
+                imageMemoryBarrier.subresourceRange = subresourceRange;
+                vkCmdPipelineBarrier(blitCmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr, 1,
+                                     &imageMemoryBarrier);
+            }
 
-			device->flushCommandBuffer(blitCmd, copyQueue, true);
+            device->flushCommandBuffer(blitCmd, copyQueue, true);
 
-			VkSamplerCreateInfo samplerInfo{};
-			samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-			samplerInfo.magFilter = VK_FILTER_LINEAR;
-			samplerInfo.minFilter = VK_FILTER_LINEAR;
-			samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-			samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-			samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-			samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-			samplerInfo.compareOp = VK_COMPARE_OP_NEVER;
-			samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-			samplerInfo.maxAnisotropy = 1.0;
-			samplerInfo.anisotropyEnable = VK_FALSE;
-			samplerInfo.maxLod = (float)mipLevels;
-			samplerInfo.maxAnisotropy = 8.0f;
-			samplerInfo.anisotropyEnable = VK_TRUE;
-			VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerInfo, nullptr, &sampler));
+            VkSamplerCreateInfo samplerInfo{};
+            samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+            samplerInfo.magFilter = VK_FILTER_LINEAR;
+            samplerInfo.minFilter = VK_FILTER_LINEAR;
+            samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+            samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+            samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+            samplerInfo.compareOp = VK_COMPARE_OP_NEVER;
+            samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+            samplerInfo.maxAnisotropy = 1.0;
+            samplerInfo.anisotropyEnable = VK_FALSE;
+            samplerInfo.maxLod = (float)mipLevels;
+            samplerInfo.maxAnisotropy = 8.0f;
+            samplerInfo.anisotropyEnable = VK_TRUE;
+            VK_CHECK_RESULT(vkCreateSampler(device->logicalDevice, &samplerInfo, nullptr, &sampler));
 
-			VkImageViewCreateInfo viewInfo{};
-			viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-			viewInfo.image = image;
-			viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-			viewInfo.format = format;
-			viewInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
-			viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			viewInfo.subresourceRange.layerCount = 1;
-			viewInfo.subresourceRange.levelCount = mipLevels;
-			VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewInfo, nullptr, &view));
+            VkImageViewCreateInfo viewInfo{};
+            viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            viewInfo.image = image;
+            viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            viewInfo.format = format;
+            viewInfo.components = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
+            viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            viewInfo.subresourceRange.layerCount = 1;
+            viewInfo.subresourceRange.levelCount = mipLevels;
+            VK_CHECK_RESULT(vkCreateImageView(device->logicalDevice, &viewInfo, nullptr, &view));
 
-			descriptor.sampler = sampler;
-			descriptor.imageView = view;
-			descriptor.imageLayout = imageLayout;
-		}
-	};
+            descriptor.sampler = sampler;
+            descriptor.imageView = view;
+            descriptor.imageLayout = imageLayout;
+        }
+    };
 
-	/*
+    /*
 		glTF material class
 	*/
-	// TODO: Base class and inheritance
-	struct Material {		
-		enum AlphaMode{ ALPHAMODE_OPAQUE, ALPHAMODE_MASK, ALPHAMODE_BLEND };
-		AlphaMode alphaMode = ALPHAMODE_OPAQUE;
-		float alphaCutoff = 1.0f;
-		float metallicFactor = 1.0f;
-		float roughnessFactor = 1.0f;
-		glm::vec4 baseColorFactor = glm::vec4(1.0f);
-		vkglTF::Texture *baseColorTexture;
-		vkglTF::Texture *metallicRoughnessTexture;
-		vkglTF::Texture *normalTexture;
-		vkglTF::Texture *occlusionTexture;
-		vkglTF::Texture *emissiveTexture;
+    // TODO: Base class and inheritance
+    struct Material
+    {
+        enum AlphaMode { ALPHAMODE_OPAQUE, ALPHAMODE_MASK, ALPHAMODE_BLEND };
+        AlphaMode alphaMode = ALPHAMODE_OPAQUE;
+        float alphaCutoff = 1.0f;
+        float metallicFactor = 1.0f;
+        float roughnessFactor = 1.0f;
+        glm::vec4 baseColorFactor = glm::vec4(1.0f);
+        vkglTF::Texture* baseColorTexture;
+        vkglTF::Texture* metallicRoughnessTexture;
+        vkglTF::Texture* normalTexture;
+        vkglTF::Texture* occlusionTexture;
+        vkglTF::Texture* emissiveTexture;
 
-		vkglTF::Texture *specularGlossinessTexture;
-		vkglTF::Texture *diffuseTexture;
+        vkglTF::Texture* specularGlossinessTexture;
+        vkglTF::Texture* diffuseTexture;
 
-		VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
-	};
+        VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
+    };
 
-	/*
+    /*
 		glTF primitive
 	*/
-	struct Primitive {
-		uint32_t firstIndex;
-		uint32_t indexCount;
-		Material &material;
+    struct Primitive
+    {
+        uint32_t firstIndex;
+        uint32_t indexCount;
+        Material& material;
 
-		struct Dimensions {
-			glm::vec3 min = glm::vec3(FLT_MAX);
-			glm::vec3 max = glm::vec3(-FLT_MAX);
-			glm::vec3 size;
-			glm::vec3 center;
-			float radius;
-		} dimensions;
+        struct Dimensions
+        {
+            glm::vec3 min = glm::vec3(FLT_MAX);
+            glm::vec3 max = glm::vec3(-FLT_MAX);
+            glm::vec3 size;
+            glm::vec3 center;
+            float radius;
+        } dimensions;
 
-		void setDimensions(glm::vec3 min, glm::vec3 max) {
-			dimensions.min = min;
-			dimensions.max = max;
-			dimensions.size = max - min;
-			dimensions.center = (min + max) / 2.0f;
-			dimensions.radius = glm::distance(min, max) / 2.0f;
-		}
+        void setDimensions(glm::vec3 min, glm::vec3 max)
+        {
+            dimensions.min = min;
+            dimensions.max = max;
+            dimensions.size = max - min;
+            dimensions.center = (min + max) / 2.0f;
+            dimensions.radius = glm::distance(min, max) / 2.0f;
+        }
 
-		Primitive(uint32_t firstIndex, uint32_t indexCount, Material &material) : firstIndex(firstIndex), indexCount(indexCount), material(material) {};
-	};
+        Primitive(uint32_t firstIndex, uint32_t indexCount, Material& material)
+            : firstIndex(firstIndex)
+            , indexCount(indexCount)
+            , material(material){};
+    };
 
-	/*
+    /*
 		glTF mesh
 	*/
-	struct Mesh {
-		vks::VulkanDevice *device;
+    struct Mesh
+    {
+        vks::VulkanDevice* device;
 
-		std::vector<Primitive*> primitives;
-		std::string name;
+        std::vector<Primitive*> primitives;
+        std::string name;
 
-		struct UniformBuffer {
-			VkBuffer buffer;
-			VkDeviceMemory memory;
-			VkDescriptorBufferInfo descriptor;
-			VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
-			void *mapped;
-		} uniformBuffer;
+        struct UniformBuffer
+        {
+            VkBuffer buffer;
+            VkDeviceMemory memory;
+            VkDescriptorBufferInfo descriptor;
+            VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
+            void* mapped;
+        } uniformBuffer;
 
-		struct UniformBlock {
-			glm::mat4 matrix;
-			glm::mat4 jointMatrix[64]{};
-			float jointcount{ 0 };
-		} uniformBlock;
+        struct UniformBlock
+        {
+            glm::mat4 matrix;
+            glm::mat4 jointMatrix[64]{};
+            float jointcount{ 0 };
+        } uniformBlock;
 
-		Mesh(vks::VulkanDevice *device, glm::mat4 matrix) {
-			this->device = device;
-			this->uniformBlock.matrix = matrix;
-			VK_CHECK_RESULT(device->createBuffer(
-				VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-				sizeof(uniformBlock),
-				&uniformBuffer.buffer,
-				&uniformBuffer.memory,
-				&uniformBlock));
-			VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, uniformBuffer.memory, 0, sizeof(uniformBlock), 0, &uniformBuffer.mapped));
-			uniformBuffer.descriptor = { uniformBuffer.buffer, 0, sizeof(uniformBlock) };
-		};
+        Mesh(vks::VulkanDevice* device, glm::mat4 matrix)
+        {
+            this->device = device;
+            this->uniformBlock.matrix = matrix;
+            VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                                                 sizeof(uniformBlock), &uniformBuffer.buffer, &uniformBuffer.memory, &uniformBlock));
+            VK_CHECK_RESULT(vkMapMemory(device->logicalDevice, uniformBuffer.memory, 0, sizeof(uniformBlock), 0, &uniformBuffer.mapped));
+            uniformBuffer.descriptor = { uniformBuffer.buffer, 0, sizeof(uniformBlock) };
+        };
 
-		~Mesh() {
-			vkDestroyBuffer(device->logicalDevice, uniformBuffer.buffer, nullptr);
-			vkFreeMemory(device->logicalDevice, uniformBuffer.memory, nullptr);
-		}
+        ~Mesh()
+        {
+            vkDestroyBuffer(device->logicalDevice, uniformBuffer.buffer, nullptr);
+            vkFreeMemory(device->logicalDevice, uniformBuffer.memory, nullptr);
+        }
+    };
 
-	};
-
-	/*
+    /*
 		glTF skin
 	*/
-	struct Skin {
-		std::string name;
-		Node *skeletonRoot = nullptr;
-		std::vector<glm::mat4> inverseBindMatrices;
-		std::vector<Node*> joints;
-	};
+    struct Skin
+    {
+        std::string name;
+        Node* skeletonRoot = nullptr;
+        std::vector<glm::mat4> inverseBindMatrices;
+        std::vector<Node*> joints;
+    };
 
-	/*
+    /*
 		glTF node
 	*/
-	struct Node {
-		Node *parent;
-		uint32_t index;
-		std::vector<Node*> children;
-		glm::mat4 matrix;
-		std::string name;
-		Mesh *mesh;
-		Skin *skin;
-		int32_t skinIndex = -1;
-		glm::vec3 translation{};
-		glm::vec3 scale{ 1.0f };
-		glm::quat rotation{};
+    struct Node
+    {
+        Node* parent;
+        uint32_t index;
+        std::vector<Node*> children;
+        glm::mat4 matrix;
+        std::string name;
+        Mesh* mesh;
+        Skin* skin;
+        int32_t skinIndex = -1;
+        glm::vec3 translation{};
+        glm::vec3 scale{ 1.0f };
+        glm::quat rotation{};
 
-		glm::mat4 localMatrix() {
-			return glm::translate(glm::mat4(1.0f), translation) * glm::mat4(rotation) * glm::scale(glm::mat4(1.0f), scale) * matrix;
-		}
+        glm::mat4 localMatrix()
+        {
+            return glm::translate(glm::mat4(1.0f), translation) * glm::mat4(rotation) * glm::scale(glm::mat4(1.0f), scale) * matrix;
+        }
 
-		glm::mat4 getMatrix() {
-			glm::mat4 m = localMatrix();
-			vkglTF::Node *p = parent;
-			while (p) {
-				m = p->localMatrix() * m;
-				p = p->parent;
-			}
-			return m;
-		}
+        glm::mat4 getMatrix()
+        {
+            glm::mat4 m = localMatrix();
+            vkglTF::Node* p = parent;
+            while (p)
+            {
+                m = p->localMatrix() * m;
+                p = p->parent;
+            }
+            return m;
+        }
 
-		void update() {
-			if (mesh) {
-				glm::mat4 m = getMatrix();
-				if (skin) {
-					mesh->uniformBlock.matrix = m;
-					// Update join matrices
-					glm::mat4 inverseTransform = glm::inverse(m);
-					for (size_t i = 0; i < skin->joints.size(); i++) {
-						vkglTF::Node *jointNode = skin->joints[i];
-						glm::mat4 jointMat = jointNode->getMatrix() * skin->inverseBindMatrices[i];
-						jointMat = inverseTransform * jointMat;
-						mesh->uniformBlock.jointMatrix[i] = jointMat;
-					}
-					mesh->uniformBlock.jointcount = (float)skin->joints.size();
-					memcpy(mesh->uniformBuffer.mapped, &mesh->uniformBlock, sizeof(mesh->uniformBlock));
-				} else {
-					memcpy(mesh->uniformBuffer.mapped, &m, sizeof(glm::mat4));
-				}
-			}
+        void update()
+        {
+            if (mesh)
+            {
+                glm::mat4 m = getMatrix();
+                if (skin)
+                {
+                    mesh->uniformBlock.matrix = m;
+                    // Update join matrices
+                    glm::mat4 inverseTransform = glm::inverse(m);
+                    for (size_t i = 0; i < skin->joints.size(); i++)
+                    {
+                        vkglTF::Node* jointNode = skin->joints[i];
+                        glm::mat4 jointMat = jointNode->getMatrix() * skin->inverseBindMatrices[i];
+                        jointMat = inverseTransform * jointMat;
+                        mesh->uniformBlock.jointMatrix[i] = jointMat;
+                    }
+                    mesh->uniformBlock.jointcount = (float)skin->joints.size();
+                    memcpy(mesh->uniformBuffer.mapped, &mesh->uniformBlock, sizeof(mesh->uniformBlock));
+                }
+                else
+                {
+                    memcpy(mesh->uniformBuffer.mapped, &m, sizeof(glm::mat4));
+                }
+            }
 
-			for (auto& child : children) {
-				child->update();
-			}
-		}
+            for (auto& child : children)
+            {
+                child->update();
+            }
+        }
 
-		~Node() {
-			if (mesh) {
-				delete mesh;
-			}
-			for (auto& child : children) {
-				delete child;
-			}
-		}
-	};
+        ~Node()
+        {
+            if (mesh)
+            {
+                delete mesh;
+            }
+            for (auto& child : children)
+            {
+                delete child;
+            }
+        }
+    };
 
-	/*
+    /*
 		glTF animation channel
 	*/
-	struct AnimationChannel {
-		enum PathType { TRANSLATION, ROTATION, SCALE };
-		PathType path;
-		Node *node;
-		uint32_t samplerIndex;
-	};
+    struct AnimationChannel
+    {
+        enum PathType { TRANSLATION, ROTATION, SCALE };
+        PathType path;
+        Node* node;
+        uint32_t samplerIndex;
+    };
 
-	/*
+    /*
 		glTF animation sampler
 	*/
-	struct AnimationSampler {
-		enum InterpolationType { LINEAR, STEP, CUBICSPLINE };
-		InterpolationType interpolation;
-		std::vector<float> inputs;
-		std::vector<glm::vec4> outputsVec4;
-	};
+    struct AnimationSampler
+    {
+        enum InterpolationType { LINEAR, STEP, CUBICSPLINE };
+        InterpolationType interpolation;
+        std::vector<float> inputs;
+        std::vector<glm::vec4> outputsVec4;
+    };
 
-	/*
+    /*
 		glTF animation
 	*/
-	struct Animation {
-		std::string name;
-		std::vector<AnimationSampler> samplers;
-		std::vector<AnimationChannel> channels;
-		float start = std::numeric_limits<float>::max();
-		float end = std::numeric_limits<float>::min();
-	};
+    struct Animation
+    {
+        std::string name;
+        std::vector<AnimationSampler> samplers;
+        std::vector<AnimationChannel> channels;
+        float start = std::numeric_limits<float>::max();
+        float end = std::numeric_limits<float>::min();
+    };
 
-	/*
+    /*
 		glTF model loading and rendering class
 	*/
-	struct Model {
+    struct Model
+    {
+        vks::VulkanDevice* device;
+        VkDescriptorPool descriptorPool;
+        VkDescriptorSetLayout descriptorSetLayout;
 
-		vks::VulkanDevice *device;
-		VkDescriptorPool descriptorPool;
-		VkDescriptorSetLayout descriptorSetLayout;
+        struct Vertex
+        {
+            glm::vec3 pos;
+            glm::vec3 normal;
+            glm::vec2 uv;
+            glm::vec4 joint0;
+            glm::vec4 weight0;
+        };
 
-		struct Vertex {
-			glm::vec3 pos;
-			glm::vec3 normal;
-			glm::vec2 uv;
-			glm::vec4 joint0;
-			glm::vec4 weight0;
-		};
+        struct Vertices
+        {
+            VkBuffer buffer;
+            VkDeviceMemory memory;
+        } vertices;
+        struct Indices
+        {
+            int count;
+            VkBuffer buffer;
+            VkDeviceMemory memory;
+        } indices;
 
-		struct Vertices {
-			VkBuffer buffer;
-			VkDeviceMemory memory;
-		} vertices;
-		struct Indices {
-			int count;
-			VkBuffer buffer;
-			VkDeviceMemory memory;
-		} indices;
+        std::vector<Node*> nodes;
+        std::vector<Node*> linearNodes;
 
-		std::vector<Node*> nodes;
-		std::vector<Node*> linearNodes;
+        std::vector<Skin*> skins;
 
-		std::vector<Skin*> skins;
+        std::vector<Texture> textures;
+        std::vector<Material> materials;
+        std::vector<Animation> animations;
 
-		std::vector<Texture> textures;
-		std::vector<Material> materials;
-		std::vector<Animation> animations;
+        struct Dimensions
+        {
+            glm::vec3 min = glm::vec3(FLT_MAX);
+            glm::vec3 max = glm::vec3(-FLT_MAX);
+            glm::vec3 size;
+            glm::vec3 center;
+            float radius;
+        } dimensions;
 
-		struct Dimensions {
-			glm::vec3 min = glm::vec3(FLT_MAX);
-			glm::vec3 max = glm::vec3(-FLT_MAX);
-			glm::vec3 size;
-			glm::vec3 center;
-			float radius;
-		} dimensions;
+        bool metallicRoughnessWorkflow = true;
 
-		bool metallicRoughnessWorkflow = true;
+        Model(){};
 
-		Model() {};
+        ~Model()
+        {
+            vkDestroyBuffer(device->logicalDevice, vertices.buffer, nullptr);
+            vkFreeMemory(device->logicalDevice, vertices.memory, nullptr);
+            vkDestroyBuffer(device->logicalDevice, indices.buffer, nullptr);
+            vkFreeMemory(device->logicalDevice, indices.memory, nullptr);
+            for (auto texture : textures)
+            {
+                texture.destroy();
+            }
+            for (auto node : nodes)
+            {
+                delete node;
+            }
+            vkDestroyDescriptorSetLayout(device->logicalDevice, descriptorSetLayout, nullptr);
+            vkDestroyDescriptorPool(device->logicalDevice, descriptorPool, nullptr);
+        }
 
-		~Model() 
-		{
-			vkDestroyBuffer(device->logicalDevice, vertices.buffer, nullptr);
-			vkFreeMemory(device->logicalDevice, vertices.memory, nullptr);
-			vkDestroyBuffer(device->logicalDevice, indices.buffer, nullptr);
-			vkFreeMemory(device->logicalDevice, indices.memory, nullptr);
-			for (auto texture : textures) {
-				texture.destroy();
-			}
-			for (auto node : nodes) {
-				delete node;
-			}
-			vkDestroyDescriptorSetLayout(device->logicalDevice, descriptorSetLayout, nullptr);
-			vkDestroyDescriptorPool(device->logicalDevice, descriptorPool, nullptr);
-		}
+        void loadNode(vkglTF::Node* parent,
+                      const tinygltf::Node& node,
+                      uint32_t nodeIndex,
+                      const tinygltf::Model& model,
+                      std::vector<uint32_t>& indexBuffer,
+                      std::vector<Vertex>& vertexBuffer,
+                      float globalscale)
+        {
+            vkglTF::Node* newNode = new Node{};
+            newNode->index = nodeIndex;
+            newNode->parent = parent;
+            newNode->name = node.name;
+            newNode->skinIndex = node.skin;
+            newNode->matrix = glm::mat4(1.0f);
 
-		void loadNode(vkglTF::Node *parent, const tinygltf::Node &node, uint32_t nodeIndex, const tinygltf::Model &model, std::vector<uint32_t>& indexBuffer, std::vector<Vertex>& vertexBuffer, float globalscale)
-		{
-			vkglTF::Node *newNode = new Node{};
-			newNode->index = nodeIndex;
-			newNode->parent = parent;
-			newNode->name = node.name;
-			newNode->skinIndex = node.skin;
-			newNode->matrix = glm::mat4(1.0f);
+            // Generate local node matrix
+            glm::vec3 translation = glm::vec3(0.0f);
+            if (node.translation.size() == 3)
+            {
+                translation = glm::make_vec3(node.translation.data());
+                newNode->translation = translation;
+            }
+            glm::mat4 rotation = glm::mat4(1.0f);
+            if (node.rotation.size() == 4)
+            {
+                glm::quat q = glm::make_quat(node.rotation.data());
+                newNode->rotation = glm::mat4(q);
+            }
+            glm::vec3 scale = glm::vec3(1.0f);
+            if (node.scale.size() == 3)
+            {
+                scale = glm::make_vec3(node.scale.data());
+                newNode->scale = scale;
+            }
+            if (node.matrix.size() == 16)
+            {
+                newNode->matrix = glm::make_mat4x4(node.matrix.data());
+                if (globalscale != 1.0f)
+                {
+                    //newNode->matrix = glm::scale(newNode->matrix, glm::vec3(globalscale));
+                }
+            };
 
-			// Generate local node matrix
-			glm::vec3 translation = glm::vec3(0.0f);
-			if (node.translation.size() == 3) {
-				translation = glm::make_vec3(node.translation.data());
-				newNode->translation = translation;
-			}
-			glm::mat4 rotation = glm::mat4(1.0f);
-			if (node.rotation.size() == 4) {
-				glm::quat q = glm::make_quat(node.rotation.data());
-				newNode->rotation = glm::mat4(q);
-			}
-			glm::vec3 scale = glm::vec3(1.0f);
-			if (node.scale.size() == 3) {
-				scale = glm::make_vec3(node.scale.data());
-				newNode->scale = scale;
-			}
-			if (node.matrix.size() == 16) {
-				newNode->matrix = glm::make_mat4x4(node.matrix.data());
-				if (globalscale != 1.0f) {
-					//newNode->matrix = glm::scale(newNode->matrix, glm::vec3(globalscale));
-				}
-			};
+            // Node with children
+            if (node.children.size() > 0)
+            {
+                for (auto i = 0; i < node.children.size(); i++)
+                {
+                    loadNode(newNode, model.nodes[node.children[i]], node.children[i], model, indexBuffer, vertexBuffer, globalscale);
+                }
+            }
 
-			// Node with children
-			if (node.children.size() > 0) {
-				for (auto i = 0; i < node.children.size(); i++) {
-					loadNode(newNode, model.nodes[node.children[i]], node.children[i], model, indexBuffer, vertexBuffer, globalscale);
-				}
-			}
+            // Node contains mesh data
+            if (node.mesh > -1)
+            {
+                const tinygltf::Mesh mesh = model.meshes[node.mesh];
+                Mesh* newMesh = new Mesh(device, newNode->matrix);
+                newMesh->name = mesh.name;
+                for (size_t j = 0; j < mesh.primitives.size(); j++)
+                {
+                    const tinygltf::Primitive& primitive = mesh.primitives[j];
+                    if (primitive.indices < 0)
+                    {
+                        continue;
+                    }
+                    uint32_t indexStart = static_cast<uint32_t>(indexBuffer.size());
+                    uint32_t vertexStart = static_cast<uint32_t>(vertexBuffer.size());
+                    uint32_t indexCount = 0;
+                    glm::vec3 posMin{};
+                    glm::vec3 posMax{};
+                    bool hasSkin = false;
+                    // Vertices
+                    {
+                        const float* bufferPos = nullptr;
+                        const float* bufferNormals = nullptr;
+                        const float* bufferTexCoords = nullptr;
+                        const uint16_t* bufferJoints = nullptr;
+                        const float* bufferWeights = nullptr;
 
-			// Node contains mesh data
-			if (node.mesh > -1) {
-				const tinygltf::Mesh mesh = model.meshes[node.mesh];
-				Mesh *newMesh = new Mesh(device, newNode->matrix);
-				newMesh->name = mesh.name;
-				for (size_t j = 0; j < mesh.primitives.size(); j++) {
-					const tinygltf::Primitive &primitive = mesh.primitives[j];
-					if (primitive.indices < 0) {
-						continue;
-					}
-					uint32_t indexStart = static_cast<uint32_t>(indexBuffer.size());
-					uint32_t vertexStart = static_cast<uint32_t>(vertexBuffer.size());
-					uint32_t indexCount = 0;
-					glm::vec3 posMin{};
-					glm::vec3 posMax{};
-					bool hasSkin = false;
-					// Vertices
-					{
-						const float *bufferPos = nullptr;
-						const float *bufferNormals = nullptr;
-						const float *bufferTexCoords = nullptr;
-						const uint16_t *bufferJoints = nullptr;
-						const float *bufferWeights = nullptr;
+                        // Position attribute is required
+                        assert(primitive.attributes.find("POSITION") != primitive.attributes.end());
 
-						// Position attribute is required
-						assert(primitive.attributes.find("POSITION") != primitive.attributes.end());
+                        const tinygltf::Accessor& posAccessor = model.accessors[primitive.attributes.find("POSITION")->second];
+                        const tinygltf::BufferView& posView = model.bufferViews[posAccessor.bufferView];
+                        bufferPos = reinterpret_cast<const float*>(&(model.buffers[posView.buffer].data[posAccessor.byteOffset + posView.byteOffset]));
+                        posMin = glm::vec3(posAccessor.minValues[0], posAccessor.minValues[1], posAccessor.minValues[2]);
+                        posMax = glm::vec3(posAccessor.maxValues[0], posAccessor.maxValues[1], posAccessor.maxValues[2]);
 
-						const tinygltf::Accessor &posAccessor = model.accessors[primitive.attributes.find("POSITION")->second];
-						const tinygltf::BufferView &posView = model.bufferViews[posAccessor.bufferView];
-						bufferPos = reinterpret_cast<const float *>(&(model.buffers[posView.buffer].data[posAccessor.byteOffset + posView.byteOffset]));
-						posMin = glm::vec3(posAccessor.minValues[0], posAccessor.minValues[1], posAccessor.minValues[2]);
-						posMax = glm::vec3(posAccessor.maxValues[0], posAccessor.maxValues[1], posAccessor.maxValues[2]);
+                        if (primitive.attributes.find("NORMAL") != primitive.attributes.end())
+                        {
+                            const tinygltf::Accessor& normAccessor = model.accessors[primitive.attributes.find("NORMAL")->second];
+                            const tinygltf::BufferView& normView = model.bufferViews[normAccessor.bufferView];
+                            bufferNormals =
+                                reinterpret_cast<const float*>(&(model.buffers[normView.buffer].data[normAccessor.byteOffset + normView.byteOffset]));
+                        }
 
-						if (primitive.attributes.find("NORMAL") != primitive.attributes.end()) {
-							const tinygltf::Accessor &normAccessor = model.accessors[primitive.attributes.find("NORMAL")->second];
-							const tinygltf::BufferView &normView = model.bufferViews[normAccessor.bufferView];
-							bufferNormals = reinterpret_cast<const float *>(&(model.buffers[normView.buffer].data[normAccessor.byteOffset + normView.byteOffset]));
-						}
+                        if (primitive.attributes.find("TEXCOORD_0") != primitive.attributes.end())
+                        {
+                            const tinygltf::Accessor& uvAccessor = model.accessors[primitive.attributes.find("TEXCOORD_0")->second];
+                            const tinygltf::BufferView& uvView = model.bufferViews[uvAccessor.bufferView];
+                            bufferTexCoords = reinterpret_cast<const float*>(&(model.buffers[uvView.buffer].data[uvAccessor.byteOffset + uvView.byteOffset]));
+                        }
 
-						if (primitive.attributes.find("TEXCOORD_0") != primitive.attributes.end()) {
-							const tinygltf::Accessor &uvAccessor = model.accessors[primitive.attributes.find("TEXCOORD_0")->second];
-							const tinygltf::BufferView &uvView = model.bufferViews[uvAccessor.bufferView];
-							bufferTexCoords = reinterpret_cast<const float *>(&(model.buffers[uvView.buffer].data[uvAccessor.byteOffset + uvView.byteOffset]));
-						}
+                        // Skinning
+                        // Joints
+                        if (primitive.attributes.find("JOINTS_0") != primitive.attributes.end())
+                        {
+                            const tinygltf::Accessor& jointAccessor = model.accessors[primitive.attributes.find("JOINTS_0")->second];
+                            const tinygltf::BufferView& jointView = model.bufferViews[jointAccessor.bufferView];
+                            bufferJoints =
+                                reinterpret_cast<const uint16_t*>(&(model.buffers[jointView.buffer].data[jointAccessor.byteOffset + jointView.byteOffset]));
+                        }
 
-						// Skinning
-						// Joints
-						if (primitive.attributes.find("JOINTS_0") != primitive.attributes.end()) {
-							const tinygltf::Accessor &jointAccessor = model.accessors[primitive.attributes.find("JOINTS_0")->second];
-							const tinygltf::BufferView &jointView = model.bufferViews[jointAccessor.bufferView];
-							bufferJoints = reinterpret_cast<const uint16_t *>(&(model.buffers[jointView.buffer].data[jointAccessor.byteOffset + jointView.byteOffset]));
-						}
+                        if (primitive.attributes.find("WEIGHTS_0") != primitive.attributes.end())
+                        {
+                            const tinygltf::Accessor& uvAccessor = model.accessors[primitive.attributes.find("WEIGHTS_0")->second];
+                            const tinygltf::BufferView& uvView = model.bufferViews[uvAccessor.bufferView];
+                            bufferWeights = reinterpret_cast<const float*>(&(model.buffers[uvView.buffer].data[uvAccessor.byteOffset + uvView.byteOffset]));
+                        }
 
-						if (primitive.attributes.find("WEIGHTS_0") != primitive.attributes.end()) {
-							const tinygltf::Accessor &uvAccessor = model.accessors[primitive.attributes.find("WEIGHTS_0")->second];
-							const tinygltf::BufferView &uvView = model.bufferViews[uvAccessor.bufferView];
-							bufferWeights = reinterpret_cast<const float *>(&(model.buffers[uvView.buffer].data[uvAccessor.byteOffset + uvView.byteOffset]));
-						}
+                        hasSkin = (bufferJoints && bufferWeights);
 
-						hasSkin = (bufferJoints && bufferWeights);
+                        for (size_t v = 0; v < posAccessor.count; v++)
+                        {
+                            Vertex vert{};
+                            vert.pos = glm::vec4(glm::make_vec3(&bufferPos[v * 3]), 1.0f);
+                            vert.normal = glm::normalize(glm::vec3(bufferNormals ? glm::make_vec3(&bufferNormals[v * 3]) : glm::vec3(0.0f)));
+                            vert.uv = bufferTexCoords ? glm::make_vec2(&bufferTexCoords[v * 2]) : glm::vec3(0.0f);
 
-						for (size_t v = 0; v < posAccessor.count; v++) {
-							Vertex vert{};
-							vert.pos = glm::vec4(glm::make_vec3(&bufferPos[v * 3]), 1.0f);
-							vert.normal = glm::normalize(glm::vec3(bufferNormals ? glm::make_vec3(&bufferNormals[v * 3]) : glm::vec3(0.0f)));
-							vert.uv = bufferTexCoords ? glm::make_vec2(&bufferTexCoords[v * 2]) : glm::vec3(0.0f);
-							
-							vert.joint0 = hasSkin ? glm::vec4(glm::make_vec4(&bufferJoints[v * 4])) : glm::vec4(0.0f);
-							vert.weight0 = hasSkin ? glm::make_vec4(&bufferWeights[v * 4]) : glm::vec4(0.0f);
-							vertexBuffer.push_back(vert);
-						}
-					}
-					// Indices
-					{
-						const tinygltf::Accessor &accessor = model.accessors[primitive.indices];
-						const tinygltf::BufferView &bufferView = model.bufferViews[accessor.bufferView];
-						const tinygltf::Buffer &buffer = model.buffers[bufferView.buffer];
+                            vert.joint0 = hasSkin ? glm::vec4(glm::make_vec4(&bufferJoints[v * 4])) : glm::vec4(0.0f);
+                            vert.weight0 = hasSkin ? glm::make_vec4(&bufferWeights[v * 4]) : glm::vec4(0.0f);
+                            vertexBuffer.push_back(vert);
+                        }
+                    }
+                    // Indices
+                    {
+                        const tinygltf::Accessor& accessor = model.accessors[primitive.indices];
+                        const tinygltf::BufferView& bufferView = model.bufferViews[accessor.bufferView];
+                        const tinygltf::Buffer& buffer = model.buffers[bufferView.buffer];
 
-						indexCount = static_cast<uint32_t>(accessor.count);
+                        indexCount = static_cast<uint32_t>(accessor.count);
 
-						switch (accessor.componentType) {
-						case TINYGLTF_PARAMETER_TYPE_UNSIGNED_INT: {
-							uint32_t *buf = new uint32_t[accessor.count];
-							memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(uint32_t));
-							for (size_t index = 0; index < accessor.count; index++) {
-								indexBuffer.push_back(buf[index] + vertexStart);
-							}
-							break;
-						}
-						case TINYGLTF_PARAMETER_TYPE_UNSIGNED_SHORT: {
-							uint16_t *buf = new uint16_t[accessor.count];
-							memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(uint16_t));
-							for (size_t index = 0; index < accessor.count; index++) {
-								indexBuffer.push_back(buf[index] + vertexStart);
-							}
-							break;
-						}
-						case TINYGLTF_PARAMETER_TYPE_UNSIGNED_BYTE: {
-							uint8_t *buf = new uint8_t[accessor.count];
-							memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(uint8_t));
-							for (size_t index = 0; index < accessor.count; index++) {
-								indexBuffer.push_back(buf[index] + vertexStart);
-							}
-							break;
-						}
-						default:
-							std::cerr << "Index component type " << accessor.componentType << " not supported!" << std::endl;
-							return;
-						}
-					}
-					Primitive *newPrimitive = new Primitive(indexStart, indexCount, materials[primitive.material]);
-					newPrimitive->setDimensions(posMin, posMax);
-					newMesh->primitives.push_back(newPrimitive);
-				}
-				newNode->mesh = newMesh;
-			}
-			if (parent) {
-				parent->children.push_back(newNode);
-			} else {
-				nodes.push_back(newNode);
-			}
-			linearNodes.push_back(newNode);
-		}
+                        switch (accessor.componentType)
+                        {
+                            case TINYGLTF_PARAMETER_TYPE_UNSIGNED_INT: {
+                                uint32_t* buf = new uint32_t[accessor.count];
+                                memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(uint32_t));
+                                for (size_t index = 0; index < accessor.count; index++)
+                                {
+                                    indexBuffer.push_back(buf[index] + vertexStart);
+                                }
+                                break;
+                            }
+                            case TINYGLTF_PARAMETER_TYPE_UNSIGNED_SHORT: {
+                                uint16_t* buf = new uint16_t[accessor.count];
+                                memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(uint16_t));
+                                for (size_t index = 0; index < accessor.count; index++)
+                                {
+                                    indexBuffer.push_back(buf[index] + vertexStart);
+                                }
+                                break;
+                            }
+                            case TINYGLTF_PARAMETER_TYPE_UNSIGNED_BYTE: {
+                                uint8_t* buf = new uint8_t[accessor.count];
+                                memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(uint8_t));
+                                for (size_t index = 0; index < accessor.count; index++)
+                                {
+                                    indexBuffer.push_back(buf[index] + vertexStart);
+                                }
+                                break;
+                            }
+                            default:
+                                std::cerr << "Index component type " << accessor.componentType << " not supported!" << std::endl;
+                                return;
+                        }
+                    }
+                    Primitive* newPrimitive = new Primitive(indexStart, indexCount, materials[primitive.material]);
+                    newPrimitive->setDimensions(posMin, posMax);
+                    newMesh->primitives.push_back(newPrimitive);
+                }
+                newNode->mesh = newMesh;
+            }
+            if (parent)
+            {
+                parent->children.push_back(newNode);
+            }
+            else
+            {
+                nodes.push_back(newNode);
+            }
+            linearNodes.push_back(newNode);
+        }
 
-		void loadSkins(tinygltf::Model &gltfModel)
-		{
-			for (tinygltf::Skin &source : gltfModel.skins) {
-				Skin *newSkin = new Skin{};
-				newSkin->name = source.name;
-				
-				// Find skeleton root node
-				if (source.skeleton > -1) {
-					newSkin->skeletonRoot = nodeFromIndex(source.skeleton);
-				}
+        void loadSkins(tinygltf::Model& gltfModel)
+        {
+            for (tinygltf::Skin& source : gltfModel.skins)
+            {
+                Skin* newSkin = new Skin{};
+                newSkin->name = source.name;
 
-				// Find joint nodes
-				for (int jointIndex : source.joints) {
-					Node* node = nodeFromIndex(jointIndex);
-					if (node) {
-						newSkin->joints.push_back(nodeFromIndex(jointIndex));
-					}
-				}
+                // Find skeleton root node
+                if (source.skeleton > -1)
+                {
+                    newSkin->skeletonRoot = nodeFromIndex(source.skeleton);
+                }
 
-				// Get inverse bind matrices from buffer
-				if (source.inverseBindMatrices > -1) {
-					const tinygltf::Accessor &accessor = gltfModel.accessors[source.inverseBindMatrices];
-					const tinygltf::BufferView &bufferView = gltfModel.bufferViews[accessor.bufferView];
-					const tinygltf::Buffer &buffer = gltfModel.buffers[bufferView.buffer];
-					newSkin->inverseBindMatrices.resize(accessor.count);
-					memcpy(newSkin->inverseBindMatrices.data(), &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(glm::mat4));
-				}
+                // Find joint nodes
+                for (int jointIndex : source.joints)
+                {
+                    Node* node = nodeFromIndex(jointIndex);
+                    if (node)
+                    {
+                        newSkin->joints.push_back(nodeFromIndex(jointIndex));
+                    }
+                }
 
-				skins.push_back(newSkin);
-			}
-		}
+                // Get inverse bind matrices from buffer
+                if (source.inverseBindMatrices > -1)
+                {
+                    const tinygltf::Accessor& accessor = gltfModel.accessors[source.inverseBindMatrices];
+                    const tinygltf::BufferView& bufferView = gltfModel.bufferViews[accessor.bufferView];
+                    const tinygltf::Buffer& buffer = gltfModel.buffers[bufferView.buffer];
+                    newSkin->inverseBindMatrices.resize(accessor.count);
+                    memcpy(newSkin->inverseBindMatrices.data(), &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(glm::mat4));
+                }
 
-		void loadImages(tinygltf::Model &gltfModel, vks::VulkanDevice *device, VkQueue transferQueue)
-		{
-			for (tinygltf::Image &image : gltfModel.images) {
-				vkglTF::Texture texture;
-				texture.fromglTfImage(image, device, transferQueue);
-				textures.push_back(texture);
-			}
-		}
+                skins.push_back(newSkin);
+            }
+        }
 
-		void loadMaterials(tinygltf::Model &gltfModel)
-		{
-			for (tinygltf::Material &mat : gltfModel.materials) {
-				vkglTF::Material material{};
-				if (mat.values.find("baseColorTexture") != mat.values.end()) {
-					material.baseColorTexture = &textures[gltfModel.textures[mat.values["baseColorTexture"].TextureIndex()].source];
-				}
-				// Metallic roughness workflow
-				if (mat.values.find("metallicRoughnessTexture") != mat.values.end()) {
-					material.metallicRoughnessTexture = &textures[gltfModel.textures[mat.values["metallicRoughnessTexture"].TextureIndex()].source];
-				}
-				if (mat.values.find("roughnessFactor") != mat.values.end()) {
-					material.roughnessFactor = static_cast<float>(mat.values["roughnessFactor"].Factor());
-				}
-				if (mat.values.find("metallicFactor") != mat.values.end()) {
-					material.metallicFactor = static_cast<float>(mat.values["metallicFactor"].Factor());
-				}
-				if (mat.values.find("baseColorFactor") != mat.values.end()) {
-					material.baseColorFactor = glm::make_vec4(mat.values["baseColorFactor"].ColorFactor().data());
-				}				
-				if (mat.additionalValues.find("normalTexture") != mat.additionalValues.end()) {
-					material.normalTexture = &textures[gltfModel.textures[mat.additionalValues["normalTexture"].TextureIndex()].source];
-				}
-				if (mat.additionalValues.find("emissiveTexture") != mat.additionalValues.end()) {
-					material.emissiveTexture = &textures[gltfModel.textures[mat.additionalValues["emissiveTexture"].TextureIndex()].source];
-				}
-				if (mat.additionalValues.find("occlusionTexture") != mat.additionalValues.end()) {
-					material.occlusionTexture = &textures[gltfModel.textures[mat.additionalValues["occlusionTexture"].TextureIndex()].source];
-				}
-				if (mat.additionalValues.find("alphaMode") != mat.additionalValues.end()) {
-					tinygltf::Parameter param = mat.additionalValues["alphaMode"];
-					if (param.string_value == "BLEND") {
-						material.alphaMode = Material::ALPHAMODE_BLEND;
-					}
-					if (param.string_value == "MASK") {
-						material.alphaMode = Material::ALPHAMODE_MASK;
-					}
-				}
-				if (mat.additionalValues.find("alphaCutoff") != mat.additionalValues.end()) {
-					material.alphaCutoff = static_cast<float>(mat.additionalValues["alphaCutoff"].Factor());
-				}
+        void loadImages(tinygltf::Model& gltfModel, vks::VulkanDevice* device, VkQueue transferQueue)
+        {
+            for (tinygltf::Image& image : gltfModel.images)
+            {
+                vkglTF::Texture texture;
+                texture.fromglTfImage(image, device, transferQueue);
+                textures.push_back(texture);
+            }
+        }
 
-				materials.push_back(material);
-			}
-		}
+        void loadMaterials(tinygltf::Model& gltfModel)
+        {
+            for (tinygltf::Material& mat : gltfModel.materials)
+            {
+                vkglTF::Material material{};
+                if (mat.values.find("baseColorTexture") != mat.values.end())
+                {
+                    material.baseColorTexture = &textures[gltfModel.textures[mat.values["baseColorTexture"].TextureIndex()].source];
+                }
+                // Metallic roughness workflow
+                if (mat.values.find("metallicRoughnessTexture") != mat.values.end())
+                {
+                    material.metallicRoughnessTexture = &textures[gltfModel.textures[mat.values["metallicRoughnessTexture"].TextureIndex()].source];
+                }
+                if (mat.values.find("roughnessFactor") != mat.values.end())
+                {
+                    material.roughnessFactor = static_cast<float>(mat.values["roughnessFactor"].Factor());
+                }
+                if (mat.values.find("metallicFactor") != mat.values.end())
+                {
+                    material.metallicFactor = static_cast<float>(mat.values["metallicFactor"].Factor());
+                }
+                if (mat.values.find("baseColorFactor") != mat.values.end())
+                {
+                    material.baseColorFactor = glm::make_vec4(mat.values["baseColorFactor"].ColorFactor().data());
+                }
+                if (mat.additionalValues.find("normalTexture") != mat.additionalValues.end())
+                {
+                    material.normalTexture = &textures[gltfModel.textures[mat.additionalValues["normalTexture"].TextureIndex()].source];
+                }
+                if (mat.additionalValues.find("emissiveTexture") != mat.additionalValues.end())
+                {
+                    material.emissiveTexture = &textures[gltfModel.textures[mat.additionalValues["emissiveTexture"].TextureIndex()].source];
+                }
+                if (mat.additionalValues.find("occlusionTexture") != mat.additionalValues.end())
+                {
+                    material.occlusionTexture = &textures[gltfModel.textures[mat.additionalValues["occlusionTexture"].TextureIndex()].source];
+                }
+                if (mat.additionalValues.find("alphaMode") != mat.additionalValues.end())
+                {
+                    tinygltf::Parameter param = mat.additionalValues["alphaMode"];
+                    if (param.string_value == "BLEND")
+                    {
+                        material.alphaMode = Material::ALPHAMODE_BLEND;
+                    }
+                    if (param.string_value == "MASK")
+                    {
+                        material.alphaMode = Material::ALPHAMODE_MASK;
+                    }
+                }
+                if (mat.additionalValues.find("alphaCutoff") != mat.additionalValues.end())
+                {
+                    material.alphaCutoff = static_cast<float>(mat.additionalValues["alphaCutoff"].Factor());
+                }
 
-		void loadAnimations(tinygltf::Model &gltfModel)
-		{
-			for (tinygltf::Animation &anim : gltfModel.animations) {
-				vkglTF::Animation animation{};
-				animation.name = anim.name;
-				if (anim.name.empty()) {
-					animation.name = std::to_string(animations.size());
-				}
+                materials.push_back(material);
+            }
+        }
 
-				// Samplers
-				for (auto &samp : anim.samplers) {
-					vkglTF::AnimationSampler sampler{};
+        void loadAnimations(tinygltf::Model& gltfModel)
+        {
+            for (tinygltf::Animation& anim : gltfModel.animations)
+            {
+                vkglTF::Animation animation{};
+                animation.name = anim.name;
+                if (anim.name.empty())
+                {
+                    animation.name = std::to_string(animations.size());
+                }
 
-					if (samp.interpolation == "LINEAR") {
-						sampler.interpolation = AnimationSampler::InterpolationType::LINEAR;
-					}
-					if (samp.interpolation == "STEP") {
-						sampler.interpolation = AnimationSampler::InterpolationType::STEP;
-					}
-					if (samp.interpolation == "CUBICSPLINE") {
-						sampler.interpolation = AnimationSampler::InterpolationType::CUBICSPLINE;
-					}
+                // Samplers
+                for (auto& samp : anim.samplers)
+                {
+                    vkglTF::AnimationSampler sampler{};
 
-					// Read sampler input time values
-					{
-						const tinygltf::Accessor &accessor = gltfModel.accessors[samp.input];
-						const tinygltf::BufferView &bufferView = gltfModel.bufferViews[accessor.bufferView];
-						const tinygltf::Buffer &buffer = gltfModel.buffers[bufferView.buffer];
+                    if (samp.interpolation == "LINEAR")
+                    {
+                        sampler.interpolation = AnimationSampler::InterpolationType::LINEAR;
+                    }
+                    if (samp.interpolation == "STEP")
+                    {
+                        sampler.interpolation = AnimationSampler::InterpolationType::STEP;
+                    }
+                    if (samp.interpolation == "CUBICSPLINE")
+                    {
+                        sampler.interpolation = AnimationSampler::InterpolationType::CUBICSPLINE;
+                    }
 
-						assert(accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT);
+                    // Read sampler input time values
+                    {
+                        const tinygltf::Accessor& accessor = gltfModel.accessors[samp.input];
+                        const tinygltf::BufferView& bufferView = gltfModel.bufferViews[accessor.bufferView];
+                        const tinygltf::Buffer& buffer = gltfModel.buffers[bufferView.buffer];
 
-						float *buf = new float[accessor.count];
-						memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(float));
-						for (size_t index = 0; index < accessor.count; index++) {
-							sampler.inputs.push_back(buf[index]);
-						}
+                        assert(accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT);
 
-						for (auto input : sampler.inputs) {
-							if (input < animation.start) {
-								animation.start = input;
-							};
-							if (input > animation.end) {
-								animation.end = input;
-							}
-						}
-					}
+                        float* buf = new float[accessor.count];
+                        memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(float));
+                        for (size_t index = 0; index < accessor.count; index++)
+                        {
+                            sampler.inputs.push_back(buf[index]);
+                        }
 
-					// Read sampler output T/R/S values 
-					{
-						const tinygltf::Accessor &accessor = gltfModel.accessors[samp.output];
-						const tinygltf::BufferView &bufferView = gltfModel.bufferViews[accessor.bufferView];
-						const tinygltf::Buffer &buffer = gltfModel.buffers[bufferView.buffer];
+                        for (auto input : sampler.inputs)
+                        {
+                            if (input < animation.start)
+                            {
+                                animation.start = input;
+                            };
+                            if (input > animation.end)
+                            {
+                                animation.end = input;
+                            }
+                        }
+                    }
 
-						assert(accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT);
+                    // Read sampler output T/R/S values
+                    {
+                        const tinygltf::Accessor& accessor = gltfModel.accessors[samp.output];
+                        const tinygltf::BufferView& bufferView = gltfModel.bufferViews[accessor.bufferView];
+                        const tinygltf::Buffer& buffer = gltfModel.buffers[bufferView.buffer];
 
-						switch (accessor.type) {
-						case TINYGLTF_TYPE_VEC3: {
-							glm::vec3 *buf = new glm::vec3[accessor.count];
-							memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(glm::vec3));
-							for (size_t index = 0; index < accessor.count; index++) {
-								sampler.outputsVec4.push_back(glm::vec4(buf[index], 0.0f));
-							}
-							break;
-						}
-						case TINYGLTF_TYPE_VEC4: {
-							glm::vec4 *buf = new glm::vec4[accessor.count];
-							memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(glm::vec4));
-							for (size_t index = 0; index < accessor.count; index++) {
-								sampler.outputsVec4.push_back(buf[index]);
-							}
-							break;
-						}
-						default: {
-							std::cout << "unknown type" << std::endl;
-							break;
-						}
-						}
-					}
+                        assert(accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT);
 
-					animation.samplers.push_back(sampler);
-				}
+                        switch (accessor.type)
+                        {
+                            case TINYGLTF_TYPE_VEC3: {
+                                glm::vec3* buf = new glm::vec3[accessor.count];
+                                memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(glm::vec3));
+                                for (size_t index = 0; index < accessor.count; index++)
+                                {
+                                    sampler.outputsVec4.push_back(glm::vec4(buf[index], 0.0f));
+                                }
+                                break;
+                            }
+                            case TINYGLTF_TYPE_VEC4: {
+                                glm::vec4* buf = new glm::vec4[accessor.count];
+                                memcpy(buf, &buffer.data[accessor.byteOffset + bufferView.byteOffset], accessor.count * sizeof(glm::vec4));
+                                for (size_t index = 0; index < accessor.count; index++)
+                                {
+                                    sampler.outputsVec4.push_back(buf[index]);
+                                }
+                                break;
+                            }
+                            default: {
+                                std::cout << "unknown type" << std::endl;
+                                break;
+                            }
+                        }
+                    }
 
-				// Channels
-				for (auto &source: anim.channels) {
-					vkglTF::AnimationChannel channel{};
+                    animation.samplers.push_back(sampler);
+                }
 
-					if (source.target_path == "rotation") {
-						channel.path = AnimationChannel::PathType::ROTATION;
-					}
-					if (source.target_path == "translation") {
-						channel.path = AnimationChannel::PathType::TRANSLATION;
-					}
-					if (source.target_path == "scale") {
-						channel.path = AnimationChannel::PathType::SCALE;
-					}
-					if (source.target_path == "weights") {
-						std::cout << "weights not yet supported, skipping channel" << std::endl;
-						continue;
-					}
-					channel.samplerIndex = source.sampler;
-					channel.node = nodeFromIndex(source.target_node);
-					if (!channel.node) {
-						continue;
-					}
+                // Channels
+                for (auto& source : anim.channels)
+                {
+                    vkglTF::AnimationChannel channel{};
 
-					animation.channels.push_back(channel);
-				}
+                    if (source.target_path == "rotation")
+                    {
+                        channel.path = AnimationChannel::PathType::ROTATION;
+                    }
+                    if (source.target_path == "translation")
+                    {
+                        channel.path = AnimationChannel::PathType::TRANSLATION;
+                    }
+                    if (source.target_path == "scale")
+                    {
+                        channel.path = AnimationChannel::PathType::SCALE;
+                    }
+                    if (source.target_path == "weights")
+                    {
+                        std::cout << "weights not yet supported, skipping channel" << std::endl;
+                        continue;
+                    }
+                    channel.samplerIndex = source.sampler;
+                    channel.node = nodeFromIndex(source.target_node);
+                    if (!channel.node)
+                    {
+                        continue;
+                    }
 
-				animations.push_back(animation);
-			}
-		}
+                    animation.channels.push_back(channel);
+                }
 
-		void loadFromFile(std::string filename, vks::VulkanDevice *device, VkQueue transferQueue, float scale = 1.0f)
-		{
-			tinygltf::Model gltfModel;
-			tinygltf::TinyGLTF gltfContext;
-			std::string error, warning;
+                animations.push_back(animation);
+            }
+        }
 
-			this->device = device;
+        void loadFromFile(std::string filename, vks::VulkanDevice* device, VkQueue transferQueue, float scale = 1.0f)
+        {
+            tinygltf::Model gltfModel;
+            tinygltf::TinyGLTF gltfContext;
+            std::string error, warning;
+
+            this->device = device;
 
 #if defined(__ANDROID__)
-			AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, filename.c_str(), AASSET_MODE_STREAMING);
-			assert(asset);
-			size_t size = AAsset_getLength(asset);
-			assert(size > 0);
-			char* fileData = new char[size];
-			AAsset_read(asset, fileData, size);
-			AAsset_close(asset);
-			std::string baseDir;
-			bool fileLoaded = gltfContext.LoadASCIIFromString(&gltfModel, &error, &warning, fileData, size, baseDir);
-			free(fileData);
+            AAsset* asset = AAssetManager_open(androidApp->activity->assetManager, filename.c_str(), AASSET_MODE_STREAMING);
+            assert(asset);
+            size_t size = AAsset_getLength(asset);
+            assert(size > 0);
+            char* fileData = new char[size];
+            AAsset_read(asset, fileData, size);
+            AAsset_close(asset);
+            std::string baseDir;
+            bool fileLoaded = gltfContext.LoadASCIIFromString(&gltfModel, &error, &warning, fileData, size, baseDir);
+            free(fileData);
 #else
-			bool fileLoaded = gltfContext.LoadASCIIFromFile(&gltfModel, &error, &warning, filename);
+            bool fileLoaded = gltfContext.LoadASCIIFromFile(&gltfModel, &error, &warning, filename);
 #endif
-			std::vector<uint32_t> indexBuffer;
-			std::vector<Vertex> vertexBuffer;
+            std::vector<uint32_t> indexBuffer;
+            std::vector<Vertex> vertexBuffer;
 
-			if (fileLoaded) {
-				loadImages(gltfModel, device, transferQueue);
-				loadMaterials(gltfModel);
-				const tinygltf::Scene &scene = gltfModel.scenes[gltfModel.defaultScene > -1 ? gltfModel.defaultScene : 0];
-				for (size_t i = 0; i < scene.nodes.size(); i++) {
-					const tinygltf::Node node = gltfModel.nodes[scene.nodes[i]];
-					loadNode(nullptr, node, scene.nodes[i], gltfModel, indexBuffer, vertexBuffer, scale);
-				}
-				if (gltfModel.animations.size() > 0) {
-					loadAnimations(gltfModel);
-				}
-				loadSkins(gltfModel);
+            if (fileLoaded)
+            {
+                loadImages(gltfModel, device, transferQueue);
+                loadMaterials(gltfModel);
+                const tinygltf::Scene& scene = gltfModel.scenes[gltfModel.defaultScene > -1 ? gltfModel.defaultScene : 0];
+                for (size_t i = 0; i < scene.nodes.size(); i++)
+                {
+                    const tinygltf::Node node = gltfModel.nodes[scene.nodes[i]];
+                    loadNode(nullptr, node, scene.nodes[i], gltfModel, indexBuffer, vertexBuffer, scale);
+                }
+                if (gltfModel.animations.size() > 0)
+                {
+                    loadAnimations(gltfModel);
+                }
+                loadSkins(gltfModel);
 
-				for (auto node : linearNodes) {
-					// Assign skins
-					if (node->skinIndex > -1) {
-						node->skin = skins[node->skinIndex];
-					}
-					// Initial pose
-					if (node->mesh) {
-						node->update();
-					}
-				}
-			}
-			else {
-				// TODO: throw
-				std::cerr << "Could not load gltf file: " << error << std::endl;
-				return;
-			}
+                for (auto node : linearNodes)
+                {
+                    // Assign skins
+                    if (node->skinIndex > -1)
+                    {
+                        node->skin = skins[node->skinIndex];
+                    }
+                    // Initial pose
+                    if (node->mesh)
+                    {
+                        node->update();
+                    }
+                }
+            }
+            else
+            {
+                // TODO: throw
+                std::cerr << "Could not load gltf file: " << error << std::endl;
+                return;
+            }
 
-			for (auto extension : gltfModel.extensionsUsed) {
-				if (extension == "KHR_materials_pbrSpecularGlossiness") {
-					std::cout << "Required extension: " << extension;
-					metallicRoughnessWorkflow = false;
-				}
-			}
+            for (auto extension : gltfModel.extensionsUsed)
+            {
+                if (extension == "KHR_materials_pbrSpecularGlossiness")
+                {
+                    std::cout << "Required extension: " << extension;
+                    metallicRoughnessWorkflow = false;
+                }
+            }
 
-			size_t vertexBufferSize = vertexBuffer.size() * sizeof(Vertex);
-			size_t indexBufferSize = indexBuffer.size() * sizeof(uint32_t);
-			indices.count = static_cast<uint32_t>(indexBuffer.size());
+            size_t vertexBufferSize = vertexBuffer.size() * sizeof(Vertex);
+            size_t indexBufferSize = indexBuffer.size() * sizeof(uint32_t);
+            indices.count = static_cast<uint32_t>(indexBuffer.size());
 
-			assert((vertexBufferSize > 0) && (indexBufferSize > 0));
+            assert((vertexBufferSize > 0) && (indexBufferSize > 0));
 
-			struct StagingBuffer {
-				VkBuffer buffer;
-				VkDeviceMemory memory;
-			} vertexStaging, indexStaging;
+            struct StagingBuffer
+            {
+                VkBuffer buffer;
+                VkDeviceMemory memory;
+            } vertexStaging, indexStaging;
 
-			// Create staging buffers
-			// Vertex data
-			VK_CHECK_RESULT(device->createBuffer(
-				VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-				vertexBufferSize,
-				&vertexStaging.buffer,
-				&vertexStaging.memory,
-				vertexBuffer.data()));
-			// Index data
-			VK_CHECK_RESULT(device->createBuffer(
-				VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-				indexBufferSize,
-				&indexStaging.buffer,
-				&indexStaging.memory,
-				indexBuffer.data()));
+            // Create staging buffers
+            // Vertex data
+            VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                                                 vertexBufferSize, &vertexStaging.buffer, &vertexStaging.memory, vertexBuffer.data()));
+            // Index data
+            VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                                                 indexBufferSize, &indexStaging.buffer, &indexStaging.memory, indexBuffer.data()));
 
-			// Create device local buffers
-			// Vertex buffer
-			VK_CHECK_RESULT(device->createBuffer(
-				VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				vertexBufferSize,
-				&vertices.buffer,
-				&vertices.memory));
-			// Index buffer
-			VK_CHECK_RESULT(device->createBuffer(
-				VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				indexBufferSize,
-				&indices.buffer,
-				&indices.memory));
+            // Create device local buffers
+            // Vertex buffer
+            VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                                 vertexBufferSize, &vertices.buffer, &vertices.memory));
+            // Index buffer
+            VK_CHECK_RESULT(device->createBuffer(VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                                 indexBufferSize, &indices.buffer, &indices.memory));
 
-			// Copy from staging buffers
-			VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+            // Copy from staging buffers
+            VkCommandBuffer copyCmd = device->createCommandBuffer(VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-			VkBufferCopy copyRegion = {};
+            VkBufferCopy copyRegion = {};
 
-			copyRegion.size = vertexBufferSize;
-			vkCmdCopyBuffer(copyCmd, vertexStaging.buffer, vertices.buffer, 1, &copyRegion);
+            copyRegion.size = vertexBufferSize;
+            vkCmdCopyBuffer(copyCmd, vertexStaging.buffer, vertices.buffer, 1, &copyRegion);
 
-			copyRegion.size = indexBufferSize;
-			vkCmdCopyBuffer(copyCmd, indexStaging.buffer, indices.buffer, 1, &copyRegion);
+            copyRegion.size = indexBufferSize;
+            vkCmdCopyBuffer(copyCmd, indexStaging.buffer, indices.buffer, 1, &copyRegion);
 
-			device->flushCommandBuffer(copyCmd, transferQueue, true);
+            device->flushCommandBuffer(copyCmd, transferQueue, true);
 
-			vkDestroyBuffer(device->logicalDevice, vertexStaging.buffer, nullptr);
-			vkFreeMemory(device->logicalDevice, vertexStaging.memory, nullptr);
-			vkDestroyBuffer(device->logicalDevice, indexStaging.buffer, nullptr);
-			vkFreeMemory(device->logicalDevice, indexStaging.memory, nullptr);
+            vkDestroyBuffer(device->logicalDevice, vertexStaging.buffer, nullptr);
+            vkFreeMemory(device->logicalDevice, vertexStaging.memory, nullptr);
+            vkDestroyBuffer(device->logicalDevice, indexStaging.buffer, nullptr);
+            vkFreeMemory(device->logicalDevice, indexStaging.memory, nullptr);
 
-			getSceneDimensions();
+            getSceneDimensions();
 
-			// Setup descriptors
-			uint32_t uboCount{ 0 };
-			for (auto node : linearNodes) {
-				if (node->mesh) {
-					uboCount++;
-				}
-			}
-			std::vector<VkDescriptorPoolSize> poolSizes = {
-				vks::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, uboCount),
-			};
-			VkDescriptorPoolCreateInfo descriptorPoolCI = vks::initializers::descriptorPoolCreateInfo(static_cast<uint32_t>(poolSizes.size()), poolSizes.data(), uboCount);
-			VK_CHECK_RESULT(vkCreateDescriptorPool(device->logicalDevice, &descriptorPoolCI, nullptr, &descriptorPool));
+            // Setup descriptors
+            uint32_t uboCount{ 0 };
+            for (auto node : linearNodes)
+            {
+                if (node->mesh)
+                {
+                    uboCount++;
+                }
+            }
+            std::vector<VkDescriptorPoolSize> poolSizes = {
+                vks::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, uboCount),
+            };
+            VkDescriptorPoolCreateInfo descriptorPoolCI =
+                vks::initializers::descriptorPoolCreateInfo(static_cast<uint32_t>(poolSizes.size()), poolSizes.data(), uboCount);
+            VK_CHECK_RESULT(vkCreateDescriptorPool(device->logicalDevice, &descriptorPoolCI, nullptr, &descriptorPool));
 
-			std::vector<VkDescriptorSetLayoutBinding> setLayoutBindings = {
-				vks::initializers::descriptorSetLayoutBinding(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_VERTEX_BIT, 0),
-			};
-			VkDescriptorSetLayoutCreateInfo descriptorLayoutCI{};
-			descriptorLayoutCI.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-			descriptorLayoutCI.bindingCount = static_cast<uint32_t>(setLayoutBindings.size());
-			descriptorLayoutCI.pBindings = setLayoutBindings.data();
-			VK_CHECK_RESULT(vkCreateDescriptorSetLayout(device->logicalDevice, &descriptorLayoutCI, nullptr, &descriptorSetLayout));
-			for (auto node : nodes) {
-				prepareNodeDescriptor(node, descriptorSetLayout);
-			}
-		}
+            std::vector<VkDescriptorSetLayoutBinding> setLayoutBindings = {
+                vks::initializers::descriptorSetLayoutBinding(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_VERTEX_BIT, 0),
+            };
+            VkDescriptorSetLayoutCreateInfo descriptorLayoutCI{};
+            descriptorLayoutCI.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+            descriptorLayoutCI.bindingCount = static_cast<uint32_t>(setLayoutBindings.size());
+            descriptorLayoutCI.pBindings = setLayoutBindings.data();
+            VK_CHECK_RESULT(vkCreateDescriptorSetLayout(device->logicalDevice, &descriptorLayoutCI, nullptr, &descriptorSetLayout));
+            for (auto node : nodes)
+            {
+                prepareNodeDescriptor(node, descriptorSetLayout);
+            }
+        }
 
-		void drawNode(Node *node, VkCommandBuffer commandBuffer)
-		{
-			if (node->mesh) {
-				for (Primitive *primitive : node->mesh->primitives) {
-					vkCmdDrawIndexed(commandBuffer, primitive->indexCount, 1, primitive->firstIndex, 0, 0);
-				}
-			}
-			for (auto& child : node->children) {
-				drawNode(child, commandBuffer);
-			}
-		}
+        void drawNode(Node* node, VkCommandBuffer commandBuffer)
+        {
+            if (node->mesh)
+            {
+                for (Primitive* primitive : node->mesh->primitives)
+                {
+                    vkCmdDrawIndexed(commandBuffer, primitive->indexCount, 1, primitive->firstIndex, 0, 0);
+                }
+            }
+            for (auto& child : node->children)
+            {
+                drawNode(child, commandBuffer);
+            }
+        }
 
-		void draw(VkCommandBuffer commandBuffer)
-		{
-			const VkDeviceSize offsets[1] = { 0 };
-			vkCmdBindVertexBuffers(commandBuffer, 0, 1, &vertices.buffer, offsets);
-			vkCmdBindIndexBuffer(commandBuffer, indices.buffer, 0, VK_INDEX_TYPE_UINT32);
-			for (auto& node : nodes) {
-				drawNode(node, commandBuffer);
-			}
-		}
+        void draw(VkCommandBuffer commandBuffer)
+        {
+            const VkDeviceSize offsets[1] = { 0 };
+            vkCmdBindVertexBuffers(commandBuffer, 0, 1, &vertices.buffer, offsets);
+            vkCmdBindIndexBuffer(commandBuffer, indices.buffer, 0, VK_INDEX_TYPE_UINT32);
+            for (auto& node : nodes)
+            {
+                drawNode(node, commandBuffer);
+            }
+        }
 
-		void getNodeDimensions(Node *node, glm::vec3 &min, glm::vec3 &max)
-		{
-			if (node->mesh) {
-				for (Primitive *primitive : node->mesh->primitives) {
-					glm::vec4 locMin = glm::vec4(primitive->dimensions.min, 1.0f) * node->getMatrix();
-					glm::vec4 locMax = glm::vec4(primitive->dimensions.max, 1.0f) * node->getMatrix();
-					if (locMin.x < min.x) { min.x = locMin.x; }
-					if (locMin.y < min.y) { min.y = locMin.y; }
-					if (locMin.z < min.z) { min.z = locMin.z; }
-					if (locMax.x > max.x) { max.x = locMax.x; }
-					if (locMax.y > max.y) { max.y = locMax.y; }
-					if (locMax.z > max.z) { max.z = locMax.z; }
-				}
-			}
-			for (auto child : node->children) {
-				getNodeDimensions(child, min, max);
-			}
-		}
+        void getNodeDimensions(Node* node, glm::vec3& min, glm::vec3& max)
+        {
+            if (node->mesh)
+            {
+                for (Primitive* primitive : node->mesh->primitives)
+                {
+                    glm::vec4 locMin = glm::vec4(primitive->dimensions.min, 1.0f) * node->getMatrix();
+                    glm::vec4 locMax = glm::vec4(primitive->dimensions.max, 1.0f) * node->getMatrix();
+                    if (locMin.x < min.x)
+                    {
+                        min.x = locMin.x;
+                    }
+                    if (locMin.y < min.y)
+                    {
+                        min.y = locMin.y;
+                    }
+                    if (locMin.z < min.z)
+                    {
+                        min.z = locMin.z;
+                    }
+                    if (locMax.x > max.x)
+                    {
+                        max.x = locMax.x;
+                    }
+                    if (locMax.y > max.y)
+                    {
+                        max.y = locMax.y;
+                    }
+                    if (locMax.z > max.z)
+                    {
+                        max.z = locMax.z;
+                    }
+                }
+            }
+            for (auto child : node->children)
+            {
+                getNodeDimensions(child, min, max);
+            }
+        }
 
-		void getSceneDimensions()
-		{
-			dimensions.min = glm::vec3(FLT_MAX);
-			dimensions.max = glm::vec3(-FLT_MAX);
-			for (auto node : nodes) {
-				getNodeDimensions(node, dimensions.min, dimensions.max);
-			}
-			dimensions.size = dimensions.max - dimensions.min;
-			dimensions.center = (dimensions.min + dimensions.max) / 2.0f;
-			dimensions.radius = glm::distance(dimensions.min, dimensions.max) / 2.0f;
-		}
+        void getSceneDimensions()
+        {
+            dimensions.min = glm::vec3(FLT_MAX);
+            dimensions.max = glm::vec3(-FLT_MAX);
+            for (auto node : nodes)
+            {
+                getNodeDimensions(node, dimensions.min, dimensions.max);
+            }
+            dimensions.size = dimensions.max - dimensions.min;
+            dimensions.center = (dimensions.min + dimensions.max) / 2.0f;
+            dimensions.radius = glm::distance(dimensions.min, dimensions.max) / 2.0f;
+        }
 
-		void updateAnimation(uint32_t index, float time) 
-		{
-			if (index > static_cast<uint32_t>(animations.size()) - 1) {
-				std::cout << "No animation with index " << index << std::endl;
-				return;
-			}
-			Animation &animation = animations[index];
+        void updateAnimation(uint32_t index, float time)
+        {
+            if (index > static_cast<uint32_t>(animations.size()) - 1)
+            {
+                std::cout << "No animation with index " << index << std::endl;
+                return;
+            }
+            Animation& animation = animations[index];
 
-			bool updated = false;
-			for (auto& channel : animation.channels) {
-				vkglTF::AnimationSampler &sampler = animation.samplers[channel.samplerIndex];
-				if (sampler.inputs.size() > sampler.outputsVec4.size()) {
-					continue;
-				}
+            bool updated = false;
+            for (auto& channel : animation.channels)
+            {
+                vkglTF::AnimationSampler& sampler = animation.samplers[channel.samplerIndex];
+                if (sampler.inputs.size() > sampler.outputsVec4.size())
+                {
+                    continue;
+                }
 
-				for (auto i = 0; i < sampler.inputs.size() - 1; i++) {
-					if ((time >= sampler.inputs[i]) && (time <= sampler.inputs[i + 1])) {
-						float u = std::max(0.0f, time - sampler.inputs[i]) / (sampler.inputs[i + 1] - sampler.inputs[i]);
-						if (u <= 1.0f) {
-							switch (channel.path) {
-							case vkglTF::AnimationChannel::PathType::TRANSLATION: {
-								glm::vec4 trans = glm::mix(sampler.outputsVec4[i], sampler.outputsVec4[i + 1], u);
-								channel.node->translation = glm::vec3(trans);
-								break;
-							}
-							case vkglTF::AnimationChannel::PathType::SCALE: {
-								glm::vec4 trans = glm::mix(sampler.outputsVec4[i], sampler.outputsVec4[i + 1], u);
-								channel.node->scale = glm::vec3(trans);
-								break;
-							}
-							case vkglTF::AnimationChannel::PathType::ROTATION: {
-								glm::quat q1;
-								q1.x = sampler.outputsVec4[i].x;
-								q1.y = sampler.outputsVec4[i].y;
-								q1.z = sampler.outputsVec4[i].z;
-								q1.w = sampler.outputsVec4[i].w;
-								glm::quat q2;
-								q2.x = sampler.outputsVec4[i + 1].x;
-								q2.y = sampler.outputsVec4[i + 1].y;
-								q2.z = sampler.outputsVec4[i + 1].z;
-								q2.w = sampler.outputsVec4[i + 1].w;
-								channel.node->rotation = glm::normalize(glm::slerp(q1, q2, u));
-								break;
-							}
-							}
-							updated = true;
-						}
-					}
-				}
-			}
-			if (updated) {
-				for (auto &node : nodes) {
-					node->update();
-				}
-			}
-		}
+                for (auto i = 0; i < sampler.inputs.size() - 1; i++)
+                {
+                    if ((time >= sampler.inputs[i]) && (time <= sampler.inputs[i + 1]))
+                    {
+                        float u = std::max(0.0f, time - sampler.inputs[i]) / (sampler.inputs[i + 1] - sampler.inputs[i]);
+                        if (u <= 1.0f)
+                        {
+                            switch (channel.path)
+                            {
+                                case vkglTF::AnimationChannel::PathType::TRANSLATION: {
+                                    glm::vec4 trans = glm::mix(sampler.outputsVec4[i], sampler.outputsVec4[i + 1], u);
+                                    channel.node->translation = glm::vec3(trans);
+                                    break;
+                                }
+                                case vkglTF::AnimationChannel::PathType::SCALE: {
+                                    glm::vec4 trans = glm::mix(sampler.outputsVec4[i], sampler.outputsVec4[i + 1], u);
+                                    channel.node->scale = glm::vec3(trans);
+                                    break;
+                                }
+                                case vkglTF::AnimationChannel::PathType::ROTATION: {
+                                    glm::quat q1;
+                                    q1.x = sampler.outputsVec4[i].x;
+                                    q1.y = sampler.outputsVec4[i].y;
+                                    q1.z = sampler.outputsVec4[i].z;
+                                    q1.w = sampler.outputsVec4[i].w;
+                                    glm::quat q2;
+                                    q2.x = sampler.outputsVec4[i + 1].x;
+                                    q2.y = sampler.outputsVec4[i + 1].y;
+                                    q2.z = sampler.outputsVec4[i + 1].z;
+                                    q2.w = sampler.outputsVec4[i + 1].w;
+                                    channel.node->rotation = glm::normalize(glm::slerp(q1, q2, u));
+                                    break;
+                                }
+                            }
+                            updated = true;
+                        }
+                    }
+                }
+            }
+            if (updated)
+            {
+                for (auto& node : nodes)
+                {
+                    node->update();
+                }
+            }
+        }
 
-		/*
+        /*
 			Helper functions
 		*/
-		Node* findNode(Node *parent, uint32_t index) {
-			Node* nodeFound = nullptr;
-			if (parent->index == index) {
-				return parent;
-			}
-			for (auto& child : parent->children) {
-				nodeFound = findNode(child, index);
-				if (nodeFound) {
-					break;
-				}
-			}
-			return nodeFound;
-		}
+        Node* findNode(Node* parent, uint32_t index)
+        {
+            Node* nodeFound = nullptr;
+            if (parent->index == index)
+            {
+                return parent;
+            }
+            for (auto& child : parent->children)
+            {
+                nodeFound = findNode(child, index);
+                if (nodeFound)
+                {
+                    break;
+                }
+            }
+            return nodeFound;
+        }
 
-		Node* nodeFromIndex(uint32_t index) {
-			Node* nodeFound = nullptr;
-			for (auto &node : nodes) {
-				nodeFound = findNode(node, index);
-				if (nodeFound) {
-					break;
-				}
-			}
-			return nodeFound;
-		}
+        Node* nodeFromIndex(uint32_t index)
+        {
+            Node* nodeFound = nullptr;
+            for (auto& node : nodes)
+            {
+                nodeFound = findNode(node, index);
+                if (nodeFound)
+                {
+                    break;
+                }
+            }
+            return nodeFound;
+        }
 
-		void prepareNodeDescriptor(vkglTF::Node *node, VkDescriptorSetLayout descriptorSetLayout) {
-			if (node->mesh) {
-				VkDescriptorSetAllocateInfo descriptorSetAllocInfo{};
-				descriptorSetAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-				descriptorSetAllocInfo.descriptorPool = descriptorPool;
-				descriptorSetAllocInfo.pSetLayouts = &descriptorSetLayout;
-				descriptorSetAllocInfo.descriptorSetCount = 1;
-				VK_CHECK_RESULT(vkAllocateDescriptorSets(device->logicalDevice, &descriptorSetAllocInfo, &node->mesh->uniformBuffer.descriptorSet));
+        void prepareNodeDescriptor(vkglTF::Node* node, VkDescriptorSetLayout descriptorSetLayout)
+        {
+            if (node->mesh)
+            {
+                VkDescriptorSetAllocateInfo descriptorSetAllocInfo{};
+                descriptorSetAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+                descriptorSetAllocInfo.descriptorPool = descriptorPool;
+                descriptorSetAllocInfo.pSetLayouts = &descriptorSetLayout;
+                descriptorSetAllocInfo.descriptorSetCount = 1;
+                VK_CHECK_RESULT(vkAllocateDescriptorSets(device->logicalDevice, &descriptorSetAllocInfo, &node->mesh->uniformBuffer.descriptorSet));
 
-				VkWriteDescriptorSet writeDescriptorSet{};
-				writeDescriptorSet.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-				writeDescriptorSet.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-				writeDescriptorSet.descriptorCount = 1;
-				writeDescriptorSet.dstSet = node->mesh->uniformBuffer.descriptorSet;
-				writeDescriptorSet.dstBinding = 0;
-				writeDescriptorSet.pBufferInfo = &node->mesh->uniformBuffer.descriptor;
+                VkWriteDescriptorSet writeDescriptorSet{};
+                writeDescriptorSet.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+                writeDescriptorSet.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+                writeDescriptorSet.descriptorCount = 1;
+                writeDescriptorSet.dstSet = node->mesh->uniformBuffer.descriptorSet;
+                writeDescriptorSet.dstBinding = 0;
+                writeDescriptorSet.pBufferInfo = &node->mesh->uniformBuffer.descriptor;
 
-				vkUpdateDescriptorSets(device->logicalDevice, 1, &writeDescriptorSet, 0, nullptr);
-			}
-			for (auto& child : node->children) {
-				prepareNodeDescriptor(child, descriptorSetLayout);
-			}
-		}
-	};
-}
+                vkUpdateDescriptorSets(device->logicalDevice, 1, &writeDescriptorSet, 0, nullptr);
+            }
+            for (auto& child : node->children)
+            {
+                prepareNodeDescriptor(child, descriptorSetLayout);
+            }
+        }
+    };
+}  // namespace vkglTF

--- a/base/benchmark.hpp
+++ b/base/benchmark.hpp
@@ -16,87 +16,97 @@
 
 namespace vks
 {
-	class Benchmark {
-	private:
-		FILE *stream;
-		VkPhysicalDeviceProperties deviceProps;
-	public:
-		bool active = false;
-		bool outputFrameTimes = false;
-		uint32_t warmup = 1;
-		uint32_t duration = 10;
-		std::vector<double> frameTimes;
-		std::string filename = "";
+    class Benchmark
+    {
+    private:
+        FILE* stream;
+        VkPhysicalDeviceProperties deviceProps;
 
-		double runtime = 0.0;
-		uint32_t frameCount = 0;
+    public:
+        bool active = false;
+        bool outputFrameTimes = false;
+        uint32_t warmup = 1;
+        uint32_t duration = 10;
+        std::vector<double> frameTimes;
+        std::string filename = "";
 
-		void run(std::function<void()> renderFunc, VkPhysicalDeviceProperties deviceProps) {
-			active = true;
-			this->deviceProps = deviceProps;
+        double runtime = 0.0;
+        uint32_t frameCount = 0;
+
+        void run(std::function<void()> renderFunc, VkPhysicalDeviceProperties deviceProps)
+        {
+            active = true;
+            this->deviceProps = deviceProps;
 #if defined(_WIN32)
-			AttachConsole(ATTACH_PARENT_PROCESS);
-			freopen_s(&stream, "CONOUT$", "w+", stdout);
-			freopen_s(&stream, "CONOUT$", "w+", stderr);
+            AttachConsole(ATTACH_PARENT_PROCESS);
+            freopen_s(&stream, "CONOUT$", "w+", stdout);
+            freopen_s(&stream, "CONOUT$", "w+", stderr);
 #endif
-			std::cout << std::fixed << std::setprecision(3);
+            std::cout << std::fixed << std::setprecision(3);
 
-			// Warm up phase to get more stable frame rates
-			{
-				double tMeasured = 0.0;
-				while (tMeasured < (warmup * 1000)) {
-					auto tStart = std::chrono::high_resolution_clock::now();
-					renderFunc();
-					auto tDiff = std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now() - tStart).count();
-					tMeasured += tDiff;
-				};
-			}
+            // Warm up phase to get more stable frame rates
+            {
+                double tMeasured = 0.0;
+                while (tMeasured < (warmup * 1000))
+                {
+                    auto tStart = std::chrono::high_resolution_clock::now();
+                    renderFunc();
+                    auto tDiff = std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now() - tStart).count();
+                    tMeasured += tDiff;
+                };
+            }
 
-			// Benchmark phase
-			{
-				while (runtime < (duration * 1000.0)) {
-					auto tStart = std::chrono::high_resolution_clock::now();
-					renderFunc();
-					auto tDiff = std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now() - tStart).count();
-					runtime += tDiff;
-					frameTimes.push_back(tDiff);
-					frameCount++;
-				};
-				std::cout << "Benchmark finished" << std::endl;
-				std::cout << "device : " << deviceProps.deviceName << " (driver version: " << deviceProps.driverVersion << ")" << std::endl;
-				std::cout << "runtime: " << (runtime / 1000.0) << std::endl;
-				std::cout << "frames : " << frameCount << std::endl;
-				std::cout << "fps    : " << frameCount / (runtime / 1000.0) << std::endl;
-			}
-		}
+            // Benchmark phase
+            {
+                while (runtime < (duration * 1000.0))
+                {
+                    auto tStart = std::chrono::high_resolution_clock::now();
+                    renderFunc();
+                    auto tDiff = std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now() - tStart).count();
+                    runtime += tDiff;
+                    frameTimes.push_back(tDiff);
+                    frameCount++;
+                };
+                std::cout << "Benchmark finished" << std::endl;
+                std::cout << "device : " << deviceProps.deviceName << " (driver version: " << deviceProps.driverVersion << ")" << std::endl;
+                std::cout << "runtime: " << (runtime / 1000.0) << std::endl;
+                std::cout << "frames : " << frameCount << std::endl;
+                std::cout << "fps    : " << frameCount / (runtime / 1000.0) << std::endl;
+            }
+        }
 
-		void saveResults() {
-			std::ofstream result(filename, std::ios::out);
-			if (result.is_open()) {
-				result << std::fixed << std::setprecision(4);
+        void saveResults()
+        {
+            std::ofstream result(filename, std::ios::out);
+            if (result.is_open())
+            {
+                result << std::fixed << std::setprecision(4);
 
-				result << "device,driverversion,duration (ms),frames,fps" << std::endl;
-				result << deviceProps.deviceName << "," << deviceProps.driverVersion << "," << runtime << "," << frameCount << "," << frameCount / (runtime / 1000.0) << std::endl;
+                result << "device,driverversion,duration (ms),frames,fps" << std::endl;
+                result << deviceProps.deviceName << "," << deviceProps.driverVersion << "," << runtime << "," << frameCount << ","
+                       << frameCount / (runtime / 1000.0) << std::endl;
 
-				if (outputFrameTimes) {
-					result << std::endl << "frame,ms" << std::endl;
-					for (size_t i = 0; i < frameTimes.size(); i++) {
-						result << i << "," << frameTimes[i] << std::endl;
-					}
-					double tMin = *std::min_element(frameTimes.begin(), frameTimes.end());
-					double tMax = *std::max_element(frameTimes.begin(), frameTimes.end());
-					double tAvg = std::accumulate(frameTimes.begin(), frameTimes.end(), 0.0) / (double)frameTimes.size();
-					std::cout << "best   : " << (1000.0 / tMin) << " fps (" << tMin << " ms)" << std::endl;
-					std::cout << "worst  : " << (1000.0 / tMax) << " fps (" << tMax << " ms)" << std::endl;
-					std::cout << "avg    : " << (1000.0 / tAvg) << " fps (" << tAvg << " ms)" << std::endl;
-					std::cout << std::endl;
-				}
+                if (outputFrameTimes)
+                {
+                    result << std::endl << "frame,ms" << std::endl;
+                    for (size_t i = 0; i < frameTimes.size(); i++)
+                    {
+                        result << i << "," << frameTimes[i] << std::endl;
+                    }
+                    double tMin = *std::min_element(frameTimes.begin(), frameTimes.end());
+                    double tMax = *std::max_element(frameTimes.begin(), frameTimes.end());
+                    double tAvg = std::accumulate(frameTimes.begin(), frameTimes.end(), 0.0) / (double)frameTimes.size();
+                    std::cout << "best   : " << (1000.0 / tMin) << " fps (" << tMin << " ms)" << std::endl;
+                    std::cout << "worst  : " << (1000.0 / tMax) << " fps (" << tMax << " ms)" << std::endl;
+                    std::cout << "avg    : " << (1000.0 / tAvg) << " fps (" << tAvg << " ms)" << std::endl;
+                    std::cout << std::endl;
+                }
 
-				result.flush();
+                result.flush();
 #if defined(_WIN32)
-				FreeConsole();
+                FreeConsole();
 #endif
-			}
-		}
-	};
-}
+            }
+        }
+    };
+}  // namespace vks

--- a/base/camera.hpp
+++ b/base/camera.hpp
@@ -15,204 +15,206 @@
 class Camera
 {
 private:
-	float fov;
-	float znear, zfar;
+    float fov;
+    float znear, zfar;
 
-	void updateViewMatrix()
-	{
-		glm::mat4 rotM = glm::mat4(1.0f);
-		glm::mat4 transM;
+    void updateViewMatrix()
+    {
+        glm::mat4 rotM = glm::mat4(1.0f);
+        glm::mat4 transM;
 
-		rotM = glm::rotate(rotM, glm::radians(rotation.x), glm::vec3(1.0f, 0.0f, 0.0f));
-		rotM = glm::rotate(rotM, glm::radians(rotation.y), glm::vec3(0.0f, 1.0f, 0.0f));
-		rotM = glm::rotate(rotM, glm::radians(rotation.z), glm::vec3(0.0f, 0.0f, 1.0f));
+        rotM = glm::rotate(rotM, glm::radians(rotation.x), glm::vec3(1.0f, 0.0f, 0.0f));
+        rotM = glm::rotate(rotM, glm::radians(rotation.y), glm::vec3(0.0f, 1.0f, 0.0f));
+        rotM = glm::rotate(rotM, glm::radians(rotation.z), glm::vec3(0.0f, 0.0f, 1.0f));
 
-		transM = glm::translate(glm::mat4(1.0f), position);
+        transM = glm::translate(glm::mat4(1.0f), position);
 
-		if (type == CameraType::firstperson)
-		{
-			matrices.view = rotM * transM;
-		}
-		else
-		{
-			matrices.view = transM * rotM;
-		}
+        if (type == CameraType::firstperson)
+        {
+            matrices.view = rotM * transM;
+        }
+        else
+        {
+            matrices.view = transM * rotM;
+        }
 
-		updated = true;
-	};
+        updated = true;
+    };
+
 public:
-	enum CameraType { lookat, firstperson };
-	CameraType type = CameraType::lookat;
+    enum CameraType { lookat, firstperson };
+    CameraType type = CameraType::lookat;
 
-	glm::vec3 rotation = glm::vec3();
-	glm::vec3 position = glm::vec3();
+    glm::vec3 rotation = glm::vec3();
+    glm::vec3 position = glm::vec3();
 
-	float rotationSpeed = 1.0f;
-	float movementSpeed = 1.0f;
+    float rotationSpeed = 1.0f;
+    float movementSpeed = 1.0f;
 
-	bool updated = false;
+    bool updated = false;
 
-	struct
-	{
-		glm::mat4 perspective;
-		glm::mat4 view;
-	} matrices;
+    struct
+    {
+        glm::mat4 perspective;
+        glm::mat4 view;
+    } matrices;
 
-	struct
-	{
-		bool left = false;
-		bool right = false;
-		bool up = false;
-		bool down = false;
-	} keys;
+    struct
+    {
+        bool left = false;
+        bool right = false;
+        bool up = false;
+        bool down = false;
+    } keys;
 
-	bool moving()
-	{
-		return keys.left || keys.right || keys.up || keys.down;
-	}
+    bool moving()
+    {
+        return keys.left || keys.right || keys.up || keys.down;
+    }
 
-	float getNearClip() { 
-		return znear;
-	}
+    float getNearClip()
+    {
+        return znear;
+    }
 
-	float getFarClip() {
-		return zfar;
-	}
+    float getFarClip()
+    {
+        return zfar;
+    }
 
-	void setPerspective(float fov, float aspect, float znear, float zfar)
-	{
-		this->fov = fov;
-		this->znear = znear;
-		this->zfar = zfar;
-		matrices.perspective = glm::perspective(glm::radians(fov), aspect, znear, zfar);
-	};
+    void setPerspective(float fov, float aspect, float znear, float zfar)
+    {
+        this->fov = fov;
+        this->znear = znear;
+        this->zfar = zfar;
+        matrices.perspective = glm::perspective(glm::radians(fov), aspect, znear, zfar);
+    };
 
-	void updateAspectRatio(float aspect)
-	{
-		matrices.perspective = glm::perspective(glm::radians(fov), aspect, znear, zfar);
-	}
+    void updateAspectRatio(float aspect)
+    {
+        matrices.perspective = glm::perspective(glm::radians(fov), aspect, znear, zfar);
+    }
 
-	void setPosition(glm::vec3 position)
-	{
-		this->position = position;
-		updateViewMatrix();
-	}
+    void setPosition(glm::vec3 position)
+    {
+        this->position = position;
+        updateViewMatrix();
+    }
 
-	void setRotation(glm::vec3 rotation)
-	{
-		this->rotation = rotation;
-		updateViewMatrix();
-	};
+    void setRotation(glm::vec3 rotation)
+    {
+        this->rotation = rotation;
+        updateViewMatrix();
+    };
 
-	void rotate(glm::vec3 delta)
-	{
-		this->rotation += delta;
-		updateViewMatrix();
-	}
+    void rotate(glm::vec3 delta)
+    {
+        this->rotation += delta;
+        updateViewMatrix();
+    }
 
-	void setTranslation(glm::vec3 translation)
-	{
-		this->position = translation;
-		updateViewMatrix();
-	};
+    void setTranslation(glm::vec3 translation)
+    {
+        this->position = translation;
+        updateViewMatrix();
+    };
 
-	void translate(glm::vec3 delta)
-	{
-		this->position += delta;
-		updateViewMatrix();
-	}
+    void translate(glm::vec3 delta)
+    {
+        this->position += delta;
+        updateViewMatrix();
+    }
 
-	void update(float deltaTime)
-	{
-		updated = false;
-		if (type == CameraType::firstperson)
-		{
-			if (moving())
-			{
-				glm::vec3 camFront;
-				camFront.x = -cos(glm::radians(rotation.x)) * sin(glm::radians(rotation.y));
-				camFront.y = sin(glm::radians(rotation.x));
-				camFront.z = cos(glm::radians(rotation.x)) * cos(glm::radians(rotation.y));
-				camFront = glm::normalize(camFront);
+    void update(float deltaTime)
+    {
+        updated = false;
+        if (type == CameraType::firstperson)
+        {
+            if (moving())
+            {
+                glm::vec3 camFront;
+                camFront.x = -cos(glm::radians(rotation.x)) * sin(glm::radians(rotation.y));
+                camFront.y = sin(glm::radians(rotation.x));
+                camFront.z = cos(glm::radians(rotation.x)) * cos(glm::radians(rotation.y));
+                camFront = glm::normalize(camFront);
 
-				float moveSpeed = deltaTime * movementSpeed;
+                float moveSpeed = deltaTime * movementSpeed;
 
-				if (keys.up)
-					position += camFront * moveSpeed;
-				if (keys.down)
-					position -= camFront * moveSpeed;
-				if (keys.left)
-					position -= glm::normalize(glm::cross(camFront, glm::vec3(0.0f, 1.0f, 0.0f))) * moveSpeed;
-				if (keys.right)
-					position += glm::normalize(glm::cross(camFront, glm::vec3(0.0f, 1.0f, 0.0f))) * moveSpeed;
+                if (keys.up)
+                    position += camFront * moveSpeed;
+                if (keys.down)
+                    position -= camFront * moveSpeed;
+                if (keys.left)
+                    position -= glm::normalize(glm::cross(camFront, glm::vec3(0.0f, 1.0f, 0.0f))) * moveSpeed;
+                if (keys.right)
+                    position += glm::normalize(glm::cross(camFront, glm::vec3(0.0f, 1.0f, 0.0f))) * moveSpeed;
 
-				updateViewMatrix();
-			}
-		}
-	};
+                updateViewMatrix();
+            }
+        }
+    };
 
-	// Update camera passing separate axis data (gamepad)
-	// Returns true if view or position has been changed
-	bool updatePad(glm::vec2 axisLeft, glm::vec2 axisRight, float deltaTime)
-	{
-		bool retVal = false;
+    // Update camera passing separate axis data (gamepad)
+    // Returns true if view or position has been changed
+    bool updatePad(glm::vec2 axisLeft, glm::vec2 axisRight, float deltaTime)
+    {
+        bool retVal = false;
 
-		if (type == CameraType::firstperson)
-		{
-			// Use the common console thumbstick layout		
-			// Left = view, right = move
+        if (type == CameraType::firstperson)
+        {
+            // Use the common console thumbstick layout
+            // Left = view, right = move
 
-			const float deadZone = 0.0015f;
-			const float range = 1.0f - deadZone;
+            const float deadZone = 0.0015f;
+            const float range = 1.0f - deadZone;
 
-			glm::vec3 camFront;
-			camFront.x = -cos(glm::radians(rotation.x)) * sin(glm::radians(rotation.y));
-			camFront.y = sin(glm::radians(rotation.x));
-			camFront.z = cos(glm::radians(rotation.x)) * cos(glm::radians(rotation.y));
-			camFront = glm::normalize(camFront);
+            glm::vec3 camFront;
+            camFront.x = -cos(glm::radians(rotation.x)) * sin(glm::radians(rotation.y));
+            camFront.y = sin(glm::radians(rotation.x));
+            camFront.z = cos(glm::radians(rotation.x)) * cos(glm::radians(rotation.y));
+            camFront = glm::normalize(camFront);
 
-			float moveSpeed = deltaTime * movementSpeed * 2.0f;
-			float rotSpeed = deltaTime * rotationSpeed * 50.0f;
-			 
-			// Move
-			if (fabsf(axisLeft.y) > deadZone)
-			{
-				float pos = (fabsf(axisLeft.y) - deadZone) / range;
-				position -= camFront * pos * ((axisLeft.y < 0.0f) ? -1.0f : 1.0f) * moveSpeed;
-				retVal = true;
-			}
-			if (fabsf(axisLeft.x) > deadZone)
-			{
-				float pos = (fabsf(axisLeft.x) - deadZone) / range;
-				position += glm::normalize(glm::cross(camFront, glm::vec3(0.0f, 1.0f, 0.0f))) * pos * ((axisLeft.x < 0.0f) ? -1.0f : 1.0f) * moveSpeed;
-				retVal = true;
-			}
+            float moveSpeed = deltaTime * movementSpeed * 2.0f;
+            float rotSpeed = deltaTime * rotationSpeed * 50.0f;
 
-			// Rotate
-			if (fabsf(axisRight.x) > deadZone)
-			{
-				float pos = (fabsf(axisRight.x) - deadZone) / range;
-				rotation.y += pos * ((axisRight.x < 0.0f) ? -1.0f : 1.0f) * rotSpeed;
-				retVal = true;
-			}
-			if (fabsf(axisRight.y) > deadZone)
-			{
-				float pos = (fabsf(axisRight.y) - deadZone) / range;
-				rotation.x -= pos * ((axisRight.y < 0.0f) ? -1.0f : 1.0f) * rotSpeed;
-				retVal = true;
-			}
-		}
-		else
-		{
-			// todo: move code from example base class for look-at
-		}
+            // Move
+            if (fabsf(axisLeft.y) > deadZone)
+            {
+                float pos = (fabsf(axisLeft.y) - deadZone) / range;
+                position -= camFront * pos * ((axisLeft.y < 0.0f) ? -1.0f : 1.0f) * moveSpeed;
+                retVal = true;
+            }
+            if (fabsf(axisLeft.x) > deadZone)
+            {
+                float pos = (fabsf(axisLeft.x) - deadZone) / range;
+                position += glm::normalize(glm::cross(camFront, glm::vec3(0.0f, 1.0f, 0.0f))) * pos * ((axisLeft.x < 0.0f) ? -1.0f : 1.0f) * moveSpeed;
+                retVal = true;
+            }
 
-		if (retVal)
-		{
-			updateViewMatrix();
-		}
+            // Rotate
+            if (fabsf(axisRight.x) > deadZone)
+            {
+                float pos = (fabsf(axisRight.x) - deadZone) / range;
+                rotation.y += pos * ((axisRight.x < 0.0f) ? -1.0f : 1.0f) * rotSpeed;
+                retVal = true;
+            }
+            if (fabsf(axisRight.y) > deadZone)
+            {
+                float pos = (fabsf(axisRight.y) - deadZone) / range;
+                rotation.x -= pos * ((axisRight.y < 0.0f) ? -1.0f : 1.0f) * rotSpeed;
+                retVal = true;
+            }
+        }
+        else
+        {
+            // todo: move code from example base class for look-at
+        }
 
-		return retVal;
-	}
+        if (retVal)
+        {
+            updateViewMatrix();
+        }
 
+        return retVal;
+    }
 };

--- a/base/frustum.hpp
+++ b/base/frustum.hpp
@@ -12,61 +12,61 @@
 
 namespace vks
 {
-	class Frustum
-	{
-	public:
-		enum side { LEFT = 0, RIGHT = 1, TOP = 2, BOTTOM = 3, BACK = 4, FRONT = 5 };
-		std::array<glm::vec4, 6> planes;
+    class Frustum
+    {
+    public:
+        enum side { LEFT = 0, RIGHT = 1, TOP = 2, BOTTOM = 3, BACK = 4, FRONT = 5 };
+        std::array<glm::vec4, 6> planes;
 
-		void update(glm::mat4 matrix)
-		{
-			planes[LEFT].x = matrix[0].w + matrix[0].x;
-			planes[LEFT].y = matrix[1].w + matrix[1].x;
-			planes[LEFT].z = matrix[2].w + matrix[2].x;
-			planes[LEFT].w = matrix[3].w + matrix[3].x;
+        void update(glm::mat4 matrix)
+        {
+            planes[LEFT].x = matrix[0].w + matrix[0].x;
+            planes[LEFT].y = matrix[1].w + matrix[1].x;
+            planes[LEFT].z = matrix[2].w + matrix[2].x;
+            planes[LEFT].w = matrix[3].w + matrix[3].x;
 
-			planes[RIGHT].x = matrix[0].w - matrix[0].x;
-			planes[RIGHT].y = matrix[1].w - matrix[1].x;
-			planes[RIGHT].z = matrix[2].w - matrix[2].x;
-			planes[RIGHT].w = matrix[3].w - matrix[3].x;
+            planes[RIGHT].x = matrix[0].w - matrix[0].x;
+            planes[RIGHT].y = matrix[1].w - matrix[1].x;
+            planes[RIGHT].z = matrix[2].w - matrix[2].x;
+            planes[RIGHT].w = matrix[3].w - matrix[3].x;
 
-			planes[TOP].x = matrix[0].w - matrix[0].y;
-			planes[TOP].y = matrix[1].w - matrix[1].y;
-			planes[TOP].z = matrix[2].w - matrix[2].y;
-			planes[TOP].w = matrix[3].w - matrix[3].y;
+            planes[TOP].x = matrix[0].w - matrix[0].y;
+            planes[TOP].y = matrix[1].w - matrix[1].y;
+            planes[TOP].z = matrix[2].w - matrix[2].y;
+            planes[TOP].w = matrix[3].w - matrix[3].y;
 
-			planes[BOTTOM].x = matrix[0].w + matrix[0].y;
-			planes[BOTTOM].y = matrix[1].w + matrix[1].y;
-			planes[BOTTOM].z = matrix[2].w + matrix[2].y;
-			planes[BOTTOM].w = matrix[3].w + matrix[3].y;
+            planes[BOTTOM].x = matrix[0].w + matrix[0].y;
+            planes[BOTTOM].y = matrix[1].w + matrix[1].y;
+            planes[BOTTOM].z = matrix[2].w + matrix[2].y;
+            planes[BOTTOM].w = matrix[3].w + matrix[3].y;
 
-			planes[BACK].x = matrix[0].w + matrix[0].z;
-			planes[BACK].y = matrix[1].w + matrix[1].z;
-			planes[BACK].z = matrix[2].w + matrix[2].z;
-			planes[BACK].w = matrix[3].w + matrix[3].z;
+            planes[BACK].x = matrix[0].w + matrix[0].z;
+            planes[BACK].y = matrix[1].w + matrix[1].z;
+            planes[BACK].z = matrix[2].w + matrix[2].z;
+            planes[BACK].w = matrix[3].w + matrix[3].z;
 
-			planes[FRONT].x = matrix[0].w - matrix[0].z;
-			planes[FRONT].y = matrix[1].w - matrix[1].z;
-			planes[FRONT].z = matrix[2].w - matrix[2].z;
-			planes[FRONT].w = matrix[3].w - matrix[3].z;
+            planes[FRONT].x = matrix[0].w - matrix[0].z;
+            planes[FRONT].y = matrix[1].w - matrix[1].z;
+            planes[FRONT].z = matrix[2].w - matrix[2].z;
+            planes[FRONT].w = matrix[3].w - matrix[3].z;
 
-			for (auto i = 0; i < planes.size(); i++)
-			{
-				float length = sqrtf(planes[i].x * planes[i].x + planes[i].y * planes[i].y + planes[i].z * planes[i].z);
-				planes[i] /= length;
-			}
-		}
-		
-		bool checkSphere(glm::vec3 pos, float radius)
-		{
-			for (auto i = 0; i < planes.size(); i++)
-			{
-				if ((planes[i].x * pos.x) + (planes[i].y * pos.y) + (planes[i].z * pos.z) + planes[i].w <= -radius)
-				{
-					return false;
-				}
-			}
-			return true;
-		}
-	};
-}
+            for (auto i = 0; i < planes.size(); i++)
+            {
+                float length = sqrtf(planes[i].x * planes[i].x + planes[i].y * planes[i].y + planes[i].z * planes[i].z);
+                planes[i] /= length;
+            }
+        }
+
+        bool checkSphere(glm::vec3 pos, float radius)
+        {
+            for (auto i = 0; i < planes.size(); i++)
+            {
+                if ((planes[i].x * pos.x) + (planes[i].y * pos.y) + (planes[i].z * pos.z) + planes[i].w <= -radius)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    };
+}  // namespace vks

--- a/base/keycodes.hpp
+++ b/base/keycodes.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #if defined(_WIN32)
-#define KEY_ESCAPE VK_ESCAPE 
+#define KEY_ESCAPE VK_ESCAPE
 #define KEY_F1 VK_F1
 #define KEY_F2 VK_F2
 #define KEY_F3 VK_F3

--- a/base/threadpool.hpp
+++ b/base/threadpool.hpp
@@ -15,107 +15,107 @@
 
 // make_unique is not available in C++11
 // Taken from Herb Sutter's blog (https://herbsutter.com/gotw/_102/)
-template<typename T, typename ...Args>
-std::unique_ptr<T> make_unique(Args&& ...args)
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
 {
-	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
 namespace vks
 {
-	class Thread
-	{
-	private:
-		bool destroying = false;
-		std::thread worker;
-		std::queue<std::function<void()>> jobQueue;
-		std::mutex queueMutex;
-		std::condition_variable condition;
+    class Thread
+    {
+    private:
+        bool destroying = false;
+        std::thread worker;
+        std::queue<std::function<void()>> jobQueue;
+        std::mutex queueMutex;
+        std::condition_variable condition;
 
-		// Loop through all remaining jobs
-		void queueLoop()
-		{
-			while (true)
-			{
-				std::function<void()> job;
-				{
-					std::unique_lock<std::mutex> lock(queueMutex);
-					condition.wait(lock, [this] { return !jobQueue.empty() || destroying; });
-					if (destroying)
-					{
-						break;
-					}
-					job = jobQueue.front();
-				}
+        // Loop through all remaining jobs
+        void queueLoop()
+        {
+            while (true)
+            {
+                std::function<void()> job;
+                {
+                    std::unique_lock<std::mutex> lock(queueMutex);
+                    condition.wait(lock, [this] { return !jobQueue.empty() || destroying; });
+                    if (destroying)
+                    {
+                        break;
+                    }
+                    job = jobQueue.front();
+                }
 
-				job();
+                job();
 
-				{
-					std::lock_guard<std::mutex> lock(queueMutex);
-					jobQueue.pop();
-					condition.notify_one();
-				}
-			}
-		}
+                {
+                    std::lock_guard<std::mutex> lock(queueMutex);
+                    jobQueue.pop();
+                    condition.notify_one();
+                }
+            }
+        }
 
-	public:
-		Thread()
-		{
-			worker = std::thread(&Thread::queueLoop, this);
-		}
+    public:
+        Thread()
+        {
+            worker = std::thread(&Thread::queueLoop, this);
+        }
 
-		~Thread()
-		{
-			if (worker.joinable())
-			{
-				wait();
-				queueMutex.lock();
-				destroying = true;
-				condition.notify_one();
-				queueMutex.unlock();
-				worker.join();
-			}
-		}
+        ~Thread()
+        {
+            if (worker.joinable())
+            {
+                wait();
+                queueMutex.lock();
+                destroying = true;
+                condition.notify_one();
+                queueMutex.unlock();
+                worker.join();
+            }
+        }
 
-		// Add a new job to the thread's queue
-		void addJob(std::function<void()> function)
-		{
-			std::lock_guard<std::mutex> lock(queueMutex);
-			jobQueue.push(std::move(function));
-			condition.notify_one();
-		}
+        // Add a new job to the thread's queue
+        void addJob(std::function<void()> function)
+        {
+            std::lock_guard<std::mutex> lock(queueMutex);
+            jobQueue.push(std::move(function));
+            condition.notify_one();
+        }
 
-		// Wait until all work items have been finished
-		void wait()
-		{
-			std::unique_lock<std::mutex> lock(queueMutex);
-			condition.wait(lock, [this]() { return jobQueue.empty(); });
-		}
-	};
-	
-	class ThreadPool
-	{
-	public:
-		std::vector<std::unique_ptr<Thread>> threads;
+        // Wait until all work items have been finished
+        void wait()
+        {
+            std::unique_lock<std::mutex> lock(queueMutex);
+            condition.wait(lock, [this]() { return jobQueue.empty(); });
+        }
+    };
 
-		// Sets the number of threads to be allocted in this pool
-		void setThreadCount(uint32_t count)
-		{
-			threads.clear();
-			for (auto i = 0; i < count; i++)
-			{
-				threads.push_back(make_unique<Thread>());
-			}
-		}
+    class ThreadPool
+    {
+    public:
+        std::vector<std::unique_ptr<Thread>> threads;
 
-		// Wait until all threads have finished their work items
-		void wait()
-		{
-			for (auto &thread : threads)
-			{
-				thread->wait();
-			}
-		}
-	};
+        // Sets the number of threads to be allocted in this pool
+        void setThreadCount(uint32_t count)
+        {
+            threads.clear();
+            for (auto i = 0; i < count; i++)
+            {
+                threads.push_back(make_unique<Thread>());
+            }
+        }
 
-}
+        // Wait until all threads have finished their work items
+        void wait()
+        {
+            for (auto& thread : threads)
+            {
+                thread->wait();
+            }
+        }
+    };
+
+}  // namespace vks

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -12,93 +12,101 @@ std::vector<const char*> VulkanExampleBase::args;
 
 VkResult VulkanExampleBase::createInstance(bool enableValidation)
 {
-	this->settings.validation = enableValidation;
+    this->settings.validation = enableValidation;
 
-	// Validation can also be forced via a define
+    // Validation can also be forced via a define
 #if defined(_VALIDATION)
-	this->settings.validation = true;
-#endif	
-
-	VkApplicationInfo appInfo = {};
-	appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-	appInfo.pApplicationName = name.c_str();
-	appInfo.pEngineName = name.c_str();
-	appInfo.apiVersion = apiVersion;
-
-	std::vector<const char*> instanceExtensions = { VK_KHR_SURFACE_EXTENSION_NAME };
-
-	// Enable surface extensions depending on os
-#if defined(_WIN32)
-	instanceExtensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-	instanceExtensions.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-#elif defined(_DIRECT2DISPLAY)
-	instanceExtensions.push_back(VK_KHR_DISPLAY_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	instanceExtensions.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_XCB_KHR)
-	instanceExtensions.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_IOS_MVK)
-	instanceExtensions.push_back(VK_MVK_IOS_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_MACOS_MVK)
-	instanceExtensions.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+    this->settings.validation = true;
 #endif
 
-	if (enabledInstanceExtensions.size() > 0) {
-		for (auto enabledExtension : enabledInstanceExtensions) {
-			instanceExtensions.push_back(enabledExtension);
-		}
-	}
+    VkApplicationInfo appInfo = {};
+    appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    appInfo.pApplicationName = name.c_str();
+    appInfo.pEngineName = name.c_str();
+    appInfo.apiVersion = apiVersion;
 
-	VkInstanceCreateInfo instanceCreateInfo = {};
-	instanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-	instanceCreateInfo.pNext = NULL;
-	instanceCreateInfo.pApplicationInfo = &appInfo;
-	if (instanceExtensions.size() > 0)
-	{
-		if (settings.validation)
-		{
-			instanceExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-		}
-		instanceCreateInfo.enabledExtensionCount = (uint32_t)instanceExtensions.size();
-		instanceCreateInfo.ppEnabledExtensionNames = instanceExtensions.data();
-	}
-	if (settings.validation)
-	{
-		// The VK_LAYER_KHRONOS_validation contains all current validation functionality.
-		// Note that on Android this layer requires at least NDK r20 
-		const char* validationLayerName = "VK_LAYER_KHRONOS_validation";
-		// Check if this layer is available at instance level
-		uint32_t instanceLayerCount;
-		vkEnumerateInstanceLayerProperties(&instanceLayerCount, nullptr);
-		std::vector<VkLayerProperties> instanceLayerProperties(instanceLayerCount);
-		vkEnumerateInstanceLayerProperties(&instanceLayerCount, instanceLayerProperties.data());
-		bool validationLayerPresent = false;
-		for (VkLayerProperties layer : instanceLayerProperties) {
-			if (strcmp(layer.layerName, validationLayerName) == 0) {
-				validationLayerPresent = true;
-				break;
-			}
-		}
-		if (validationLayerPresent) {
-			instanceCreateInfo.ppEnabledLayerNames = &validationLayerName;
-			instanceCreateInfo.enabledLayerCount = 1;
-		} else {
-			std::cerr << "Validation layer VK_LAYER_KHRONOS_validation not present, validation is disabled";
-		}
-	}
-	return vkCreateInstance(&instanceCreateInfo, nullptr, &instance);
+    std::vector<const char*> instanceExtensions = { VK_KHR_SURFACE_EXTENSION_NAME };
+
+    // Enable surface extensions depending on os
+#if defined(_WIN32)
+    instanceExtensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+#elif defined(VK_USE_PLATFORM_ANDROID_KHR)
+    instanceExtensions.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
+#elif defined(_DIRECT2DISPLAY)
+    instanceExtensions.push_back(VK_KHR_DISPLAY_EXTENSION_NAME);
+#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
+    instanceExtensions.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
+#elif defined(VK_USE_PLATFORM_XCB_KHR)
+    instanceExtensions.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+#elif defined(VK_USE_PLATFORM_IOS_MVK)
+    instanceExtensions.push_back(VK_MVK_IOS_SURFACE_EXTENSION_NAME);
+#elif defined(VK_USE_PLATFORM_MACOS_MVK)
+    instanceExtensions.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+#endif
+
+    if (enabledInstanceExtensions.size() > 0)
+    {
+        for (auto enabledExtension : enabledInstanceExtensions)
+        {
+            instanceExtensions.push_back(enabledExtension);
+        }
+    }
+
+    VkInstanceCreateInfo instanceCreateInfo = {};
+    instanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instanceCreateInfo.pNext = NULL;
+    instanceCreateInfo.pApplicationInfo = &appInfo;
+    if (instanceExtensions.size() > 0)
+    {
+        if (settings.validation)
+        {
+            instanceExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+        }
+        instanceCreateInfo.enabledExtensionCount = (uint32_t)instanceExtensions.size();
+        instanceCreateInfo.ppEnabledExtensionNames = instanceExtensions.data();
+    }
+    if (settings.validation)
+    {
+        // The VK_LAYER_KHRONOS_validation contains all current validation functionality.
+        // Note that on Android this layer requires at least NDK r20
+        const char* validationLayerName = "VK_LAYER_KHRONOS_validation";
+        // Check if this layer is available at instance level
+        uint32_t instanceLayerCount;
+        vkEnumerateInstanceLayerProperties(&instanceLayerCount, nullptr);
+        std::vector<VkLayerProperties> instanceLayerProperties(instanceLayerCount);
+        vkEnumerateInstanceLayerProperties(&instanceLayerCount, instanceLayerProperties.data());
+        bool validationLayerPresent = false;
+        for (VkLayerProperties layer : instanceLayerProperties)
+        {
+            if (strcmp(layer.layerName, validationLayerName) == 0)
+            {
+                validationLayerPresent = true;
+                break;
+            }
+        }
+        if (validationLayerPresent)
+        {
+            instanceCreateInfo.ppEnabledLayerNames = &validationLayerName;
+            instanceCreateInfo.enabledLayerCount = 1;
+        }
+        else
+        {
+            std::cerr << "Validation layer VK_LAYER_KHRONOS_validation not present, validation is disabled";
+        }
+    }
+    return vkCreateInstance(&instanceCreateInfo, nullptr, &instance);
 }
 
 std::string VulkanExampleBase::getWindowTitle()
 {
-	std::string device(deviceProperties.deviceName);
-	std::string windowTitle;
-	windowTitle = title + " - " + device;
-	if (!settings.overlay) {
-		windowTitle += " - " + std::to_string(frameCounter) + " fps";
-	}
-	return windowTitle;
+    std::string device(deviceProperties.deviceName);
+    std::string windowTitle;
+    windowTitle = title + " - " + device;
+    if (!settings.overlay)
+    {
+        windowTitle += " - " + std::to_string(frameCounter) + " fps";
+    }
+    return windowTitle;
 }
 
 #if !(defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
@@ -106,2183 +114,2186 @@ std::string VulkanExampleBase::getWindowTitle()
 const std::string VulkanExampleBase::getAssetPath()
 {
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	return "";
+    return "";
 #elif defined(VK_EXAMPLE_DATA_DIR)
-	return VK_EXAMPLE_DATA_DIR;
+    return VK_EXAMPLE_DATA_DIR;
 #else
-	return "./../data/";
+    return "./../data/";
 #endif
 }
 #endif
 
 bool VulkanExampleBase::checkCommandBuffers()
 {
-	for (auto& cmdBuffer : drawCmdBuffers)
-	{
-		if (cmdBuffer == VK_NULL_HANDLE)
-		{
-			return false;
-		}
-	}
-	return true;
+    for (auto& cmdBuffer : drawCmdBuffers)
+    {
+        if (cmdBuffer == VK_NULL_HANDLE)
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 void VulkanExampleBase::createCommandBuffers()
 {
-	// Create one command buffer for each swap chain image and reuse for rendering
-	drawCmdBuffers.resize(swapChain.imageCount);
+    // Create one command buffer for each swap chain image and reuse for rendering
+    drawCmdBuffers.resize(swapChain.imageCount);
 
-	VkCommandBufferAllocateInfo cmdBufAllocateInfo =
-		vks::initializers::commandBufferAllocateInfo(
-			cmdPool,
-			VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-			static_cast<uint32_t>(drawCmdBuffers.size()));
+    VkCommandBufferAllocateInfo cmdBufAllocateInfo =
+        vks::initializers::commandBufferAllocateInfo(cmdPool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, static_cast<uint32_t>(drawCmdBuffers.size()));
 
-	VK_CHECK_RESULT(vkAllocateCommandBuffers(device, &cmdBufAllocateInfo, drawCmdBuffers.data()));
+    VK_CHECK_RESULT(vkAllocateCommandBuffers(device, &cmdBufAllocateInfo, drawCmdBuffers.data()));
 }
 
 void VulkanExampleBase::destroyCommandBuffers()
 {
-	vkFreeCommandBuffers(device, cmdPool, static_cast<uint32_t>(drawCmdBuffers.size()), drawCmdBuffers.data());
+    vkFreeCommandBuffers(device, cmdPool, static_cast<uint32_t>(drawCmdBuffers.size()), drawCmdBuffers.data());
 }
 
 VkCommandBuffer VulkanExampleBase::createCommandBuffer(VkCommandBufferLevel level, bool begin)
 {
-	VkCommandBuffer cmdBuffer;
+    VkCommandBuffer cmdBuffer;
 
-	VkCommandBufferAllocateInfo cmdBufAllocateInfo =
-		vks::initializers::commandBufferAllocateInfo(
-			cmdPool,
-			level,
-			1);
+    VkCommandBufferAllocateInfo cmdBufAllocateInfo = vks::initializers::commandBufferAllocateInfo(cmdPool, level, 1);
 
-	VK_CHECK_RESULT(vkAllocateCommandBuffers(device, &cmdBufAllocateInfo, &cmdBuffer));
+    VK_CHECK_RESULT(vkAllocateCommandBuffers(device, &cmdBufAllocateInfo, &cmdBuffer));
 
-	// If requested, also start the new command buffer
-	if (begin)
-	{
-		VkCommandBufferBeginInfo cmdBufInfo = vks::initializers::commandBufferBeginInfo();
-		VK_CHECK_RESULT(vkBeginCommandBuffer(cmdBuffer, &cmdBufInfo));
-	}
+    // If requested, also start the new command buffer
+    if (begin)
+    {
+        VkCommandBufferBeginInfo cmdBufInfo = vks::initializers::commandBufferBeginInfo();
+        VK_CHECK_RESULT(vkBeginCommandBuffer(cmdBuffer, &cmdBufInfo));
+    }
 
-	return cmdBuffer;
+    return cmdBuffer;
 }
 
 void VulkanExampleBase::flushCommandBuffer(VkCommandBuffer commandBuffer, VkQueue queue, bool free)
 {
-	if (commandBuffer == VK_NULL_HANDLE)
-	{
-		return;
-	}
-	
-	VK_CHECK_RESULT(vkEndCommandBuffer(commandBuffer));
+    if (commandBuffer == VK_NULL_HANDLE)
+    {
+        return;
+    }
 
-	VkSubmitInfo submitInfo = {};
-	submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-	submitInfo.commandBufferCount = 1;
-	submitInfo.pCommandBuffers = &commandBuffer;
+    VK_CHECK_RESULT(vkEndCommandBuffer(commandBuffer));
 
-	VK_CHECK_RESULT(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
-	VK_CHECK_RESULT(vkQueueWaitIdle(queue));
+    VkSubmitInfo submitInfo = {};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &commandBuffer;
 
-	if (free)
-	{
-		vkFreeCommandBuffers(device, cmdPool, 1, &commandBuffer);
-	}
+    VK_CHECK_RESULT(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
+    VK_CHECK_RESULT(vkQueueWaitIdle(queue));
+
+    if (free)
+    {
+        vkFreeCommandBuffers(device, cmdPool, 1, &commandBuffer);
+    }
 }
 
 void VulkanExampleBase::createPipelineCache()
 {
-	VkPipelineCacheCreateInfo pipelineCacheCreateInfo = {};
-	pipelineCacheCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
-	VK_CHECK_RESULT(vkCreatePipelineCache(device, &pipelineCacheCreateInfo, nullptr, &pipelineCache));
+    VkPipelineCacheCreateInfo pipelineCacheCreateInfo = {};
+    pipelineCacheCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+    VK_CHECK_RESULT(vkCreatePipelineCache(device, &pipelineCacheCreateInfo, nullptr, &pipelineCache));
 }
 
 void VulkanExampleBase::prepare()
 {
-	if (vulkanDevice->enableDebugMarkers) {
-		vks::debugmarker::setup(device);
-	}
-	initSwapchain();
-	createCommandPool();
-	setupSwapChain();
-	createCommandBuffers();
-	createSynchronizationPrimitives();
-	setupDepthStencil();
-	setupRenderPass();
-	createPipelineCache();
-	setupFrameBuffer();
-	settings.overlay = settings.overlay && (!benchmark.active);
-	if (settings.overlay) {
-		UIOverlay.device = vulkanDevice;
-		UIOverlay.queue = queue;
-		UIOverlay.shaders = {
-			loadShader(getAssetPath() + "shaders/base/uioverlay.vert.spv", VK_SHADER_STAGE_VERTEX_BIT),
-			loadShader(getAssetPath() + "shaders/base/uioverlay.frag.spv", VK_SHADER_STAGE_FRAGMENT_BIT),
-		};
-		UIOverlay.prepareResources();
-		UIOverlay.preparePipeline(pipelineCache, renderPass);
-	}
+    if (vulkanDevice->enableDebugMarkers)
+    {
+        vks::debugmarker::setup(device);
+    }
+    initSwapchain();
+    createCommandPool();
+    setupSwapChain();
+    createCommandBuffers();
+    createSynchronizationPrimitives();
+    setupDepthStencil();
+    setupRenderPass();
+    createPipelineCache();
+    setupFrameBuffer();
+    settings.overlay = settings.overlay && (!benchmark.active);
+    if (settings.overlay)
+    {
+        UIOverlay.device = vulkanDevice;
+        UIOverlay.queue = queue;
+        UIOverlay.shaders = {
+            loadShader(getAssetPath() + "shaders/base/uioverlay.vert.spv", VK_SHADER_STAGE_VERTEX_BIT),
+            loadShader(getAssetPath() + "shaders/base/uioverlay.frag.spv", VK_SHADER_STAGE_FRAGMENT_BIT),
+        };
+        UIOverlay.prepareResources();
+        UIOverlay.preparePipeline(pipelineCache, renderPass);
+    }
 }
 
 VkPipelineShaderStageCreateInfo VulkanExampleBase::loadShader(std::string fileName, VkShaderStageFlagBits stage)
 {
-	VkPipelineShaderStageCreateInfo shaderStage = {};
-	shaderStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-	shaderStage.stage = stage;
+    VkPipelineShaderStageCreateInfo shaderStage = {};
+    shaderStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    shaderStage.stage = stage;
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	shaderStage.module = vks::tools::loadShader(androidApp->activity->assetManager, fileName.c_str(), device);
+    shaderStage.module = vks::tools::loadShader(androidApp->activity->assetManager, fileName.c_str(), device);
 #else
-	shaderStage.module = vks::tools::loadShader(fileName.c_str(), device);
+    shaderStage.module = vks::tools::loadShader(fileName.c_str(), device);
 #endif
-	shaderStage.pName = "main"; // todo : make param
-	assert(shaderStage.module != VK_NULL_HANDLE);
-	shaderModules.push_back(shaderStage.module);
-	return shaderStage;
+    shaderStage.pName = "main";  // todo : make param
+    assert(shaderStage.module != VK_NULL_HANDLE);
+    shaderModules.push_back(shaderStage.module);
+    return shaderStage;
 }
 
 void VulkanExampleBase::renderFrame()
 {
-	auto tStart = std::chrono::high_resolution_clock::now();
-	if (viewUpdated)
-	{
-		viewUpdated = false;
-		viewChanged();
-	}
+    auto tStart = std::chrono::high_resolution_clock::now();
+    if (viewUpdated)
+    {
+        viewUpdated = false;
+        viewChanged();
+    }
 
-	render();
-	frameCounter++;
-	auto tEnd = std::chrono::high_resolution_clock::now();
-	auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
-	frameTimer = (float)tDiff / 1000.0f;
-	camera.update(frameTimer);
-	if (camera.moving())
-	{
-		viewUpdated = true;
-	}
-	// Convert to clamped timer value
-	if (!paused)
-	{
-		timer += timerSpeed * frameTimer;
-		if (timer > 1.0)
-		{
-			timer -= 1.0f;
-		}
-	}
-	float fpsTimer = (float)(std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count());
-	if (fpsTimer > 1000.0f)
-	{
-		lastFPS = static_cast<uint32_t>((float)frameCounter * (1000.0f / fpsTimer));
+    render();
+    frameCounter++;
+    auto tEnd = std::chrono::high_resolution_clock::now();
+    auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
+    frameTimer = (float)tDiff / 1000.0f;
+    camera.update(frameTimer);
+    if (camera.moving())
+    {
+        viewUpdated = true;
+    }
+    // Convert to clamped timer value
+    if (!paused)
+    {
+        timer += timerSpeed * frameTimer;
+        if (timer > 1.0)
+        {
+            timer -= 1.0f;
+        }
+    }
+    float fpsTimer = (float)(std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count());
+    if (fpsTimer > 1000.0f)
+    {
+        lastFPS = static_cast<uint32_t>((float)frameCounter * (1000.0f / fpsTimer));
 #if defined(_WIN32)
-		if (!settings.overlay)	{
-			std::string windowTitle = getWindowTitle();
-			SetWindowText(window, windowTitle.c_str());
-		}
+        if (!settings.overlay)
+        {
+            std::string windowTitle = getWindowTitle();
+            SetWindowText(window, windowTitle.c_str());
+        }
 #endif
-		frameCounter = 0;
-		lastTimestamp = tEnd;
-	}
-	// TODO: Cap UI overlay update rates
-	updateOverlay();
+        frameCounter = 0;
+        lastTimestamp = tEnd;
+    }
+    // TODO: Cap UI overlay update rates
+    updateOverlay();
 }
 
 void VulkanExampleBase::renderLoop()
 {
-	if (benchmark.active) {
-		benchmark.run([=] { render(); }, vulkanDevice->properties);
-		vkDeviceWaitIdle(device);
-		if (benchmark.filename != "") {
-			benchmark.saveResults();
-		}
-		return;
-	}
+    if (benchmark.active)
+    {
+        benchmark.run([=] { render(); }, vulkanDevice->properties);
+        vkDeviceWaitIdle(device);
+        if (benchmark.filename != "")
+        {
+            benchmark.saveResults();
+        }
+        return;
+    }
 
-	destWidth = width;
-	destHeight = height;
-	lastTimestamp = std::chrono::high_resolution_clock::now();
+    destWidth = width;
+    destHeight = height;
+    lastTimestamp = std::chrono::high_resolution_clock::now();
 #if defined(_WIN32)
-	MSG msg;
-	bool quitMessageReceived = false;
-	while (!quitMessageReceived) {
-		while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-			if (msg.message == WM_QUIT) {
-				quitMessageReceived = true;
-				break;
-			}
-		}
-		if (!IsIconic(window)) {
-			renderFrame();
-		}
-	}
+    MSG msg;
+    bool quitMessageReceived = false;
+    while (!quitMessageReceived)
+    {
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+        {
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+            if (msg.message == WM_QUIT)
+            {
+                quitMessageReceived = true;
+                break;
+            }
+        }
+        if (!IsIconic(window))
+        {
+            renderFrame();
+        }
+    }
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-	while (1)
-	{
-		int ident;
-		int events;
-		struct android_poll_source* source;
-		bool destroy = false;
+    while (1)
+    {
+        int ident;
+        int events;
+        struct android_poll_source* source;
+        bool destroy = false;
 
-		focused = true;
+        focused = true;
 
-		while ((ident = ALooper_pollAll(focused ? 0 : -1, NULL, &events, (void**)&source)) >= 0)
-		{
-			if (source != NULL)
-			{
-				source->process(androidApp, source);
-			}
-			if (androidApp->destroyRequested != 0)
-			{
-				LOGD("Android app destroy requested");
-				destroy = true;
-				break;
-			}
-		}
+        while ((ident = ALooper_pollAll(focused ? 0 : -1, NULL, &events, (void**)&source)) >= 0)
+        {
+            if (source != NULL)
+            {
+                source->process(androidApp, source);
+            }
+            if (androidApp->destroyRequested != 0)
+            {
+                LOGD("Android app destroy requested");
+                destroy = true;
+                break;
+            }
+        }
 
-		// App destruction requested
-		// Exit loop, example will be destroyed in application main
-		if (destroy)
-		{
-			ANativeActivity_finish(androidApp->activity);
-			break;
-		}
+        // App destruction requested
+        // Exit loop, example will be destroyed in application main
+        if (destroy)
+        {
+            ANativeActivity_finish(androidApp->activity);
+            break;
+        }
 
-		// Render frame
-		if (prepared)
-		{
-			auto tStart = std::chrono::high_resolution_clock::now();
-			render();
-			frameCounter++;
-			auto tEnd = std::chrono::high_resolution_clock::now();
-			auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
-			frameTimer = tDiff / 1000.0f;
-			camera.update(frameTimer);
-			// Convert to clamped timer value
-			if (!paused)
-			{
-				timer += timerSpeed * frameTimer;
-				if (timer > 1.0)
-				{
-					timer -= 1.0f;
-				}
-			}
-			float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
-			if (fpsTimer > 1000.0f)
-			{
-				lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
-				frameCounter = 0;
-				lastTimestamp = tEnd;
-			}
+        // Render frame
+        if (prepared)
+        {
+            auto tStart = std::chrono::high_resolution_clock::now();
+            render();
+            frameCounter++;
+            auto tEnd = std::chrono::high_resolution_clock::now();
+            auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
+            frameTimer = tDiff / 1000.0f;
+            camera.update(frameTimer);
+            // Convert to clamped timer value
+            if (!paused)
+            {
+                timer += timerSpeed * frameTimer;
+                if (timer > 1.0)
+                {
+                    timer -= 1.0f;
+                }
+            }
+            float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
+            if (fpsTimer > 1000.0f)
+            {
+                lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
+                frameCounter = 0;
+                lastTimestamp = tEnd;
+            }
 
-			// TODO: Cap UI overlay update rates/only issue when update requested
-			updateOverlay();
+            // TODO: Cap UI overlay update rates/only issue when update requested
+            updateOverlay();
 
-			bool updateView = false;
+            bool updateView = false;
 
-			// Check touch state (for movement)
-			if (touchDown) {
-				touchTimer += frameTimer;
-			}
-			if (touchTimer >= 1.0) {
-				camera.keys.up = true;
-				viewChanged();
-			}
+            // Check touch state (for movement)
+            if (touchDown)
+            {
+                touchTimer += frameTimer;
+            }
+            if (touchTimer >= 1.0)
+            {
+                camera.keys.up = true;
+                viewChanged();
+            }
 
-			// Check gamepad state
-			const float deadZone = 0.0015f;
-			// todo : check if gamepad is present
-			// todo : time based and relative axis positions
-			if (camera.type != Camera::CameraType::firstperson)
-			{
-				// Rotate
-				if (std::abs(gamePadState.axisLeft.x) > deadZone)
-				{
-					rotation.y += gamePadState.axisLeft.x * 0.5f * rotationSpeed;
-					camera.rotate(glm::vec3(0.0f, gamePadState.axisLeft.x * 0.5f, 0.0f));
-					updateView = true;
-				}
-				if (std::abs(gamePadState.axisLeft.y) > deadZone)
-				{
-					rotation.x -= gamePadState.axisLeft.y * 0.5f * rotationSpeed;
-					camera.rotate(glm::vec3(gamePadState.axisLeft.y * 0.5f, 0.0f, 0.0f));
-					updateView = true;
-				}
-				// Zoom
-				if (std::abs(gamePadState.axisRight.y) > deadZone)
-				{
-					zoom -= gamePadState.axisRight.y * 0.01f * zoomSpeed;
-					updateView = true;
-				}
-				if (updateView)
-				{
-					viewChanged();
-				}
-			}
-			else
-			{
-				updateView = camera.updatePad(gamePadState.axisLeft, gamePadState.axisRight, frameTimer);
-				if (updateView)
-				{
-					viewChanged();
-				}
-			}
-		}
-	}
+            // Check gamepad state
+            const float deadZone = 0.0015f;
+            // todo : check if gamepad is present
+            // todo : time based and relative axis positions
+            if (camera.type != Camera::CameraType::firstperson)
+            {
+                // Rotate
+                if (std::abs(gamePadState.axisLeft.x) > deadZone)
+                {
+                    rotation.y += gamePadState.axisLeft.x * 0.5f * rotationSpeed;
+                    camera.rotate(glm::vec3(0.0f, gamePadState.axisLeft.x * 0.5f, 0.0f));
+                    updateView = true;
+                }
+                if (std::abs(gamePadState.axisLeft.y) > deadZone)
+                {
+                    rotation.x -= gamePadState.axisLeft.y * 0.5f * rotationSpeed;
+                    camera.rotate(glm::vec3(gamePadState.axisLeft.y * 0.5f, 0.0f, 0.0f));
+                    updateView = true;
+                }
+                // Zoom
+                if (std::abs(gamePadState.axisRight.y) > deadZone)
+                {
+                    zoom -= gamePadState.axisRight.y * 0.01f * zoomSpeed;
+                    updateView = true;
+                }
+                if (updateView)
+                {
+                    viewChanged();
+                }
+            }
+            else
+            {
+                updateView = camera.updatePad(gamePadState.axisLeft, gamePadState.axisRight, frameTimer);
+                if (updateView)
+                {
+                    viewChanged();
+                }
+            }
+        }
+    }
 #elif defined(_DIRECT2DISPLAY)
-	while (!quit)
-	{
-		auto tStart = std::chrono::high_resolution_clock::now();
-		if (viewUpdated)
-		{
-			viewUpdated = false;
-			viewChanged();
-		}
-		render();
-		frameCounter++;
-		auto tEnd = std::chrono::high_resolution_clock::now();
-		auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
-		frameTimer = tDiff / 1000.0f;
-		camera.update(frameTimer);
-		if (camera.moving())
-		{
-			viewUpdated = true;
-		}
-		// Convert to clamped timer value
-		if (!paused)
-		{
-			timer += timerSpeed * frameTimer;
-			if (timer > 1.0)
-			{
-				timer -= 1.0f;
-			}
-		}
-		float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
-		if (fpsTimer > 1000.0f)
-		{
-			lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
-			frameCounter = 0;
-			lastTimestamp = tEnd;
-		}
-		updateOverlay();
-	}
+    while (!quit)
+    {
+        auto tStart = std::chrono::high_resolution_clock::now();
+        if (viewUpdated)
+        {
+            viewUpdated = false;
+            viewChanged();
+        }
+        render();
+        frameCounter++;
+        auto tEnd = std::chrono::high_resolution_clock::now();
+        auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
+        frameTimer = tDiff / 1000.0f;
+        camera.update(frameTimer);
+        if (camera.moving())
+        {
+            viewUpdated = true;
+        }
+        // Convert to clamped timer value
+        if (!paused)
+        {
+            timer += timerSpeed * frameTimer;
+            if (timer > 1.0)
+            {
+                timer -= 1.0f;
+            }
+        }
+        float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
+        if (fpsTimer > 1000.0f)
+        {
+            lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
+            frameCounter = 0;
+            lastTimestamp = tEnd;
+        }
+        updateOverlay();
+    }
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	while (!quit)
-	{
-		auto tStart = std::chrono::high_resolution_clock::now();
-		if (viewUpdated)
-		{
-			viewUpdated = false;
-			viewChanged();
-		}
+    while (!quit)
+    {
+        auto tStart = std::chrono::high_resolution_clock::now();
+        if (viewUpdated)
+        {
+            viewUpdated = false;
+            viewChanged();
+        }
 
-		while (!configured)
-			wl_display_dispatch(display);
-		while (wl_display_prepare_read(display) != 0)
-			wl_display_dispatch_pending(display);
-		wl_display_flush(display);
-		wl_display_read_events(display);
-		wl_display_dispatch_pending(display);
+        while (!configured)
+            wl_display_dispatch(display);
+        while (wl_display_prepare_read(display) != 0)
+            wl_display_dispatch_pending(display);
+        wl_display_flush(display);
+        wl_display_read_events(display);
+        wl_display_dispatch_pending(display);
 
-		render();
-		frameCounter++;
-		auto tEnd = std::chrono::high_resolution_clock::now();
-		auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
-		frameTimer = tDiff / 1000.0f;
-		camera.update(frameTimer);
-		if (camera.moving())
-		{
-			viewUpdated = true;
-		}
-		// Convert to clamped timer value
-		if (!paused)
-		{
-			timer += timerSpeed * frameTimer;
-			if (timer > 1.0)
-			{
-				timer -= 1.0f;
-			}
-		}
-		float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
-		if (fpsTimer > 1000.0f)
-		{
-			if (!settings.overlay)
-			{
-				std::string windowTitle = getWindowTitle();
-				xdg_toplevel_set_title(xdg_toplevel, windowTitle.c_str());
-			}
-			lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
-			frameCounter = 0;
-			lastTimestamp = tEnd;
-		}
-		updateOverlay();
-	}
+        render();
+        frameCounter++;
+        auto tEnd = std::chrono::high_resolution_clock::now();
+        auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
+        frameTimer = tDiff / 1000.0f;
+        camera.update(frameTimer);
+        if (camera.moving())
+        {
+            viewUpdated = true;
+        }
+        // Convert to clamped timer value
+        if (!paused)
+        {
+            timer += timerSpeed * frameTimer;
+            if (timer > 1.0)
+            {
+                timer -= 1.0f;
+            }
+        }
+        float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
+        if (fpsTimer > 1000.0f)
+        {
+            if (!settings.overlay)
+            {
+                std::string windowTitle = getWindowTitle();
+                xdg_toplevel_set_title(xdg_toplevel, windowTitle.c_str());
+            }
+            lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
+            frameCounter = 0;
+            lastTimestamp = tEnd;
+        }
+        updateOverlay();
+    }
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-	xcb_flush(connection);
-	while (!quit)
-	{
-		auto tStart = std::chrono::high_resolution_clock::now();
-		if (viewUpdated)
-		{
-			viewUpdated = false;
-			viewChanged();
-		}
-		xcb_generic_event_t *event;
-		while ((event = xcb_poll_for_event(connection)))
-		{
-			handleEvent(event);
-			free(event);
-		}
-		render();
-		frameCounter++;
-		auto tEnd = std::chrono::high_resolution_clock::now();
-		auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
-		frameTimer = tDiff / 1000.0f;
-		camera.update(frameTimer);
-		if (camera.moving())
-		{
-			viewUpdated = true;
-		}
-		// Convert to clamped timer value
-		if (!paused)
-		{
-			timer += timerSpeed * frameTimer;
-			if (timer > 1.0)
-			{
-				timer -= 1.0f;
-			}
-		}
-		float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
-		if (fpsTimer > 1000.0f)
-		{
-			if (!settings.overlay)
-			{
-				std::string windowTitle = getWindowTitle();
-				xcb_change_property(connection, XCB_PROP_MODE_REPLACE,
-					window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8,
-					windowTitle.size(), windowTitle.c_str());
-			}
-			lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
-			frameCounter = 0;
-			lastTimestamp = tEnd;
-		}
-		updateOverlay();
-	}
+    xcb_flush(connection);
+    while (!quit)
+    {
+        auto tStart = std::chrono::high_resolution_clock::now();
+        if (viewUpdated)
+        {
+            viewUpdated = false;
+            viewChanged();
+        }
+        xcb_generic_event_t* event;
+        while ((event = xcb_poll_for_event(connection)))
+        {
+            handleEvent(event);
+            free(event);
+        }
+        render();
+        frameCounter++;
+        auto tEnd = std::chrono::high_resolution_clock::now();
+        auto tDiff = std::chrono::duration<double, std::milli>(tEnd - tStart).count();
+        frameTimer = tDiff / 1000.0f;
+        camera.update(frameTimer);
+        if (camera.moving())
+        {
+            viewUpdated = true;
+        }
+        // Convert to clamped timer value
+        if (!paused)
+        {
+            timer += timerSpeed * frameTimer;
+            if (timer > 1.0)
+            {
+                timer -= 1.0f;
+            }
+        }
+        float fpsTimer = std::chrono::duration<double, std::milli>(tEnd - lastTimestamp).count();
+        if (fpsTimer > 1000.0f)
+        {
+            if (!settings.overlay)
+            {
+                std::string windowTitle = getWindowTitle();
+                xcb_change_property(connection, XCB_PROP_MODE_REPLACE, window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8, windowTitle.size(), windowTitle.c_str());
+            }
+            lastFPS = (float)frameCounter * (1000.0f / fpsTimer);
+            frameCounter = 0;
+            lastTimestamp = tEnd;
+        }
+        updateOverlay();
+    }
 #endif
-	// Flush device to make sure all resources can be freed
-	if (device != VK_NULL_HANDLE) {
-		vkDeviceWaitIdle(device);
-	}
+    // Flush device to make sure all resources can be freed
+    if (device != VK_NULL_HANDLE)
+    {
+        vkDeviceWaitIdle(device);
+    }
 }
 
 void VulkanExampleBase::updateOverlay()
 {
-	if (!settings.overlay)
-		return;
+    if (!settings.overlay)
+        return;
 
-	ImGuiIO& io = ImGui::GetIO();
+    ImGuiIO& io = ImGui::GetIO();
 
-	io.DisplaySize = ImVec2((float)width, (float)height);
-	io.DeltaTime = frameTimer;
+    io.DisplaySize = ImVec2((float)width, (float)height);
+    io.DeltaTime = frameTimer;
 
-	io.MousePos = ImVec2(mousePos.x, mousePos.y);
-	io.MouseDown[0] = mouseButtons.left;
-	io.MouseDown[1] = mouseButtons.right;
+    io.MousePos = ImVec2(mousePos.x, mousePos.y);
+    io.MouseDown[0] = mouseButtons.left;
+    io.MouseDown[1] = mouseButtons.right;
 
-	ImGui::NewFrame();
+    ImGui::NewFrame();
 
-	ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0);
-	ImGui::SetNextWindowPos(ImVec2(10, 10));
-	ImGui::SetNextWindowSize(ImVec2(0, 0), ImGuiSetCond_FirstUseEver);
-	ImGui::Begin("Vulkan Example", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
-	ImGui::TextUnformatted(title.c_str());
-	ImGui::TextUnformatted(deviceProperties.deviceName);
-	ImGui::Text("%.2f ms/frame (%.1d fps)", (1000.0f / lastFPS), lastFPS);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0);
+    ImGui::SetNextWindowPos(ImVec2(10, 10));
+    ImGui::SetNextWindowSize(ImVec2(0, 0), ImGuiSetCond_FirstUseEver);
+    ImGui::Begin("Vulkan Example", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
+    ImGui::TextUnformatted(title.c_str());
+    ImGui::TextUnformatted(deviceProperties.deviceName);
+    ImGui::Text("%.2f ms/frame (%.1d fps)", (1000.0f / lastFPS), lastFPS);
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 5.0f * UIOverlay.scale));
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 5.0f * UIOverlay.scale));
 #endif
-	ImGui::PushItemWidth(110.0f * UIOverlay.scale);
-	OnUpdateUIOverlay(&UIOverlay);
-	ImGui::PopItemWidth();
+    ImGui::PushItemWidth(110.0f * UIOverlay.scale);
+    OnUpdateUIOverlay(&UIOverlay);
+    ImGui::PopItemWidth();
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	ImGui::PopStyleVar();
+    ImGui::PopStyleVar();
 #endif
 
-	ImGui::End();
-	ImGui::PopStyleVar();
-	ImGui::Render();
+    ImGui::End();
+    ImGui::PopStyleVar();
+    ImGui::Render();
 
-	if (UIOverlay.update() || UIOverlay.updated) {
-		buildCommandBuffers();
-		UIOverlay.updated = false;
-	}
+    if (UIOverlay.update() || UIOverlay.updated)
+    {
+        buildCommandBuffers();
+        UIOverlay.updated = false;
+    }
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	if (mouseButtons.left) {
-		mouseButtons.left = false;
-	}
+    if (mouseButtons.left)
+    {
+        mouseButtons.left = false;
+    }
 #endif
 }
 
 void VulkanExampleBase::drawUI(const VkCommandBuffer commandBuffer)
 {
-	if (settings.overlay) {
-		const VkViewport viewport = vks::initializers::viewport((float)width, (float)height, 0.0f, 1.0f);
-		const VkRect2D scissor = vks::initializers::rect2D(width, height, 0, 0);
-		vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
-		vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
+    if (settings.overlay)
+    {
+        const VkViewport viewport = vks::initializers::viewport((float)width, (float)height, 0.0f, 1.0f);
+        const VkRect2D scissor = vks::initializers::rect2D(width, height, 0, 0);
+        vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
+        vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
 
-		UIOverlay.draw(commandBuffer);
-	}
+        UIOverlay.draw(commandBuffer);
+    }
 }
 
 void VulkanExampleBase::prepareFrame()
 {
-	// Acquire the next image from the swap chain
-	VkResult result = swapChain.acquireNextImage(semaphores.presentComplete, &currentBuffer);
-	// Recreate the swapchain if it's no longer compatible with the surface (OUT_OF_DATE) or no longer optimal for presentation (SUBOPTIMAL)
-	if ((result == VK_ERROR_OUT_OF_DATE_KHR) || (result == VK_SUBOPTIMAL_KHR)) {
-		windowResize();
-	}
-	else {
-		VK_CHECK_RESULT(result);
-	}
+    // Acquire the next image from the swap chain
+    VkResult result = swapChain.acquireNextImage(semaphores.presentComplete, &currentBuffer);
+    // Recreate the swapchain if it's no longer compatible with the surface (OUT_OF_DATE) or no longer optimal for presentation (SUBOPTIMAL)
+    if ((result == VK_ERROR_OUT_OF_DATE_KHR) || (result == VK_SUBOPTIMAL_KHR))
+    {
+        windowResize();
+    }
+    else
+    {
+        VK_CHECK_RESULT(result);
+    }
 }
 
 void VulkanExampleBase::submitFrame()
 {
-	VkResult result = swapChain.queuePresent(queue, currentBuffer, semaphores.renderComplete);
-	if (!((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR))) {
-		if (result == VK_ERROR_OUT_OF_DATE_KHR) {
-			// Swap chain is no longer compatible with the surface and needs to be recreated
-			windowResize();
-			return;
-		} else {
-			VK_CHECK_RESULT(result);
-		}
-	}
-	VK_CHECK_RESULT(vkQueueWaitIdle(queue));
+    VkResult result = swapChain.queuePresent(queue, currentBuffer, semaphores.renderComplete);
+    if (!((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR)))
+    {
+        if (result == VK_ERROR_OUT_OF_DATE_KHR)
+        {
+            // Swap chain is no longer compatible with the surface and needs to be recreated
+            windowResize();
+            return;
+        }
+        else
+        {
+            VK_CHECK_RESULT(result);
+        }
+    }
+    VK_CHECK_RESULT(vkQueueWaitIdle(queue));
 }
 
 VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 {
 #if !defined(VK_USE_PLATFORM_ANDROID_KHR)
-	// Check for a valid asset path
-	struct stat info;
-	if (stat(getAssetPath().c_str(), &info) != 0)
-	{
+    // Check for a valid asset path
+    struct stat info;
+    if (stat(getAssetPath().c_str(), &info) != 0)
+    {
 #if defined(_WIN32)
-		std::string msg = "Could not locate asset path in \"" + getAssetPath() + "\" !";
-		MessageBox(NULL, msg.c_str(), "Fatal error", MB_OK | MB_ICONERROR);
+        std::string msg = "Could not locate asset path in \"" + getAssetPath() + "\" !";
+        MessageBox(NULL, msg.c_str(), "Fatal error", MB_OK | MB_ICONERROR);
 #else
-		std::cerr << "Error: Could not find asset path in " << getAssetPath() << std::endl;
+        std::cerr << "Error: Could not find asset path in " << getAssetPath() << std::endl;
 #endif
-		exit(-1);
-	}
+        exit(-1);
+    }
 #endif
 
-	settings.validation = enableValidation;
+    settings.validation = enableValidation;
 
-	char* numConvPtr;
+    char* numConvPtr;
 
-	// Parse command line arguments
-	for (size_t i = 0; i < args.size(); i++)
-	{
-		if (args[i] == std::string("-validation")) {
-			settings.validation = true;
-		}
-		if (args[i] == std::string("-vsync")) {
-			settings.vsync = true;
-		}
-		if ((args[i] == std::string("-f")) || (args[i] == std::string("--fullscreen"))) {
-			settings.fullscreen = true;
-		}
-		if ((args[i] == std::string("-w")) || (args[i] == std::string("-width"))) {
-			uint32_t w = strtol(args[i + 1], &numConvPtr, 10);
-			if (numConvPtr != args[i + 1]) { width = w; };
-		}
-		if ((args[i] == std::string("-h")) || (args[i] == std::string("-height"))) {
-			uint32_t h = strtol(args[i + 1], &numConvPtr, 10);
-			if (numConvPtr != args[i + 1]) { height = h; };
-		}
-		// Benchmark
-		if ((args[i] == std::string("-b")) || (args[i] == std::string("--benchmark"))) {
-			benchmark.active = true;
-			vks::tools::errorModeSilent = true;
-		}
-		// Warmup time (in seconds)
-		if ((args[i] == std::string("-bw")) || (args[i] == std::string("--benchwarmup"))) {
-			if (args.size() > i + 1) {
-				uint32_t num = strtol(args[i + 1], &numConvPtr, 10);
-				if (numConvPtr != args[i + 1]) {
-					benchmark.warmup = num;
-				} else {
-					std::cerr << "Warmup time for benchmark mode must be specified as a number!" << std::endl;
-				}
-			}
-		}
-		// Benchmark runtime (in seconds)
-		if ((args[i] == std::string("-br")) || (args[i] == std::string("--benchruntime"))) {
-			if (args.size() > i + 1) {
-				uint32_t num = strtol(args[i + 1], &numConvPtr, 10);
-				if (numConvPtr != args[i + 1]) {
-					benchmark.duration = num;
-				}
-				else {
-					std::cerr << "Benchmark run duration must be specified as a number!" << std::endl;
-				}
-			}
-		}
-		// Bench result save filename (overrides default)
-		if ((args[i] == std::string("-bf")) || (args[i] == std::string("--benchfilename"))) {
-			if (args.size() > i + 1) {
-				if (args[i + 1][0] == '-') {
-					std::cerr << "Filename for benchmark results must not start with a hyphen!" << std::endl;
-				} else {
-					benchmark.filename = args[i + 1];
-				}
-			}
-		}
-		// Output frame times to benchmark result file
-		if ((args[i] == std::string("-bt")) || (args[i] == std::string("--benchframetimes"))) {
-			benchmark.outputFrameTimes = true;
-		}
-	}
-	
+    // Parse command line arguments
+    for (size_t i = 0; i < args.size(); i++)
+    {
+        if (args[i] == std::string("-validation"))
+        {
+            settings.validation = true;
+        }
+        if (args[i] == std::string("-vsync"))
+        {
+            settings.vsync = true;
+        }
+        if ((args[i] == std::string("-f")) || (args[i] == std::string("--fullscreen")))
+        {
+            settings.fullscreen = true;
+        }
+        if ((args[i] == std::string("-w")) || (args[i] == std::string("-width")))
+        {
+            uint32_t w = strtol(args[i + 1], &numConvPtr, 10);
+            if (numConvPtr != args[i + 1])
+            {
+                width = w;
+            };
+        }
+        if ((args[i] == std::string("-h")) || (args[i] == std::string("-height")))
+        {
+            uint32_t h = strtol(args[i + 1], &numConvPtr, 10);
+            if (numConvPtr != args[i + 1])
+            {
+                height = h;
+            };
+        }
+        // Benchmark
+        if ((args[i] == std::string("-b")) || (args[i] == std::string("--benchmark")))
+        {
+            benchmark.active = true;
+            vks::tools::errorModeSilent = true;
+        }
+        // Warmup time (in seconds)
+        if ((args[i] == std::string("-bw")) || (args[i] == std::string("--benchwarmup")))
+        {
+            if (args.size() > i + 1)
+            {
+                uint32_t num = strtol(args[i + 1], &numConvPtr, 10);
+                if (numConvPtr != args[i + 1])
+                {
+                    benchmark.warmup = num;
+                }
+                else
+                {
+                    std::cerr << "Warmup time for benchmark mode must be specified as a number!" << std::endl;
+                }
+            }
+        }
+        // Benchmark runtime (in seconds)
+        if ((args[i] == std::string("-br")) || (args[i] == std::string("--benchruntime")))
+        {
+            if (args.size() > i + 1)
+            {
+                uint32_t num = strtol(args[i + 1], &numConvPtr, 10);
+                if (numConvPtr != args[i + 1])
+                {
+                    benchmark.duration = num;
+                }
+                else
+                {
+                    std::cerr << "Benchmark run duration must be specified as a number!" << std::endl;
+                }
+            }
+        }
+        // Bench result save filename (overrides default)
+        if ((args[i] == std::string("-bf")) || (args[i] == std::string("--benchfilename")))
+        {
+            if (args.size() > i + 1)
+            {
+                if (args[i + 1][0] == '-')
+                {
+                    std::cerr << "Filename for benchmark results must not start with a hyphen!" << std::endl;
+                }
+                else
+                {
+                    benchmark.filename = args[i + 1];
+                }
+            }
+        }
+        // Output frame times to benchmark result file
+        if ((args[i] == std::string("-bt")) || (args[i] == std::string("--benchframetimes")))
+        {
+            benchmark.outputFrameTimes = true;
+        }
+    }
+
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	// Vulkan library is loaded dynamically on Android
-	bool libLoaded = vks::android::loadVulkanLibrary();
-	assert(libLoaded);
+    // Vulkan library is loaded dynamically on Android
+    bool libLoaded = vks::android::loadVulkanLibrary();
+    assert(libLoaded);
 #elif defined(_DIRECT2DISPLAY)
 
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	initWaylandConnection();
+    initWaylandConnection();
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-	initxcbConnection();
+    initxcbConnection();
 #endif
 
 #if defined(_WIN32)
-	// Enable console if validation is active
-	// Debug message callback will output to it
-	if (this->settings.validation)
-	{
-		setupConsole("Vulkan validation output");
-	}
-	setupDPIAwareness();
+    // Enable console if validation is active
+    // Debug message callback will output to it
+    if (this->settings.validation)
+    {
+        setupConsole("Vulkan validation output");
+    }
+    setupDPIAwareness();
 #endif
 }
 
 VulkanExampleBase::~VulkanExampleBase()
 {
-	// Clean up Vulkan resources
-	swapChain.cleanup();
-	if (descriptorPool != VK_NULL_HANDLE)
-	{
-		vkDestroyDescriptorPool(device, descriptorPool, nullptr);
-	}
-	destroyCommandBuffers();
-	vkDestroyRenderPass(device, renderPass, nullptr);
-	for (uint32_t i = 0; i < frameBuffers.size(); i++)
-	{
-		vkDestroyFramebuffer(device, frameBuffers[i], nullptr);
-	}
+    // Clean up Vulkan resources
+    swapChain.cleanup();
+    if (descriptorPool != VK_NULL_HANDLE)
+    {
+        vkDestroyDescriptorPool(device, descriptorPool, nullptr);
+    }
+    destroyCommandBuffers();
+    vkDestroyRenderPass(device, renderPass, nullptr);
+    for (uint32_t i = 0; i < frameBuffers.size(); i++)
+    {
+        vkDestroyFramebuffer(device, frameBuffers[i], nullptr);
+    }
 
-	for (auto& shaderModule : shaderModules)
-	{
-		vkDestroyShaderModule(device, shaderModule, nullptr);
-	}
-	vkDestroyImageView(device, depthStencil.view, nullptr);
-	vkDestroyImage(device, depthStencil.image, nullptr);
-	vkFreeMemory(device, depthStencil.mem, nullptr);
+    for (auto& shaderModule : shaderModules)
+    {
+        vkDestroyShaderModule(device, shaderModule, nullptr);
+    }
+    vkDestroyImageView(device, depthStencil.view, nullptr);
+    vkDestroyImage(device, depthStencil.image, nullptr);
+    vkFreeMemory(device, depthStencil.mem, nullptr);
 
-	vkDestroyPipelineCache(device, pipelineCache, nullptr);
+    vkDestroyPipelineCache(device, pipelineCache, nullptr);
 
-	vkDestroyCommandPool(device, cmdPool, nullptr);
+    vkDestroyCommandPool(device, cmdPool, nullptr);
 
-	vkDestroySemaphore(device, semaphores.presentComplete, nullptr);
-	vkDestroySemaphore(device, semaphores.renderComplete, nullptr);
-	for (auto& fence : waitFences) {
-		vkDestroyFence(device, fence, nullptr);
-	}
+    vkDestroySemaphore(device, semaphores.presentComplete, nullptr);
+    vkDestroySemaphore(device, semaphores.renderComplete, nullptr);
+    for (auto& fence : waitFences)
+    {
+        vkDestroyFence(device, fence, nullptr);
+    }
 
-	if (settings.overlay) {
-		UIOverlay.freeResources();
-	}
+    if (settings.overlay)
+    {
+        UIOverlay.freeResources();
+    }
 
-	delete vulkanDevice;
+    delete vulkanDevice;
 
-	if (settings.validation)
-	{
-		vks::debug::freeDebugCallback(instance);
-	}
+    if (settings.validation)
+    {
+        vks::debug::freeDebugCallback(instance);
+    }
 
-	vkDestroyInstance(instance, nullptr);
+    vkDestroyInstance(instance, nullptr);
 
 #if defined(_DIRECT2DISPLAY)
 
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	xdg_toplevel_destroy(xdg_toplevel);
-	xdg_surface_destroy(xdg_surface);
-	wl_surface_destroy(surface);
-	if (keyboard)
-		wl_keyboard_destroy(keyboard);
-	if (pointer)
-		wl_pointer_destroy(pointer);
-	wl_seat_destroy(seat);
-	xdg_wm_base_destroy(shell);
-	wl_compositor_destroy(compositor);
-	wl_registry_destroy(registry);
-	wl_display_disconnect(display);
+    xdg_toplevel_destroy(xdg_toplevel);
+    xdg_surface_destroy(xdg_surface);
+    wl_surface_destroy(surface);
+    if (keyboard)
+        wl_keyboard_destroy(keyboard);
+    if (pointer)
+        wl_pointer_destroy(pointer);
+    wl_seat_destroy(seat);
+    xdg_wm_base_destroy(shell);
+    wl_compositor_destroy(compositor);
+    wl_registry_destroy(registry);
+    wl_display_disconnect(display);
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-	// todo : android cleanup (if required)
+    // todo : android cleanup (if required)
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-	xcb_destroy_window(connection, window);
-	xcb_disconnect(connection);
+    xcb_destroy_window(connection, window);
+    xcb_disconnect(connection);
 #endif
 }
 
 bool VulkanExampleBase::initVulkan()
 {
-	VkResult err;
+    VkResult err;
 
-	// Vulkan instance
-	err = createInstance(settings.validation);
-	if (err) {
-		vks::tools::exitFatal("Could not create Vulkan instance : \n" + vks::tools::errorString(err), err);
-		return false;
-	}
-
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	vks::android::loadVulkanFunctions(instance);
-#endif
-
-	// If requested, we enable the default validation layers for debugging
-	if (settings.validation)
-	{
-		// The report flags determine what type of messages for the layers will be displayed
-		// For validating (debugging) an appplication the error and warning bits should suffice
-		VkDebugReportFlagsEXT debugReportFlags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
-		// Additional flags include performance info, loader and layer debug messages, etc.
-		vks::debug::setupDebugging(instance, debugReportFlags, VK_NULL_HANDLE);
-	}
-
-	// Physical device
-	uint32_t gpuCount = 0;
-	// Get number of available physical devices
-	VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, nullptr));
-	assert(gpuCount > 0);
-	// Enumerate devices
-	std::vector<VkPhysicalDevice> physicalDevices(gpuCount);
-	err = vkEnumeratePhysicalDevices(instance, &gpuCount, physicalDevices.data());
-	if (err) {
-		vks::tools::exitFatal("Could not enumerate physical devices : \n" + vks::tools::errorString(err), err);
-		return false;
-	}
-
-	// GPU selection
-
-	// Select physical device to be used for the Vulkan example
-	// Defaults to the first device unless specified by command line
-	uint32_t selectedDevice = 0;
-
-#if !defined(VK_USE_PLATFORM_ANDROID_KHR)	
-	// GPU selection via command line argument
-	for (size_t i = 0; i < args.size(); i++)
-	{
-		// Select GPU
-		if ((args[i] == std::string("-g")) || (args[i] == std::string("-gpu")))
-		{
-			char* endptr;
-			uint32_t index = strtol(args[i + 1], &endptr, 10);
-			if (endptr != args[i + 1]) 
-			{ 
-				if (index > gpuCount - 1)
-				{
-					std::cerr << "Selected device index " << index << " is out of range, reverting to device 0 (use -listgpus to show available Vulkan devices)" << std::endl;
-				} 
-				else
-				{
-					std::cout << "Selected Vulkan device " << index << std::endl;
-					selectedDevice = index;
-				}
-			};
-			break;
-		}
-		// List available GPUs
-		if (args[i] == std::string("-listgpus"))
-		{
-			uint32_t gpuCount = 0;
-			VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, nullptr));
-			if (gpuCount == 0) 
-			{
-				std::cerr << "No Vulkan devices found!" << std::endl;
-			}
-			else 
-			{
-				// Enumerate devices
-				std::cout << "Available Vulkan devices" << std::endl;
-				std::vector<VkPhysicalDevice> devices(gpuCount);
-				VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, devices.data()));
-				for (uint32_t i = 0; i < gpuCount; i++) {
-					VkPhysicalDeviceProperties deviceProperties;
-					vkGetPhysicalDeviceProperties(devices[i], &deviceProperties);
-					std::cout << "Device [" << i << "] : " << deviceProperties.deviceName << std::endl;
-					std::cout << " Type: " << vks::tools::physicalDeviceTypeString(deviceProperties.deviceType) << std::endl;
-					std::cout << " API: " << (deviceProperties.apiVersion >> 22) << "." << ((deviceProperties.apiVersion >> 12) & 0x3ff) << "." << (deviceProperties.apiVersion & 0xfff) << std::endl;
-				}
-			}
-		}
-	}
-#endif
-
-	physicalDevice = physicalDevices[selectedDevice];
-
-	// Store properties (including limits), features and memory properties of the phyiscal device (so that examples can check against them)
-	vkGetPhysicalDeviceProperties(physicalDevice, &deviceProperties);
-	vkGetPhysicalDeviceFeatures(physicalDevice, &deviceFeatures);
-	vkGetPhysicalDeviceMemoryProperties(physicalDevice, &deviceMemoryProperties);
-
-	// Derived examples can override this to set actual features (based on above readings) to enable for logical device creation
-	getEnabledFeatures();
-
-	// Vulkan device creation
-	// This is handled by a separate class that gets a logical device representation
-	// and encapsulates functions related to a device
-	vulkanDevice = new vks::VulkanDevice(physicalDevice);
-	VkResult res = vulkanDevice->createLogicalDevice(enabledFeatures, enabledDeviceExtensions, deviceCreatepNextChain);
-	if (res != VK_SUCCESS) {
-		vks::tools::exitFatal("Could not create Vulkan device: \n" + vks::tools::errorString(res), res);
-		return false;
-	}
-	device = vulkanDevice->logicalDevice;
-
-	// Get a graphics queue from the device
-	vkGetDeviceQueue(device, vulkanDevice->queueFamilyIndices.graphics, 0, &queue);
-
-	// Find a suitable depth format
-	VkBool32 validDepthFormat = vks::tools::getSupportedDepthFormat(physicalDevice, &depthFormat);
-	assert(validDepthFormat);
-
-	swapChain.connect(instance, physicalDevice, device);
-
-	// Create synchronization objects
-	VkSemaphoreCreateInfo semaphoreCreateInfo = vks::initializers::semaphoreCreateInfo();
-	// Create a semaphore used to synchronize image presentation
-	// Ensures that the image is displayed before we start submitting new commands to the queu
-	VK_CHECK_RESULT(vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &semaphores.presentComplete));
-	// Create a semaphore used to synchronize command submission
-	// Ensures that the image is not presented until all commands have been sumbitted and executed
-	VK_CHECK_RESULT(vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &semaphores.renderComplete));
-
-	// Set up submit info structure
-	// Semaphores will stay the same during application lifetime
-	// Command buffer submission info is set by each example
-	submitInfo = vks::initializers::submitInfo();
-	submitInfo.pWaitDstStageMask = &submitPipelineStages;
-	submitInfo.waitSemaphoreCount = 1;
-	submitInfo.pWaitSemaphores = &semaphores.presentComplete;
-	submitInfo.signalSemaphoreCount = 1;
-	submitInfo.pSignalSemaphores = &semaphores.renderComplete;
+    // Vulkan instance
+    err = createInstance(settings.validation);
+    if (err)
+    {
+        vks::tools::exitFatal("Could not create Vulkan instance : \n" + vks::tools::errorString(err), err);
+        return false;
+    }
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-	// Get Android device name and manufacturer (to display along GPU name)
-	androidProduct = "";
-	char prop[PROP_VALUE_MAX+1];
-	int len = __system_property_get("ro.product.manufacturer", prop);
-	if (len > 0) {
-		androidProduct += std::string(prop) + " ";
-	};
-	len = __system_property_get("ro.product.model", prop);
-	if (len > 0) {
-		androidProduct += std::string(prop);
-	};
-	LOGD("androidProduct = %s", androidProduct.c_str());
-#endif	
+    vks::android::loadVulkanFunctions(instance);
+#endif
 
-	return true;
+    // If requested, we enable the default validation layers for debugging
+    if (settings.validation)
+    {
+        // The report flags determine what type of messages for the layers will be displayed
+        // For validating (debugging) an appplication the error and warning bits should suffice
+        VkDebugReportFlagsEXT debugReportFlags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
+        // Additional flags include performance info, loader and layer debug messages, etc.
+        vks::debug::setupDebugging(instance, debugReportFlags, VK_NULL_HANDLE);
+    }
+
+    // Physical device
+    uint32_t gpuCount = 0;
+    // Get number of available physical devices
+    VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, nullptr));
+    assert(gpuCount > 0);
+    // Enumerate devices
+    std::vector<VkPhysicalDevice> physicalDevices(gpuCount);
+    err = vkEnumeratePhysicalDevices(instance, &gpuCount, physicalDevices.data());
+    if (err)
+    {
+        vks::tools::exitFatal("Could not enumerate physical devices : \n" + vks::tools::errorString(err), err);
+        return false;
+    }
+
+    // GPU selection
+
+    // Select physical device to be used for the Vulkan example
+    // Defaults to the first device unless specified by command line
+    uint32_t selectedDevice = 0;
+
+#if !defined(VK_USE_PLATFORM_ANDROID_KHR)
+    // GPU selection via command line argument
+    for (size_t i = 0; i < args.size(); i++)
+    {
+        // Select GPU
+        if ((args[i] == std::string("-g")) || (args[i] == std::string("-gpu")))
+        {
+            char* endptr;
+            uint32_t index = strtol(args[i + 1], &endptr, 10);
+            if (endptr != args[i + 1])
+            {
+                if (index > gpuCount - 1)
+                {
+                    std::cerr << "Selected device index " << index << " is out of range, reverting to device 0 (use -listgpus to show available Vulkan devices)"
+                              << std::endl;
+                }
+                else
+                {
+                    std::cout << "Selected Vulkan device " << index << std::endl;
+                    selectedDevice = index;
+                }
+            };
+            break;
+        }
+        // List available GPUs
+        if (args[i] == std::string("-listgpus"))
+        {
+            uint32_t gpuCount = 0;
+            VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, nullptr));
+            if (gpuCount == 0)
+            {
+                std::cerr << "No Vulkan devices found!" << std::endl;
+            }
+            else
+            {
+                // Enumerate devices
+                std::cout << "Available Vulkan devices" << std::endl;
+                std::vector<VkPhysicalDevice> devices(gpuCount);
+                VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, devices.data()));
+                for (uint32_t i = 0; i < gpuCount; i++)
+                {
+                    VkPhysicalDeviceProperties deviceProperties;
+                    vkGetPhysicalDeviceProperties(devices[i], &deviceProperties);
+                    std::cout << "Device [" << i << "] : " << deviceProperties.deviceName << std::endl;
+                    std::cout << " Type: " << vks::tools::physicalDeviceTypeString(deviceProperties.deviceType) << std::endl;
+                    std::cout << " API: " << (deviceProperties.apiVersion >> 22) << "." << ((deviceProperties.apiVersion >> 12) & 0x3ff) << "."
+                              << (deviceProperties.apiVersion & 0xfff) << std::endl;
+                }
+            }
+        }
+    }
+#endif
+
+    physicalDevice = physicalDevices[selectedDevice];
+
+    // Store properties (including limits), features and memory properties of the phyiscal device (so that examples can check against them)
+    vkGetPhysicalDeviceProperties(physicalDevice, &deviceProperties);
+    vkGetPhysicalDeviceFeatures(physicalDevice, &deviceFeatures);
+    vkGetPhysicalDeviceMemoryProperties(physicalDevice, &deviceMemoryProperties);
+
+    // Derived examples can override this to set actual features (based on above readings) to enable for logical device creation
+    getEnabledFeatures();
+
+    // Vulkan device creation
+    // This is handled by a separate class that gets a logical device representation
+    // and encapsulates functions related to a device
+    vulkanDevice = new vks::VulkanDevice(physicalDevice);
+    VkResult res = vulkanDevice->createLogicalDevice(enabledFeatures, enabledDeviceExtensions, deviceCreatepNextChain);
+    if (res != VK_SUCCESS)
+    {
+        vks::tools::exitFatal("Could not create Vulkan device: \n" + vks::tools::errorString(res), res);
+        return false;
+    }
+    device = vulkanDevice->logicalDevice;
+
+    // Get a graphics queue from the device
+    vkGetDeviceQueue(device, vulkanDevice->queueFamilyIndices.graphics, 0, &queue);
+
+    // Find a suitable depth format
+    VkBool32 validDepthFormat = vks::tools::getSupportedDepthFormat(physicalDevice, &depthFormat);
+    assert(validDepthFormat);
+
+    swapChain.connect(instance, physicalDevice, device);
+
+    // Create synchronization objects
+    VkSemaphoreCreateInfo semaphoreCreateInfo = vks::initializers::semaphoreCreateInfo();
+    // Create a semaphore used to synchronize image presentation
+    // Ensures that the image is displayed before we start submitting new commands to the queu
+    VK_CHECK_RESULT(vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &semaphores.presentComplete));
+    // Create a semaphore used to synchronize command submission
+    // Ensures that the image is not presented until all commands have been sumbitted and executed
+    VK_CHECK_RESULT(vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &semaphores.renderComplete));
+
+    // Set up submit info structure
+    // Semaphores will stay the same during application lifetime
+    // Command buffer submission info is set by each example
+    submitInfo = vks::initializers::submitInfo();
+    submitInfo.pWaitDstStageMask = &submitPipelineStages;
+    submitInfo.waitSemaphoreCount = 1;
+    submitInfo.pWaitSemaphores = &semaphores.presentComplete;
+    submitInfo.signalSemaphoreCount = 1;
+    submitInfo.pSignalSemaphores = &semaphores.renderComplete;
+
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    // Get Android device name and manufacturer (to display along GPU name)
+    androidProduct = "";
+    char prop[PROP_VALUE_MAX + 1];
+    int len = __system_property_get("ro.product.manufacturer", prop);
+    if (len > 0)
+    {
+        androidProduct += std::string(prop) + " ";
+    };
+    len = __system_property_get("ro.product.model", prop);
+    if (len > 0)
+    {
+        androidProduct += std::string(prop);
+    };
+    LOGD("androidProduct = %s", androidProduct.c_str());
+#endif
+
+    return true;
 }
 
 #if defined(_WIN32)
 // Win32 : Sets up a console window and redirects standard output to it
 void VulkanExampleBase::setupConsole(std::string title)
 {
-	AllocConsole();
-	AttachConsole(GetCurrentProcessId());
-	FILE *stream;
-	freopen_s(&stream, "CONOUT$", "w+", stdout);
-	freopen_s(&stream, "CONOUT$", "w+", stderr);
-	SetConsoleTitle(TEXT(title.c_str()));
+    AllocConsole();
+    AttachConsole(GetCurrentProcessId());
+    FILE* stream;
+    freopen_s(&stream, "CONOUT$", "w+", stdout);
+    freopen_s(&stream, "CONOUT$", "w+", stderr);
+    SetConsoleTitle(TEXT(title.c_str()));
 }
 
 void VulkanExampleBase::setupDPIAwareness()
 {
-	typedef HRESULT *(__stdcall *SetProcessDpiAwarenessFunc)(PROCESS_DPI_AWARENESS);
+    typedef HRESULT*(__stdcall * SetProcessDpiAwarenessFunc)(PROCESS_DPI_AWARENESS);
 
-	HMODULE shCore = LoadLibraryA("Shcore.dll");
-	if (shCore)
-	{
-		SetProcessDpiAwarenessFunc setProcessDpiAwareness =
-			(SetProcessDpiAwarenessFunc)GetProcAddress(shCore, "SetProcessDpiAwareness");
+    HMODULE shCore = LoadLibraryA("Shcore.dll");
+    if (shCore)
+    {
+        SetProcessDpiAwarenessFunc setProcessDpiAwareness = (SetProcessDpiAwarenessFunc)GetProcAddress(shCore, "SetProcessDpiAwareness");
 
-		if (setProcessDpiAwareness != nullptr)
-		{
-			setProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
-		}
+        if (setProcessDpiAwareness != nullptr)
+        {
+            setProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+        }
 
-		FreeLibrary(shCore);
-	}
+        FreeLibrary(shCore);
+    }
 }
 
 HWND VulkanExampleBase::setupWindow(HINSTANCE hinstance, WNDPROC wndproc)
 {
-	this->windowInstance = hinstance;
+    this->windowInstance = hinstance;
 
-	WNDCLASSEX wndClass;
+    WNDCLASSEX wndClass;
 
-	wndClass.cbSize = sizeof(WNDCLASSEX);
-	wndClass.style = CS_HREDRAW | CS_VREDRAW;
-	wndClass.lpfnWndProc = wndproc;
-	wndClass.cbClsExtra = 0;
-	wndClass.cbWndExtra = 0;
-	wndClass.hInstance = hinstance;
-	wndClass.hIcon = LoadIcon(NULL, IDI_APPLICATION);
-	wndClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	wndClass.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
-	wndClass.lpszMenuName = NULL;
-	wndClass.lpszClassName = name.c_str();
-	wndClass.hIconSm = LoadIcon(NULL, IDI_WINLOGO);
+    wndClass.cbSize = sizeof(WNDCLASSEX);
+    wndClass.style = CS_HREDRAW | CS_VREDRAW;
+    wndClass.lpfnWndProc = wndproc;
+    wndClass.cbClsExtra = 0;
+    wndClass.cbWndExtra = 0;
+    wndClass.hInstance = hinstance;
+    wndClass.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+    wndClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+    wndClass.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
+    wndClass.lpszMenuName = NULL;
+    wndClass.lpszClassName = name.c_str();
+    wndClass.hIconSm = LoadIcon(NULL, IDI_WINLOGO);
 
-	if (!RegisterClassEx(&wndClass))
-	{
-		std::cout << "Could not register window class!\n";
-		fflush(stdout);
-		exit(1);
-	}
+    if (!RegisterClassEx(&wndClass))
+    {
+        std::cout << "Could not register window class!\n";
+        fflush(stdout);
+        exit(1);
+    }
 
-	int screenWidth = GetSystemMetrics(SM_CXSCREEN);
-	int screenHeight = GetSystemMetrics(SM_CYSCREEN);
+    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
+    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
 
-	if (settings.fullscreen)
-	{
-		DEVMODE dmScreenSettings;
-		memset(&dmScreenSettings, 0, sizeof(dmScreenSettings));
-		dmScreenSettings.dmSize = sizeof(dmScreenSettings);
-		dmScreenSettings.dmPelsWidth = screenWidth;
-		dmScreenSettings.dmPelsHeight = screenHeight;
-		dmScreenSettings.dmBitsPerPel = 32;
-		dmScreenSettings.dmFields = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT;
+    if (settings.fullscreen)
+    {
+        DEVMODE dmScreenSettings;
+        memset(&dmScreenSettings, 0, sizeof(dmScreenSettings));
+        dmScreenSettings.dmSize = sizeof(dmScreenSettings);
+        dmScreenSettings.dmPelsWidth = screenWidth;
+        dmScreenSettings.dmPelsHeight = screenHeight;
+        dmScreenSettings.dmBitsPerPel = 32;
+        dmScreenSettings.dmFields = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT;
 
-		if ((width != (uint32_t)screenWidth) && (height != (uint32_t)screenHeight))
-		{
-			if (ChangeDisplaySettings(&dmScreenSettings, CDS_FULLSCREEN) != DISP_CHANGE_SUCCESSFUL)
-			{
-				if (MessageBox(NULL, "Fullscreen Mode not supported!\n Switch to window mode?", "Error", MB_YESNO | MB_ICONEXCLAMATION) == IDYES)
-				{
-					settings.fullscreen = false;
-				}
-				else
-				{
-					return nullptr;
-				}
-			}
-		}
+        if ((width != (uint32_t)screenWidth) && (height != (uint32_t)screenHeight))
+        {
+            if (ChangeDisplaySettings(&dmScreenSettings, CDS_FULLSCREEN) != DISP_CHANGE_SUCCESSFUL)
+            {
+                if (MessageBox(NULL, "Fullscreen Mode not supported!\n Switch to window mode?", "Error", MB_YESNO | MB_ICONEXCLAMATION) == IDYES)
+                {
+                    settings.fullscreen = false;
+                }
+                else
+                {
+                    return nullptr;
+                }
+            }
+        }
+    }
 
-	}
+    DWORD dwExStyle;
+    DWORD dwStyle;
 
-	DWORD dwExStyle;
-	DWORD dwStyle;
+    if (settings.fullscreen)
+    {
+        dwExStyle = WS_EX_APPWINDOW;
+        dwStyle = WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+    }
+    else
+    {
+        dwExStyle = WS_EX_APPWINDOW | WS_EX_WINDOWEDGE;
+        dwStyle = WS_OVERLAPPEDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+    }
 
-	if (settings.fullscreen)
-	{
-		dwExStyle = WS_EX_APPWINDOW;
-		dwStyle = WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
-	}
-	else
-	{
-		dwExStyle = WS_EX_APPWINDOW | WS_EX_WINDOWEDGE;
-		dwStyle = WS_OVERLAPPEDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
-	}
+    RECT windowRect;
+    windowRect.left = 0L;
+    windowRect.top = 0L;
+    windowRect.right = settings.fullscreen ? (long)screenWidth : (long)width;
+    windowRect.bottom = settings.fullscreen ? (long)screenHeight : (long)height;
 
-	RECT windowRect;
-	windowRect.left = 0L;
-	windowRect.top = 0L;
-	windowRect.right = settings.fullscreen ? (long)screenWidth : (long)width;
-	windowRect.bottom = settings.fullscreen ? (long)screenHeight : (long)height;
+    AdjustWindowRectEx(&windowRect, dwStyle, FALSE, dwExStyle);
 
-	AdjustWindowRectEx(&windowRect, dwStyle, FALSE, dwExStyle);
+    std::string windowTitle = getWindowTitle();
+    window = CreateWindowEx(0, name.c_str(), windowTitle.c_str(), dwStyle | WS_CLIPSIBLINGS | WS_CLIPCHILDREN, 0, 0, windowRect.right - windowRect.left,
+                            windowRect.bottom - windowRect.top, NULL, NULL, hinstance, NULL);
 
-	std::string windowTitle = getWindowTitle();
-	window = CreateWindowEx(0,
-		name.c_str(),
-		windowTitle.c_str(),
-		dwStyle | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
-		0,
-		0,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,
-		NULL,
-		hinstance,
-		NULL);
+    if (!settings.fullscreen)
+    {
+        // Center on screen
+        uint32_t x = (GetSystemMetrics(SM_CXSCREEN) - windowRect.right) / 2;
+        uint32_t y = (GetSystemMetrics(SM_CYSCREEN) - windowRect.bottom) / 2;
+        SetWindowPos(window, 0, x, y, 0, 0, SWP_NOZORDER | SWP_NOSIZE);
+    }
 
-	if (!settings.fullscreen)
-	{
-		// Center on screen
-		uint32_t x = (GetSystemMetrics(SM_CXSCREEN) - windowRect.right) / 2;
-		uint32_t y = (GetSystemMetrics(SM_CYSCREEN) - windowRect.bottom) / 2;
-		SetWindowPos(window, 0, x, y, 0, 0, SWP_NOZORDER | SWP_NOSIZE);
-	}
+    if (!window)
+    {
+        printf("Could not create window!\n");
+        fflush(stdout);
+        return nullptr;
+        exit(1);
+    }
 
-	if (!window)
-	{
-		printf("Could not create window!\n");
-		fflush(stdout);
-		return nullptr;
-		exit(1);
-	}
+    ShowWindow(window, SW_SHOW);
+    SetForegroundWindow(window);
+    SetFocus(window);
 
-	ShowWindow(window, SW_SHOW);
-	SetForegroundWindow(window);
-	SetFocus(window);
-
-	return window;
+    return window;
 }
 
 void VulkanExampleBase::handleMessages(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-	case WM_CLOSE:
-		prepared = false;
-		DestroyWindow(hWnd);
-		PostQuitMessage(0);
-		break;
-	case WM_PAINT:
-		ValidateRect(window, NULL);
-		break;
-	case WM_KEYDOWN:
-		switch (wParam)
-		{
-		case KEY_P:
-			paused = !paused;
-			break;
-		case KEY_F1:
-			if (settings.overlay) {
-				UIOverlay.visible = !UIOverlay.visible;
-			}
-			break;
-		case KEY_ESCAPE:
-			PostQuitMessage(0);
-			break;
-		}
+    switch (uMsg)
+    {
+        case WM_CLOSE:
+            prepared = false;
+            DestroyWindow(hWnd);
+            PostQuitMessage(0);
+            break;
+        case WM_PAINT:
+            ValidateRect(window, NULL);
+            break;
+        case WM_KEYDOWN:
+            switch (wParam)
+            {
+                case KEY_P:
+                    paused = !paused;
+                    break;
+                case KEY_F1:
+                    if (settings.overlay)
+                    {
+                        UIOverlay.visible = !UIOverlay.visible;
+                    }
+                    break;
+                case KEY_ESCAPE:
+                    PostQuitMessage(0);
+                    break;
+            }
 
-		if (camera.firstperson)
-		{
-			switch (wParam)
-			{
-			case KEY_W:
-				camera.keys.up = true;
-				break;
-			case KEY_S:
-				camera.keys.down = true;
-				break;
-			case KEY_A:
-				camera.keys.left = true;
-				break;
-			case KEY_D:
-				camera.keys.right = true;
-				break;
-			}
-		}
+            if (camera.firstperson)
+            {
+                switch (wParam)
+                {
+                    case KEY_W:
+                        camera.keys.up = true;
+                        break;
+                    case KEY_S:
+                        camera.keys.down = true;
+                        break;
+                    case KEY_A:
+                        camera.keys.left = true;
+                        break;
+                    case KEY_D:
+                        camera.keys.right = true;
+                        break;
+                }
+            }
 
-		keyPressed((uint32_t)wParam);
-		break;
-	case WM_KEYUP:
-		if (camera.firstperson)
-		{
-			switch (wParam)
-			{
-			case KEY_W:
-				camera.keys.up = false;
-				break;
-			case KEY_S:
-				camera.keys.down = false;
-				break;
-			case KEY_A:
-				camera.keys.left = false;
-				break;
-			case KEY_D:
-				camera.keys.right = false;
-				break;
-			}
-		}
-		break;
-	case WM_LBUTTONDOWN:
-		mousePos = glm::vec2((float)LOWORD(lParam), (float)HIWORD(lParam));
-		mouseButtons.left = true;
-		break;
-	case WM_RBUTTONDOWN:
-		mousePos = glm::vec2((float)LOWORD(lParam), (float)HIWORD(lParam));
-		mouseButtons.right = true;
-		break;
-	case WM_MBUTTONDOWN:
-		mousePos = glm::vec2((float)LOWORD(lParam), (float)HIWORD(lParam));
-		mouseButtons.middle = true;
-		break;
-	case WM_LBUTTONUP:
-		mouseButtons.left = false;
-		break;
-	case WM_RBUTTONUP:
-		mouseButtons.right = false;
-		break;
-	case WM_MBUTTONUP:
-		mouseButtons.middle = false;
-		break;
-	case WM_MOUSEWHEEL:
-	{
-		short wheelDelta = GET_WHEEL_DELTA_WPARAM(wParam);
-		zoom += (float)wheelDelta * 0.005f * zoomSpeed;
-		camera.translate(glm::vec3(0.0f, 0.0f, (float)wheelDelta * 0.005f * zoomSpeed));
-		viewUpdated = true;
-		break;
-	}
-	case WM_MOUSEMOVE:
-	{
-		handleMouseMove(LOWORD(lParam), HIWORD(lParam));
-		break;
-	}
-	case WM_SIZE:
-		if ((prepared) && (wParam != SIZE_MINIMIZED))
-		{
-			if ((resizing) || ((wParam == SIZE_MAXIMIZED) || (wParam == SIZE_RESTORED)))
-			{
-				destWidth = LOWORD(lParam);
-				destHeight = HIWORD(lParam);
-				windowResize();
-			}
-		}
-		break;
-	case WM_ENTERSIZEMOVE:
-		resizing = true;
-		break;
-	case WM_EXITSIZEMOVE:
-		resizing = false;
-		break;
-	}
+            keyPressed((uint32_t)wParam);
+            break;
+        case WM_KEYUP:
+            if (camera.firstperson)
+            {
+                switch (wParam)
+                {
+                    case KEY_W:
+                        camera.keys.up = false;
+                        break;
+                    case KEY_S:
+                        camera.keys.down = false;
+                        break;
+                    case KEY_A:
+                        camera.keys.left = false;
+                        break;
+                    case KEY_D:
+                        camera.keys.right = false;
+                        break;
+                }
+            }
+            break;
+        case WM_LBUTTONDOWN:
+            mousePos = glm::vec2((float)LOWORD(lParam), (float)HIWORD(lParam));
+            mouseButtons.left = true;
+            break;
+        case WM_RBUTTONDOWN:
+            mousePos = glm::vec2((float)LOWORD(lParam), (float)HIWORD(lParam));
+            mouseButtons.right = true;
+            break;
+        case WM_MBUTTONDOWN:
+            mousePos = glm::vec2((float)LOWORD(lParam), (float)HIWORD(lParam));
+            mouseButtons.middle = true;
+            break;
+        case WM_LBUTTONUP:
+            mouseButtons.left = false;
+            break;
+        case WM_RBUTTONUP:
+            mouseButtons.right = false;
+            break;
+        case WM_MBUTTONUP:
+            mouseButtons.middle = false;
+            break;
+        case WM_MOUSEWHEEL: {
+            short wheelDelta = GET_WHEEL_DELTA_WPARAM(wParam);
+            zoom += (float)wheelDelta * 0.005f * zoomSpeed;
+            camera.translate(glm::vec3(0.0f, 0.0f, (float)wheelDelta * 0.005f * zoomSpeed));
+            viewUpdated = true;
+            break;
+        }
+        case WM_MOUSEMOVE: {
+            handleMouseMove(LOWORD(lParam), HIWORD(lParam));
+            break;
+        }
+        case WM_SIZE:
+            if ((prepared) && (wParam != SIZE_MINIMIZED))
+            {
+                if ((resizing) || ((wParam == SIZE_MAXIMIZED) || (wParam == SIZE_RESTORED)))
+                {
+                    destWidth = LOWORD(lParam);
+                    destHeight = HIWORD(lParam);
+                    windowResize();
+                }
+            }
+            break;
+        case WM_ENTERSIZEMOVE:
+            resizing = true;
+            break;
+        case WM_EXITSIZEMOVE:
+            resizing = false;
+            break;
+    }
 }
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
 int32_t VulkanExampleBase::handleAppInput(struct android_app* app, AInputEvent* event)
 {
-	VulkanExampleBase* vulkanExample = reinterpret_cast<VulkanExampleBase*>(app->userData);
-	if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_MOTION)
-	{
-		int32_t eventSource = AInputEvent_getSource(event);
-		switch (eventSource) {
-			case AINPUT_SOURCE_JOYSTICK: {
-				// Left thumbstick
-				vulkanExample->gamePadState.axisLeft.x = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_X, 0);
-				vulkanExample->gamePadState.axisLeft.y = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_Y, 0);
-				// Right thumbstick
-				vulkanExample->gamePadState.axisRight.x = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_Z, 0);
-				vulkanExample->gamePadState.axisRight.y = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_RZ, 0);
-				break;
-			}
+    VulkanExampleBase* vulkanExample = reinterpret_cast<VulkanExampleBase*>(app->userData);
+    if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_MOTION)
+    {
+        int32_t eventSource = AInputEvent_getSource(event);
+        switch (eventSource)
+        {
+            case AINPUT_SOURCE_JOYSTICK: {
+                // Left thumbstick
+                vulkanExample->gamePadState.axisLeft.x = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_X, 0);
+                vulkanExample->gamePadState.axisLeft.y = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_Y, 0);
+                // Right thumbstick
+                vulkanExample->gamePadState.axisRight.x = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_Z, 0);
+                vulkanExample->gamePadState.axisRight.y = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_RZ, 0);
+                break;
+            }
 
-			case AINPUT_SOURCE_TOUCHSCREEN: {
-				int32_t action = AMotionEvent_getAction(event);
+            case AINPUT_SOURCE_TOUCHSCREEN: {
+                int32_t action = AMotionEvent_getAction(event);
 
-				switch (action) {
-					case AMOTION_EVENT_ACTION_UP: {
-						vulkanExample->lastTapTime = AMotionEvent_getEventTime(event);
-						vulkanExample->touchPos.x = AMotionEvent_getX(event, 0);
-						vulkanExample->touchPos.y = AMotionEvent_getY(event, 0);
-						vulkanExample->touchTimer = 0.0;
-						vulkanExample->touchDown = false;
-						vulkanExample->camera.keys.up = false;
+                switch (action)
+                {
+                    case AMOTION_EVENT_ACTION_UP: {
+                        vulkanExample->lastTapTime = AMotionEvent_getEventTime(event);
+                        vulkanExample->touchPos.x = AMotionEvent_getX(event, 0);
+                        vulkanExample->touchPos.y = AMotionEvent_getY(event, 0);
+                        vulkanExample->touchTimer = 0.0;
+                        vulkanExample->touchDown = false;
+                        vulkanExample->camera.keys.up = false;
 
-						// Detect single tap
-						int64_t eventTime = AMotionEvent_getEventTime(event);
-						int64_t downTime = AMotionEvent_getDownTime(event);
-						if (eventTime - downTime <= vks::android::TAP_TIMEOUT) {
-							float deadZone = (160.f / vks::android::screenDensity) * vks::android::TAP_SLOP * vks::android::TAP_SLOP;
-							float x = AMotionEvent_getX(event, 0) - vulkanExample->touchPos.x;
-							float y = AMotionEvent_getY(event, 0) - vulkanExample->touchPos.y;
-							if ((x * x + y * y) < deadZone) {
-								vulkanExample->mouseButtons.left = true;
-							}
-						};
+                        // Detect single tap
+                        int64_t eventTime = AMotionEvent_getEventTime(event);
+                        int64_t downTime = AMotionEvent_getDownTime(event);
+                        if (eventTime - downTime <= vks::android::TAP_TIMEOUT)
+                        {
+                            float deadZone = (160.f / vks::android::screenDensity) * vks::android::TAP_SLOP * vks::android::TAP_SLOP;
+                            float x = AMotionEvent_getX(event, 0) - vulkanExample->touchPos.x;
+                            float y = AMotionEvent_getY(event, 0) - vulkanExample->touchPos.y;
+                            if ((x * x + y * y) < deadZone)
+                            {
+                                vulkanExample->mouseButtons.left = true;
+                            }
+                        };
 
-						return 1;
-						break;
-					}
-					case AMOTION_EVENT_ACTION_DOWN: {
-						// Detect double tap
-						int64_t eventTime = AMotionEvent_getEventTime(event);
-						if (eventTime - vulkanExample->lastTapTime <= vks::android::DOUBLE_TAP_TIMEOUT) {
-							float deadZone = (160.f / vks::android::screenDensity) * vks::android::DOUBLE_TAP_SLOP * vks::android::DOUBLE_TAP_SLOP;
-							float x = AMotionEvent_getX(event, 0) - vulkanExample->touchPos.x;
-							float y = AMotionEvent_getY(event, 0) - vulkanExample->touchPos.y;
-							if ((x * x + y * y) < deadZone) {
-								vulkanExample->keyPressed(TOUCH_DOUBLE_TAP);
-								vulkanExample->touchDown = false;
-							}
-						}
-						else {
-							vulkanExample->touchDown = true;
-						}
-						vulkanExample->touchPos.x = AMotionEvent_getX(event, 0);
-						vulkanExample->touchPos.y = AMotionEvent_getY(event, 0);
-						vulkanExample->mousePos.x = AMotionEvent_getX(event, 0);
-						vulkanExample->mousePos.y = AMotionEvent_getY(event, 0);
-						break;
-					}					
-					case AMOTION_EVENT_ACTION_MOVE: {
-						bool handled = false;
-						if (vulkanExample->settings.overlay) {
-							ImGuiIO& io = ImGui::GetIO();
-							handled = io.WantCaptureMouse;
-						}					
-						if (!handled) {
-							int32_t eventX = AMotionEvent_getX(event, 0);
-							int32_t eventY = AMotionEvent_getY(event, 0);
+                        return 1;
+                        break;
+                    }
+                    case AMOTION_EVENT_ACTION_DOWN: {
+                        // Detect double tap
+                        int64_t eventTime = AMotionEvent_getEventTime(event);
+                        if (eventTime - vulkanExample->lastTapTime <= vks::android::DOUBLE_TAP_TIMEOUT)
+                        {
+                            float deadZone = (160.f / vks::android::screenDensity) * vks::android::DOUBLE_TAP_SLOP * vks::android::DOUBLE_TAP_SLOP;
+                            float x = AMotionEvent_getX(event, 0) - vulkanExample->touchPos.x;
+                            float y = AMotionEvent_getY(event, 0) - vulkanExample->touchPos.y;
+                            if ((x * x + y * y) < deadZone)
+                            {
+                                vulkanExample->keyPressed(TOUCH_DOUBLE_TAP);
+                                vulkanExample->touchDown = false;
+                            }
+                        }
+                        else
+                        {
+                            vulkanExample->touchDown = true;
+                        }
+                        vulkanExample->touchPos.x = AMotionEvent_getX(event, 0);
+                        vulkanExample->touchPos.y = AMotionEvent_getY(event, 0);
+                        vulkanExample->mousePos.x = AMotionEvent_getX(event, 0);
+                        vulkanExample->mousePos.y = AMotionEvent_getY(event, 0);
+                        break;
+                    }
+                    case AMOTION_EVENT_ACTION_MOVE: {
+                        bool handled = false;
+                        if (vulkanExample->settings.overlay)
+                        {
+                            ImGuiIO& io = ImGui::GetIO();
+                            handled = io.WantCaptureMouse;
+                        }
+                        if (!handled)
+                        {
+                            int32_t eventX = AMotionEvent_getX(event, 0);
+                            int32_t eventY = AMotionEvent_getY(event, 0);
 
-							float deltaX = (float)(vulkanExample->touchPos.y - eventY) * vulkanExample->rotationSpeed * 0.5f;
-							float deltaY = (float)(vulkanExample->touchPos.x - eventX) * vulkanExample->rotationSpeed * 0.5f;
+                            float deltaX = (float)(vulkanExample->touchPos.y - eventY) * vulkanExample->rotationSpeed * 0.5f;
+                            float deltaY = (float)(vulkanExample->touchPos.x - eventX) * vulkanExample->rotationSpeed * 0.5f;
 
-							vulkanExample->camera.rotate(glm::vec3(deltaX, 0.0f, 0.0f));
-							vulkanExample->camera.rotate(glm::vec3(0.0f, -deltaY, 0.0f));
+                            vulkanExample->camera.rotate(glm::vec3(deltaX, 0.0f, 0.0f));
+                            vulkanExample->camera.rotate(glm::vec3(0.0f, -deltaY, 0.0f));
 
-							vulkanExample->rotation.x += deltaX;
-							vulkanExample->rotation.y -= deltaY;
+                            vulkanExample->rotation.x += deltaX;
+                            vulkanExample->rotation.y -= deltaY;
 
-							vulkanExample->viewChanged();
+                            vulkanExample->viewChanged();
 
-							vulkanExample->touchPos.x = eventX;
-							vulkanExample->touchPos.y = eventY;
-						}
-						break;
-					}
-					default:
-						return 1;
-						break;
-				}
-			}
+                            vulkanExample->touchPos.x = eventX;
+                            vulkanExample->touchPos.y = eventY;
+                        }
+                        break;
+                    }
+                    default:
+                        return 1;
+                        break;
+                }
+            }
 
-			return 1;
-		}
-	}
+                return 1;
+        }
+    }
 
-	if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_KEY)
-	{
-		int32_t keyCode = AKeyEvent_getKeyCode((const AInputEvent*)event);
-		int32_t action = AKeyEvent_getAction((const AInputEvent*)event);
-		int32_t button = 0;
+    if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_KEY)
+    {
+        int32_t keyCode = AKeyEvent_getKeyCode((const AInputEvent*)event);
+        int32_t action = AKeyEvent_getAction((const AInputEvent*)event);
+        int32_t button = 0;
 
-		if (action == AKEY_EVENT_ACTION_UP)
-			return 0;
+        if (action == AKEY_EVENT_ACTION_UP)
+            return 0;
 
-		switch (keyCode)
-		{
-		case AKEYCODE_BUTTON_A:
-			vulkanExample->keyPressed(GAMEPAD_BUTTON_A);
-			break;
-		case AKEYCODE_BUTTON_B:
-			vulkanExample->keyPressed(GAMEPAD_BUTTON_B);
-			break;
-		case AKEYCODE_BUTTON_X:
-			vulkanExample->keyPressed(GAMEPAD_BUTTON_X);
-			break;
-		case AKEYCODE_BUTTON_Y:
-			vulkanExample->keyPressed(GAMEPAD_BUTTON_Y);
-			break;
-		case AKEYCODE_BUTTON_L1:
-			vulkanExample->keyPressed(GAMEPAD_BUTTON_L1);
-			break;
-		case AKEYCODE_BUTTON_R1:
-			vulkanExample->keyPressed(GAMEPAD_BUTTON_R1);
-			break;
-		case AKEYCODE_BUTTON_START:
-			vulkanExample->paused = !vulkanExample->paused;
-			break;
-		};
+        switch (keyCode)
+        {
+            case AKEYCODE_BUTTON_A:
+                vulkanExample->keyPressed(GAMEPAD_BUTTON_A);
+                break;
+            case AKEYCODE_BUTTON_B:
+                vulkanExample->keyPressed(GAMEPAD_BUTTON_B);
+                break;
+            case AKEYCODE_BUTTON_X:
+                vulkanExample->keyPressed(GAMEPAD_BUTTON_X);
+                break;
+            case AKEYCODE_BUTTON_Y:
+                vulkanExample->keyPressed(GAMEPAD_BUTTON_Y);
+                break;
+            case AKEYCODE_BUTTON_L1:
+                vulkanExample->keyPressed(GAMEPAD_BUTTON_L1);
+                break;
+            case AKEYCODE_BUTTON_R1:
+                vulkanExample->keyPressed(GAMEPAD_BUTTON_R1);
+                break;
+            case AKEYCODE_BUTTON_START:
+                vulkanExample->paused = !vulkanExample->paused;
+                break;
+        };
 
-		LOGD("Button %d pressed", keyCode);
-	}
+        LOGD("Button %d pressed", keyCode);
+    }
 
-	return 0;
+    return 0;
 }
 
-void VulkanExampleBase::handleAppCommand(android_app * app, int32_t cmd)
+void VulkanExampleBase::handleAppCommand(android_app* app, int32_t cmd)
 {
-	assert(app->userData != NULL);
-	VulkanExampleBase* vulkanExample = reinterpret_cast<VulkanExampleBase*>(app->userData);
-	switch (cmd)
-	{
-	case APP_CMD_SAVE_STATE:
-		LOGD("APP_CMD_SAVE_STATE");
-		/*
+    assert(app->userData != NULL);
+    VulkanExampleBase* vulkanExample = reinterpret_cast<VulkanExampleBase*>(app->userData);
+    switch (cmd)
+    {
+        case APP_CMD_SAVE_STATE:
+            LOGD("APP_CMD_SAVE_STATE");
+            /*
 		vulkanExample->app->savedState = malloc(sizeof(struct saved_state));
 		*((struct saved_state*)vulkanExample->app->savedState) = vulkanExample->state;
 		vulkanExample->app->savedStateSize = sizeof(struct saved_state);
 		*/
-		break;
-	case APP_CMD_INIT_WINDOW:
-		LOGD("APP_CMD_INIT_WINDOW");
-		if (androidApp->window != NULL)
-		{
-			if (vulkanExample->initVulkan()) {
-				vulkanExample->prepare();
-				assert(vulkanExample->prepared);
-			}
-			else {
-				LOGE("Could not initialize Vulkan, exiting!");
-				androidApp->destroyRequested = 1;
-			}
-		}
-		else
-		{
-			LOGE("No window assigned!");
-		}
-		break;
-	case APP_CMD_LOST_FOCUS:
-		LOGD("APP_CMD_LOST_FOCUS");
-		vulkanExample->focused = false;
-		break;
-	case APP_CMD_GAINED_FOCUS:
-		LOGD("APP_CMD_GAINED_FOCUS");
-		vulkanExample->focused = true;
-		break;
-	case APP_CMD_TERM_WINDOW:
-		// Window is hidden or closed, clean up resources
-		LOGD("APP_CMD_TERM_WINDOW");
-		if (vulkanExample->prepared) {
-			vulkanExample->swapChain.cleanup();
-		}
-		break;
-	}
+            break;
+        case APP_CMD_INIT_WINDOW:
+            LOGD("APP_CMD_INIT_WINDOW");
+            if (androidApp->window != NULL)
+            {
+                if (vulkanExample->initVulkan())
+                {
+                    vulkanExample->prepare();
+                    assert(vulkanExample->prepared);
+                }
+                else
+                {
+                    LOGE("Could not initialize Vulkan, exiting!");
+                    androidApp->destroyRequested = 1;
+                }
+            }
+            else
+            {
+                LOGE("No window assigned!");
+            }
+            break;
+        case APP_CMD_LOST_FOCUS:
+            LOGD("APP_CMD_LOST_FOCUS");
+            vulkanExample->focused = false;
+            break;
+        case APP_CMD_GAINED_FOCUS:
+            LOGD("APP_CMD_GAINED_FOCUS");
+            vulkanExample->focused = true;
+            break;
+        case APP_CMD_TERM_WINDOW:
+            // Window is hidden or closed, clean up resources
+            LOGD("APP_CMD_TERM_WINDOW");
+            if (vulkanExample->prepared)
+            {
+                vulkanExample->swapChain.cleanup();
+            }
+            break;
+    }
 }
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
 void* VulkanExampleBase::setupWindow(void* view)
 {
-	this->view = view;
-	return view;
+    this->view = view;
+    return view;
 }
 #elif defined(_DIRECT2DISPLAY)
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-/*static*/void VulkanExampleBase::registryGlobalCb(void *data,
-		wl_registry *registry, uint32_t name, const char *interface,
-		uint32_t version)
+/*static*/ void VulkanExampleBase::registryGlobalCb(void* data, wl_registry* registry, uint32_t name, const char* interface, uint32_t version)
 {
-	VulkanExampleBase *self = reinterpret_cast<VulkanExampleBase *>(data);
-	self->registryGlobal(registry, name, interface, version);
+    VulkanExampleBase* self = reinterpret_cast<VulkanExampleBase*>(data);
+    self->registryGlobal(registry, name, interface, version);
 }
 
-/*static*/void VulkanExampleBase::seatCapabilitiesCb(void *data, wl_seat *seat,
-		uint32_t caps)
+/*static*/ void VulkanExampleBase::seatCapabilitiesCb(void* data, wl_seat* seat, uint32_t caps)
 {
-	VulkanExampleBase *self = reinterpret_cast<VulkanExampleBase *>(data);
-	self->seatCapabilities(seat, caps);
+    VulkanExampleBase* self = reinterpret_cast<VulkanExampleBase*>(data);
+    self->seatCapabilities(seat, caps);
 }
 
-/*static*/void VulkanExampleBase::pointerEnterCb(void *data,
-		wl_pointer *pointer, uint32_t serial, wl_surface *surface,
-		wl_fixed_t sx, wl_fixed_t sy)
+/*static*/ void VulkanExampleBase::pointerEnterCb(void* data, wl_pointer* pointer, uint32_t serial, wl_surface* surface, wl_fixed_t sx, wl_fixed_t sy)
+{}
+
+/*static*/ void VulkanExampleBase::pointerLeaveCb(void* data, wl_pointer* pointer, uint32_t serial, wl_surface* surface)
+{}
+
+/*static*/ void VulkanExampleBase::pointerMotionCb(void* data, wl_pointer* pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
 {
+    VulkanExampleBase* self = reinterpret_cast<VulkanExampleBase*>(data);
+    self->pointerMotion(pointer, time, sx, sy);
+}
+void VulkanExampleBase::pointerMotion(wl_pointer* pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
+{
+    handleMouseMove(wl_fixed_to_int(sx), wl_fixed_to_int(sy));
 }
 
-/*static*/void VulkanExampleBase::pointerLeaveCb(void *data,
-		wl_pointer *pointer, uint32_t serial, wl_surface *surface)
+/*static*/ void VulkanExampleBase::pointerButtonCb(void* data, wl_pointer* pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
 {
+    VulkanExampleBase* self = reinterpret_cast<VulkanExampleBase*>(data);
+    self->pointerButton(pointer, serial, time, button, state);
 }
 
-/*static*/void VulkanExampleBase::pointerMotionCb(void *data,
-		wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
+void VulkanExampleBase::pointerButton(struct wl_pointer* pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
 {
-	VulkanExampleBase *self = reinterpret_cast<VulkanExampleBase *>(data);
-	self->pointerMotion(pointer, time, sx, sy);
-}
-void VulkanExampleBase::pointerMotion(wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
-{
-	handleMouseMove(wl_fixed_to_int(sx), wl_fixed_to_int(sy));
-}
-
-/*static*/void VulkanExampleBase::pointerButtonCb(void *data,
-		wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button,
-		uint32_t state)
-{
-	VulkanExampleBase *self = reinterpret_cast<VulkanExampleBase *>(data);
-	self->pointerButton(pointer, serial, time, button, state);
-}
-
-void VulkanExampleBase::pointerButton(struct wl_pointer *pointer,
-		uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
-{
-	switch (button)
-	{
-	case BTN_LEFT:
-		mouseButtons.left = !!state;
-		break;
-	case BTN_MIDDLE:
-		mouseButtons.middle = !!state;
-		break;
-	case BTN_RIGHT:
-		mouseButtons.right = !!state;
-		break;
-	default:
-		break;
-	}
+    switch (button)
+    {
+        case BTN_LEFT:
+            mouseButtons.left = !!state;
+            break;
+        case BTN_MIDDLE:
+            mouseButtons.middle = !!state;
+            break;
+        case BTN_RIGHT:
+            mouseButtons.right = !!state;
+            break;
+        default:
+            break;
+    }
 }
 
-/*static*/void VulkanExampleBase::pointerAxisCb(void *data,
-		wl_pointer *pointer, uint32_t time, uint32_t axis,
-		wl_fixed_t value)
+/*static*/ void VulkanExampleBase::pointerAxisCb(void* data, wl_pointer* pointer, uint32_t time, uint32_t axis, wl_fixed_t value)
 {
-	VulkanExampleBase *self = reinterpret_cast<VulkanExampleBase *>(data);
-	self->pointerAxis(pointer, time, axis, value);
+    VulkanExampleBase* self = reinterpret_cast<VulkanExampleBase*>(data);
+    self->pointerAxis(pointer, time, axis, value);
 }
 
-void VulkanExampleBase::pointerAxis(wl_pointer *pointer, uint32_t time,
-		uint32_t axis, wl_fixed_t value)
+void VulkanExampleBase::pointerAxis(wl_pointer* pointer, uint32_t time, uint32_t axis, wl_fixed_t value)
 {
-	double d = wl_fixed_to_double(value);
-	switch (axis)
-	{
-	case REL_X:
-		zoom += d * 0.005f * zoomSpeed;
-		camera.translate(glm::vec3(0.0f, 0.0f, d * 0.005f * zoomSpeed));
-		viewUpdated = true;
-		break;
-	default:
-		break;
-	}
+    double d = wl_fixed_to_double(value);
+    switch (axis)
+    {
+        case REL_X:
+            zoom += d * 0.005f * zoomSpeed;
+            camera.translate(glm::vec3(0.0f, 0.0f, d * 0.005f * zoomSpeed));
+            viewUpdated = true;
+            break;
+        default:
+            break;
+    }
 }
 
-/*static*/void VulkanExampleBase::keyboardKeymapCb(void *data,
-		struct wl_keyboard *keyboard, uint32_t format, int fd, uint32_t size)
+/*static*/ void VulkanExampleBase::keyboardKeymapCb(void* data, struct wl_keyboard* keyboard, uint32_t format, int fd, uint32_t size)
+{}
+
+/*static*/ void VulkanExampleBase::keyboardEnterCb(void* data, struct wl_keyboard* keyboard, uint32_t serial, struct wl_surface* surface, struct wl_array* keys)
+{}
+
+/*static*/ void VulkanExampleBase::keyboardLeaveCb(void* data, struct wl_keyboard* keyboard, uint32_t serial, struct wl_surface* surface)
+{}
+
+/*static*/ void VulkanExampleBase::keyboardKeyCb(void* data, struct wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
 {
+    VulkanExampleBase* self = reinterpret_cast<VulkanExampleBase*>(data);
+    self->keyboardKey(keyboard, serial, time, key, state);
 }
 
-/*static*/void VulkanExampleBase::keyboardEnterCb(void *data,
-		struct wl_keyboard *keyboard, uint32_t serial,
-		struct wl_surface *surface, struct wl_array *keys)
+void VulkanExampleBase::keyboardKey(struct wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
 {
+    switch (key)
+    {
+        case KEY_W:
+            camera.keys.up = !!state;
+            break;
+        case KEY_S:
+            camera.keys.down = !!state;
+            break;
+        case KEY_A:
+            camera.keys.left = !!state;
+            break;
+        case KEY_D:
+            camera.keys.right = !!state;
+            break;
+        case KEY_P:
+            if (state)
+                paused = !paused;
+            break;
+        case KEY_F1:
+            if (state && settings.overlay)
+                settings.overlay = !settings.overlay;
+            break;
+        case KEY_ESC:
+            quit = true;
+            break;
+    }
+
+    if (state)
+        keyPressed(key);
 }
 
-/*static*/void VulkanExampleBase::keyboardLeaveCb(void *data,
-		struct wl_keyboard *keyboard, uint32_t serial,
-		struct wl_surface *surface)
+/*static*/ void VulkanExampleBase::keyboardModifiersCb(void* data,
+                                                       struct wl_keyboard* keyboard,
+                                                       uint32_t serial,
+                                                       uint32_t mods_depressed,
+                                                       uint32_t mods_latched,
+                                                       uint32_t mods_locked,
+                                                       uint32_t group)
+{}
+
+void VulkanExampleBase::seatCapabilities(wl_seat* seat, uint32_t caps)
 {
+    if ((caps & WL_SEAT_CAPABILITY_POINTER) && !pointer)
+    {
+        pointer = wl_seat_get_pointer(seat);
+        static const struct wl_pointer_listener pointer_listener = {
+            pointerEnterCb, pointerLeaveCb, pointerMotionCb, pointerButtonCb, pointerAxisCb,
+        };
+        wl_pointer_add_listener(pointer, &pointer_listener, this);
+    }
+    else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && pointer)
+    {
+        wl_pointer_destroy(pointer);
+        pointer = nullptr;
+    }
+
+    if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !keyboard)
+    {
+        keyboard = wl_seat_get_keyboard(seat);
+        static const struct wl_keyboard_listener keyboard_listener = {
+            keyboardKeymapCb, keyboardEnterCb, keyboardLeaveCb, keyboardKeyCb, keyboardModifiersCb,
+        };
+        wl_keyboard_add_listener(keyboard, &keyboard_listener, this);
+    }
+    else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && keyboard)
+    {
+        wl_keyboard_destroy(keyboard);
+        keyboard = nullptr;
+    }
 }
 
-/*static*/void VulkanExampleBase::keyboardKeyCb(void *data,
-		struct wl_keyboard *keyboard, uint32_t serial, uint32_t time,
-		uint32_t key, uint32_t state)
+static void xdg_wm_base_ping(void* data, struct xdg_wm_base* shell, uint32_t serial)
 {
-	VulkanExampleBase *self = reinterpret_cast<VulkanExampleBase *>(data);
-	self->keyboardKey(keyboard, serial, time, key, state);
-}
-
-void VulkanExampleBase::keyboardKey(struct wl_keyboard *keyboard,
-		uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
-{
-	switch (key)
-	{
-	case KEY_W:
-		camera.keys.up = !!state;
-		break;
-	case KEY_S:
-		camera.keys.down = !!state;
-		break;
-	case KEY_A:
-		camera.keys.left = !!state;
-		break;
-	case KEY_D:
-		camera.keys.right = !!state;
-		break;
-	case KEY_P:
-		if (state)
-			paused = !paused;
-		break;
-	case KEY_F1:
-		if (state && settings.overlay)
-			settings.overlay = !settings.overlay;
-		break;
-	case KEY_ESC:
-		quit = true;
-		break;
-	}
-
-	if (state)
-		keyPressed(key);
-}
-
-/*static*/void VulkanExampleBase::keyboardModifiersCb(void *data,
-		struct wl_keyboard *keyboard, uint32_t serial, uint32_t mods_depressed,
-		uint32_t mods_latched, uint32_t mods_locked, uint32_t group)
-{
-}
-
-void VulkanExampleBase::seatCapabilities(wl_seat *seat, uint32_t caps)
-{
-	if ((caps & WL_SEAT_CAPABILITY_POINTER) && !pointer)
-	{
-		pointer = wl_seat_get_pointer(seat);
-		static const struct wl_pointer_listener pointer_listener =
-		{ pointerEnterCb, pointerLeaveCb, pointerMotionCb, pointerButtonCb,
-				pointerAxisCb, };
-		wl_pointer_add_listener(pointer, &pointer_listener, this);
-	}
-	else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && pointer)
-	{
-		wl_pointer_destroy(pointer);
-		pointer = nullptr;
-	}
-
-	if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !keyboard)
-	{
-		keyboard = wl_seat_get_keyboard(seat);
-		static const struct wl_keyboard_listener keyboard_listener =
-		{ keyboardKeymapCb, keyboardEnterCb, keyboardLeaveCb, keyboardKeyCb,
-				keyboardModifiersCb, };
-		wl_keyboard_add_listener(keyboard, &keyboard_listener, this);
-	}
-	else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && keyboard)
-	{
-		wl_keyboard_destroy(keyboard);
-		keyboard = nullptr;
-	}
-}
-
-static void xdg_wm_base_ping(void *data, struct xdg_wm_base *shell, uint32_t serial)
-{
-	xdg_wm_base_pong(shell, serial);
+    xdg_wm_base_pong(shell, serial);
 }
 
 static const struct xdg_wm_base_listener xdg_wm_base_listener = {
-	xdg_wm_base_ping,
+    xdg_wm_base_ping,
 };
 
-void VulkanExampleBase::registryGlobal(wl_registry *registry, uint32_t name,
-		const char *interface, uint32_t version)
+void VulkanExampleBase::registryGlobal(wl_registry* registry, uint32_t name, const char* interface, uint32_t version)
 {
-	if (strcmp(interface, "wl_compositor") == 0)
-	{
-		compositor = (wl_compositor *) wl_registry_bind(registry, name,
-				&wl_compositor_interface, 3);
-	}
-	else if (strcmp(interface, "xdg_wm_base") == 0)
-	{
-		shell = (xdg_wm_base *) wl_registry_bind(registry, name,
-				&xdg_wm_base_interface, 1);
-		xdg_wm_base_add_listener(shell, &xdg_wm_base_listener, nullptr);
-	}
-	else if (strcmp(interface, "wl_seat") == 0)
-	{
-		seat = (wl_seat *) wl_registry_bind(registry, name, &wl_seat_interface,
-				1);
+    if (strcmp(interface, "wl_compositor") == 0)
+    {
+        compositor = (wl_compositor*)wl_registry_bind(registry, name, &wl_compositor_interface, 3);
+    }
+    else if (strcmp(interface, "xdg_wm_base") == 0)
+    {
+        shell = (xdg_wm_base*)wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+        xdg_wm_base_add_listener(shell, &xdg_wm_base_listener, nullptr);
+    }
+    else if (strcmp(interface, "wl_seat") == 0)
+    {
+        seat = (wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 1);
 
-		static const struct wl_seat_listener seat_listener =
-		{ seatCapabilitiesCb, };
-		wl_seat_add_listener(seat, &seat_listener, this);
-	}
+        static const struct wl_seat_listener seat_listener = {
+            seatCapabilitiesCb,
+        };
+        wl_seat_add_listener(seat, &seat_listener, this);
+    }
 }
 
-/*static*/void VulkanExampleBase::registryGlobalRemoveCb(void *data,
-		struct wl_registry *registry, uint32_t name)
-{
-}
+/*static*/ void VulkanExampleBase::registryGlobalRemoveCb(void* data, struct wl_registry* registry, uint32_t name)
+{}
 
 void VulkanExampleBase::initWaylandConnection()
 {
-	display = wl_display_connect(NULL);
-	if (!display)
-	{
-		std::cout << "Could not connect to Wayland display!\n";
-		fflush(stdout);
-		exit(1);
-	}
+    display = wl_display_connect(NULL);
+    if (!display)
+    {
+        std::cout << "Could not connect to Wayland display!\n";
+        fflush(stdout);
+        exit(1);
+    }
 
-	registry = wl_display_get_registry(display);
-	if (!registry)
-	{
-		std::cout << "Could not get Wayland registry!\n";
-		fflush(stdout);
-		exit(1);
-	}
+    registry = wl_display_get_registry(display);
+    if (!registry)
+    {
+        std::cout << "Could not get Wayland registry!\n";
+        fflush(stdout);
+        exit(1);
+    }
 
-	static const struct wl_registry_listener registry_listener =
-	{ registryGlobalCb, registryGlobalRemoveCb };
-	wl_registry_add_listener(registry, &registry_listener, this);
-	wl_display_dispatch(display);
-	wl_display_roundtrip(display);
-	if (!compositor || !shell || !seat)
-	{
-		std::cout << "Could not bind Wayland protocols!\n";
-		fflush(stdout);
-		exit(1);
-	}
+    static const struct wl_registry_listener registry_listener = { registryGlobalCb, registryGlobalRemoveCb };
+    wl_registry_add_listener(registry, &registry_listener, this);
+    wl_display_dispatch(display);
+    wl_display_roundtrip(display);
+    if (!compositor || !shell || !seat)
+    {
+        std::cout << "Could not bind Wayland protocols!\n";
+        fflush(stdout);
+        exit(1);
+    }
 }
 
 void VulkanExampleBase::setSize(int width, int height)
 {
-	if (width <= 0 || height <= 0)
-		return;
+    if (width <= 0 || height <= 0)
+        return;
 
-	destWidth = width;
-	destHeight = height;
+    destWidth = width;
+    destHeight = height;
 
-	windowResize();
+    windowResize();
 }
 
-static void
-xdg_surface_handle_configure(void *data, struct xdg_surface *surface,
-			     uint32_t serial)
+static void xdg_surface_handle_configure(void* data, struct xdg_surface* surface, uint32_t serial)
 {
-	VulkanExampleBase *base = (VulkanExampleBase *) data;
+    VulkanExampleBase* base = (VulkanExampleBase*)data;
 
-	xdg_surface_ack_configure(surface, serial);
-	base->configured = true;
+    xdg_surface_ack_configure(surface, serial);
+    base->configured = true;
 }
 
 static const struct xdg_surface_listener xdg_surface_listener = {
-	xdg_surface_handle_configure,
+    xdg_surface_handle_configure,
 };
 
-
-static void
-xdg_toplevel_handle_configure(void *data, struct xdg_toplevel *toplevel,
-			      int32_t width, int32_t height,
-			      struct wl_array *states)
+static void xdg_toplevel_handle_configure(void* data, struct xdg_toplevel* toplevel, int32_t width, int32_t height, struct wl_array* states)
 {
-	VulkanExampleBase *base = (VulkanExampleBase *) data;
+    VulkanExampleBase* base = (VulkanExampleBase*)data;
 
-	base->setSize(width, height);
+    base->setSize(width, height);
 }
 
-static void
-xdg_toplevel_handle_close(void *data, struct xdg_toplevel *xdg_toplevel)
+static void xdg_toplevel_handle_close(void* data, struct xdg_toplevel* xdg_toplevel)
 {
-	VulkanExampleBase *base = (VulkanExampleBase *) data;
+    VulkanExampleBase* base = (VulkanExampleBase*)data;
 
-	base->quit = true;
+    base->quit = true;
 }
-
 
 static const struct xdg_toplevel_listener xdg_toplevel_listener = {
-	xdg_toplevel_handle_configure,
-	xdg_toplevel_handle_close,
+    xdg_toplevel_handle_configure,
+    xdg_toplevel_handle_close,
 };
 
-
-struct xdg_surface *VulkanExampleBase::setupWindow()
+struct xdg_surface* VulkanExampleBase::setupWindow()
 {
-	surface = wl_compositor_create_surface(compositor);
-	xdg_surface = xdg_wm_base_get_xdg_surface(shell, surface);
+    surface = wl_compositor_create_surface(compositor);
+    xdg_surface = xdg_wm_base_get_xdg_surface(shell, surface);
 
-	xdg_surface_add_listener(xdg_surface, &xdg_surface_listener, this);
-	xdg_toplevel = xdg_surface_get_toplevel(xdg_surface);
-	xdg_toplevel_add_listener(xdg_toplevel, &xdg_toplevel_listener, this);
+    xdg_surface_add_listener(xdg_surface, &xdg_surface_listener, this);
+    xdg_toplevel = xdg_surface_get_toplevel(xdg_surface);
+    xdg_toplevel_add_listener(xdg_toplevel, &xdg_toplevel_listener, this);
 
-	std::string windowTitle = getWindowTitle();
-	xdg_toplevel_set_title(xdg_toplevel, windowTitle.c_str());
-	wl_surface_commit(surface);
-	return xdg_surface;
+    std::string windowTitle = getWindowTitle();
+    xdg_toplevel_set_title(xdg_toplevel, windowTitle.c_str());
+    wl_surface_commit(surface);
+    return xdg_surface;
 }
 
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
 
-static inline xcb_intern_atom_reply_t* intern_atom_helper(xcb_connection_t *conn, bool only_if_exists, const char *str)
+static inline xcb_intern_atom_reply_t* intern_atom_helper(xcb_connection_t* conn, bool only_if_exists, const char* str)
 {
-	xcb_intern_atom_cookie_t cookie = xcb_intern_atom(conn, only_if_exists, strlen(str), str);
-	return xcb_intern_atom_reply(conn, cookie, NULL);
+    xcb_intern_atom_cookie_t cookie = xcb_intern_atom(conn, only_if_exists, strlen(str), str);
+    return xcb_intern_atom_reply(conn, cookie, NULL);
 }
 
 // Set up a window using XCB and request event types
 xcb_window_t VulkanExampleBase::setupWindow()
 {
-	uint32_t value_mask, value_list[32];
+    uint32_t value_mask, value_list[32];
 
-	window = xcb_generate_id(connection);
+    window = xcb_generate_id(connection);
 
-	value_mask = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
-	value_list[0] = screen->black_pixel;
-	value_list[1] =
-		XCB_EVENT_MASK_KEY_RELEASE |
-		XCB_EVENT_MASK_KEY_PRESS |
-		XCB_EVENT_MASK_EXPOSURE |
-		XCB_EVENT_MASK_STRUCTURE_NOTIFY |
-		XCB_EVENT_MASK_POINTER_MOTION |
-		XCB_EVENT_MASK_BUTTON_PRESS |
-		XCB_EVENT_MASK_BUTTON_RELEASE;
+    value_mask = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
+    value_list[0] = screen->black_pixel;
+    value_list[1] = XCB_EVENT_MASK_KEY_RELEASE | XCB_EVENT_MASK_KEY_PRESS | XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_STRUCTURE_NOTIFY |
+                    XCB_EVENT_MASK_POINTER_MOTION | XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE;
 
-	if (settings.fullscreen)
-	{
-		width = destWidth = screen->width_in_pixels;
-		height = destHeight = screen->height_in_pixels;
-	}
+    if (settings.fullscreen)
+    {
+        width = destWidth = screen->width_in_pixels;
+        height = destHeight = screen->height_in_pixels;
+    }
 
-	xcb_create_window(connection,
-		XCB_COPY_FROM_PARENT,
-		window, screen->root,
-		0, 0, width, height, 0,
-		XCB_WINDOW_CLASS_INPUT_OUTPUT,
-		screen->root_visual,
-		value_mask, value_list);
+    xcb_create_window(connection, XCB_COPY_FROM_PARENT, window, screen->root, 0, 0, width, height, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT, screen->root_visual,
+                      value_mask, value_list);
 
-	/* Magic code that will send notification when window is destroyed */
-	xcb_intern_atom_reply_t* reply = intern_atom_helper(connection, true, "WM_PROTOCOLS");
-	atom_wm_delete_window = intern_atom_helper(connection, false, "WM_DELETE_WINDOW");
+    /* Magic code that will send notification when window is destroyed */
+    xcb_intern_atom_reply_t* reply = intern_atom_helper(connection, true, "WM_PROTOCOLS");
+    atom_wm_delete_window = intern_atom_helper(connection, false, "WM_DELETE_WINDOW");
 
-	xcb_change_property(connection, XCB_PROP_MODE_REPLACE,
-		window, (*reply).atom, 4, 32, 1,
-		&(*atom_wm_delete_window).atom);
+    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, window, (*reply).atom, 4, 32, 1, &(*atom_wm_delete_window).atom);
 
-	std::string windowTitle = getWindowTitle();
-	xcb_change_property(connection, XCB_PROP_MODE_REPLACE,
-		window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8,
-		title.size(), windowTitle.c_str());
+    std::string windowTitle = getWindowTitle();
+    xcb_change_property(connection, XCB_PROP_MODE_REPLACE, window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8, title.size(), windowTitle.c_str());
 
-	free(reply);
+    free(reply);
 
-	if (settings.fullscreen)
-	{
-		xcb_intern_atom_reply_t *atom_wm_state = intern_atom_helper(connection, false, "_NET_WM_STATE");
-		xcb_intern_atom_reply_t *atom_wm_fullscreen = intern_atom_helper(connection, false, "_NET_WM_STATE_FULLSCREEN");
-		xcb_change_property(connection,
-				XCB_PROP_MODE_REPLACE,
-				window, atom_wm_state->atom,
-				XCB_ATOM_ATOM, 32, 1,
-				&(atom_wm_fullscreen->atom));
-		free(atom_wm_fullscreen);
-		free(atom_wm_state);
-	}	
+    if (settings.fullscreen)
+    {
+        xcb_intern_atom_reply_t* atom_wm_state = intern_atom_helper(connection, false, "_NET_WM_STATE");
+        xcb_intern_atom_reply_t* atom_wm_fullscreen = intern_atom_helper(connection, false, "_NET_WM_STATE_FULLSCREEN");
+        xcb_change_property(connection, XCB_PROP_MODE_REPLACE, window, atom_wm_state->atom, XCB_ATOM_ATOM, 32, 1, &(atom_wm_fullscreen->atom));
+        free(atom_wm_fullscreen);
+        free(atom_wm_state);
+    }
 
-	xcb_map_window(connection, window);
+    xcb_map_window(connection, window);
 
-	return(window);
+    return (window);
 }
 
 // Initialize XCB connection
 void VulkanExampleBase::initxcbConnection()
 {
-	const xcb_setup_t *setup;
-	xcb_screen_iterator_t iter;
-	int scr;
+    const xcb_setup_t* setup;
+    xcb_screen_iterator_t iter;
+    int scr;
 
-	connection = xcb_connect(NULL, &scr);
-	if (connection == NULL) {
-		printf("Could not find a compatible Vulkan ICD!\n");
-		fflush(stdout);
-		exit(1);
-	}
+    connection = xcb_connect(NULL, &scr);
+    if (connection == NULL)
+    {
+        printf("Could not find a compatible Vulkan ICD!\n");
+        fflush(stdout);
+        exit(1);
+    }
 
-	setup = xcb_get_setup(connection);
-	iter = xcb_setup_roots_iterator(setup);
-	while (scr-- > 0)
-		xcb_screen_next(&iter);
-	screen = iter.data;
+    setup = xcb_get_setup(connection);
+    iter = xcb_setup_roots_iterator(setup);
+    while (scr-- > 0)
+        xcb_screen_next(&iter);
+    screen = iter.data;
 }
 
-void VulkanExampleBase::handleEvent(const xcb_generic_event_t *event)
+void VulkanExampleBase::handleEvent(const xcb_generic_event_t* event)
 {
-	switch (event->response_type & 0x7f)
-	{
-	case XCB_CLIENT_MESSAGE:
-		if ((*(xcb_client_message_event_t*)event).data.data32[0] ==
-			(*atom_wm_delete_window).atom) {
-			quit = true;
-		}
-		break;
-	case XCB_MOTION_NOTIFY:
-	{
-		xcb_motion_notify_event_t *motion = (xcb_motion_notify_event_t *)event;
-		handleMouseMove((int32_t)motion->event_x, (int32_t)motion->event_y);
-		break;
-	}
-	break;
-	case XCB_BUTTON_PRESS:
-	{
-		xcb_button_press_event_t *press = (xcb_button_press_event_t *)event;
-		if (press->detail == XCB_BUTTON_INDEX_1)
-			mouseButtons.left = true;
-		if (press->detail == XCB_BUTTON_INDEX_2)
-			mouseButtons.middle = true;
-		if (press->detail == XCB_BUTTON_INDEX_3)
-			mouseButtons.right = true;
-	}
-	break;
-	case XCB_BUTTON_RELEASE:
-	{
-		xcb_button_press_event_t *press = (xcb_button_press_event_t *)event;
-		if (press->detail == XCB_BUTTON_INDEX_1)
-			mouseButtons.left = false;
-		if (press->detail == XCB_BUTTON_INDEX_2)
-			mouseButtons.middle = false;
-		if (press->detail == XCB_BUTTON_INDEX_3)
-			mouseButtons.right = false;
-	}
-	break;
-	case XCB_KEY_PRESS:
-	{
-		const xcb_key_release_event_t *keyEvent = (const xcb_key_release_event_t *)event;
-		switch (keyEvent->detail)
-		{
-			case KEY_W:
-				camera.keys.up = true;
-				break;
-			case KEY_S:
-				camera.keys.down = true;
-				break;
-			case KEY_A:
-				camera.keys.left = true;
-				break;
-			case KEY_D:
-				camera.keys.right = true;
-				break;
-			case KEY_P:
-				paused = !paused;
-				break;
-			case KEY_F1:
-				if (settings.overlay) {
-					settings.overlay = !settings.overlay;
-				}
-				break;				
-		}
-	}
-	break;	
-	case XCB_KEY_RELEASE:
-	{
-		const xcb_key_release_event_t *keyEvent = (const xcb_key_release_event_t *)event;
-		switch (keyEvent->detail)
-		{
-			case KEY_W:
-				camera.keys.up = false;
-				break;
-			case KEY_S:
-				camera.keys.down = false;
-				break;
-			case KEY_A:
-				camera.keys.left = false;
-				break;
-			case KEY_D:
-				camera.keys.right = false;
-				break;			
-			case KEY_ESCAPE:
-				quit = true;
-				break;
-		}
-		keyPressed(keyEvent->detail);
-	}
-	break;
-	case XCB_DESTROY_NOTIFY:
-		quit = true;
-		break;
-	case XCB_CONFIGURE_NOTIFY:
-	{
-		const xcb_configure_notify_event_t *cfgEvent = (const xcb_configure_notify_event_t *)event;
-		if ((prepared) && ((cfgEvent->width != width) || (cfgEvent->height != height)))
-		{
-				destWidth = cfgEvent->width;
-				destHeight = cfgEvent->height;
-				if ((destWidth > 0) && (destHeight > 0))
-				{
-					windowResize();
-				}
-		}
-	}
-	break;
-	default:
-		break;
-	}
+    switch (event->response_type & 0x7f)
+    {
+        case XCB_CLIENT_MESSAGE:
+            if ((*(xcb_client_message_event_t*)event).data.data32[0] == (*atom_wm_delete_window).atom)
+            {
+                quit = true;
+            }
+            break;
+        case XCB_MOTION_NOTIFY: {
+            xcb_motion_notify_event_t* motion = (xcb_motion_notify_event_t*)event;
+            handleMouseMove((int32_t)motion->event_x, (int32_t)motion->event_y);
+            break;
+        }
+        break;
+        case XCB_BUTTON_PRESS: {
+            xcb_button_press_event_t* press = (xcb_button_press_event_t*)event;
+            if (press->detail == XCB_BUTTON_INDEX_1)
+                mouseButtons.left = true;
+            if (press->detail == XCB_BUTTON_INDEX_2)
+                mouseButtons.middle = true;
+            if (press->detail == XCB_BUTTON_INDEX_3)
+                mouseButtons.right = true;
+        }
+        break;
+        case XCB_BUTTON_RELEASE: {
+            xcb_button_press_event_t* press = (xcb_button_press_event_t*)event;
+            if (press->detail == XCB_BUTTON_INDEX_1)
+                mouseButtons.left = false;
+            if (press->detail == XCB_BUTTON_INDEX_2)
+                mouseButtons.middle = false;
+            if (press->detail == XCB_BUTTON_INDEX_3)
+                mouseButtons.right = false;
+        }
+        break;
+        case XCB_KEY_PRESS: {
+            const xcb_key_release_event_t* keyEvent = (const xcb_key_release_event_t*)event;
+            switch (keyEvent->detail)
+            {
+                case KEY_W:
+                    camera.keys.up = true;
+                    break;
+                case KEY_S:
+                    camera.keys.down = true;
+                    break;
+                case KEY_A:
+                    camera.keys.left = true;
+                    break;
+                case KEY_D:
+                    camera.keys.right = true;
+                    break;
+                case KEY_P:
+                    paused = !paused;
+                    break;
+                case KEY_F1:
+                    if (settings.overlay)
+                    {
+                        settings.overlay = !settings.overlay;
+                    }
+                    break;
+            }
+        }
+        break;
+        case XCB_KEY_RELEASE: {
+            const xcb_key_release_event_t* keyEvent = (const xcb_key_release_event_t*)event;
+            switch (keyEvent->detail)
+            {
+                case KEY_W:
+                    camera.keys.up = false;
+                    break;
+                case KEY_S:
+                    camera.keys.down = false;
+                    break;
+                case KEY_A:
+                    camera.keys.left = false;
+                    break;
+                case KEY_D:
+                    camera.keys.right = false;
+                    break;
+                case KEY_ESCAPE:
+                    quit = true;
+                    break;
+            }
+            keyPressed(keyEvent->detail);
+        }
+        break;
+        case XCB_DESTROY_NOTIFY:
+            quit = true;
+            break;
+        case XCB_CONFIGURE_NOTIFY: {
+            const xcb_configure_notify_event_t* cfgEvent = (const xcb_configure_notify_event_t*)event;
+            if ((prepared) && ((cfgEvent->width != width) || (cfgEvent->height != height)))
+            {
+                destWidth = cfgEvent->width;
+                destHeight = cfgEvent->height;
+                if ((destWidth > 0) && (destHeight > 0))
+                {
+                    windowResize();
+                }
+            }
+        }
+        break;
+        default:
+            break;
+    }
 }
 #endif
 
-void VulkanExampleBase::viewChanged() {}
+void VulkanExampleBase::viewChanged()
+{}
 
-void VulkanExampleBase::keyPressed(uint32_t) {}
+void VulkanExampleBase::keyPressed(uint32_t)
+{}
 
-void VulkanExampleBase::mouseMoved(double x, double y, bool & handled) {}
+void VulkanExampleBase::mouseMoved(double x, double y, bool& handled)
+{}
 
-void VulkanExampleBase::buildCommandBuffers() {}
+void VulkanExampleBase::buildCommandBuffers()
+{}
 
 void VulkanExampleBase::createSynchronizationPrimitives()
 {
-	// Wait fences to sync command buffer access
-	VkFenceCreateInfo fenceCreateInfo = vks::initializers::fenceCreateInfo(VK_FENCE_CREATE_SIGNALED_BIT);
-	waitFences.resize(drawCmdBuffers.size());
-	for (auto& fence : waitFences) {
-		VK_CHECK_RESULT(vkCreateFence(device, &fenceCreateInfo, nullptr, &fence));
-	}
+    // Wait fences to sync command buffer access
+    VkFenceCreateInfo fenceCreateInfo = vks::initializers::fenceCreateInfo(VK_FENCE_CREATE_SIGNALED_BIT);
+    waitFences.resize(drawCmdBuffers.size());
+    for (auto& fence : waitFences)
+    {
+        VK_CHECK_RESULT(vkCreateFence(device, &fenceCreateInfo, nullptr, &fence));
+    }
 }
 
 void VulkanExampleBase::createCommandPool()
 {
-	VkCommandPoolCreateInfo cmdPoolInfo = {};
-	cmdPoolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-	cmdPoolInfo.queueFamilyIndex = swapChain.queueNodeIndex;
-	cmdPoolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-	VK_CHECK_RESULT(vkCreateCommandPool(device, &cmdPoolInfo, nullptr, &cmdPool));
+    VkCommandPoolCreateInfo cmdPoolInfo = {};
+    cmdPoolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    cmdPoolInfo.queueFamilyIndex = swapChain.queueNodeIndex;
+    cmdPoolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    VK_CHECK_RESULT(vkCreateCommandPool(device, &cmdPoolInfo, nullptr, &cmdPool));
 }
 
 void VulkanExampleBase::setupDepthStencil()
 {
-	VkImageCreateInfo imageCI{};
-	imageCI.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-	imageCI.imageType = VK_IMAGE_TYPE_2D;
-	imageCI.format = depthFormat;
-	imageCI.extent = { width, height, 1 };
-	imageCI.mipLevels = 1;
-	imageCI.arrayLayers = 1;
-	imageCI.samples = VK_SAMPLE_COUNT_1_BIT;
-	imageCI.tiling = VK_IMAGE_TILING_OPTIMAL;
-	imageCI.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    VkImageCreateInfo imageCI{};
+    imageCI.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageCI.imageType = VK_IMAGE_TYPE_2D;
+    imageCI.format = depthFormat;
+    imageCI.extent = { width, height, 1 };
+    imageCI.mipLevels = 1;
+    imageCI.arrayLayers = 1;
+    imageCI.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageCI.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageCI.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
-	VK_CHECK_RESULT(vkCreateImage(device, &imageCI, nullptr, &depthStencil.image));
-	VkMemoryRequirements memReqs{};
-	vkGetImageMemoryRequirements(device, depthStencil.image, &memReqs);
+    VK_CHECK_RESULT(vkCreateImage(device, &imageCI, nullptr, &depthStencil.image));
+    VkMemoryRequirements memReqs{};
+    vkGetImageMemoryRequirements(device, depthStencil.image, &memReqs);
 
-	VkMemoryAllocateInfo memAllloc{};
-	memAllloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	memAllloc.allocationSize = memReqs.size;
-	memAllloc.memoryTypeIndex = vulkanDevice->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-	VK_CHECK_RESULT(vkAllocateMemory(device, &memAllloc, nullptr, &depthStencil.mem));
-	VK_CHECK_RESULT(vkBindImageMemory(device, depthStencil.image, depthStencil.mem, 0));
+    VkMemoryAllocateInfo memAllloc{};
+    memAllloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    memAllloc.allocationSize = memReqs.size;
+    memAllloc.memoryTypeIndex = vulkanDevice->getMemoryType(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    VK_CHECK_RESULT(vkAllocateMemory(device, &memAllloc, nullptr, &depthStencil.mem));
+    VK_CHECK_RESULT(vkBindImageMemory(device, depthStencil.image, depthStencil.mem, 0));
 
-	VkImageViewCreateInfo imageViewCI{};
-	imageViewCI.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-	imageViewCI.viewType = VK_IMAGE_VIEW_TYPE_2D;
-	imageViewCI.image = depthStencil.image;
-	imageViewCI.format = depthFormat;
-	imageViewCI.subresourceRange.baseMipLevel = 0;
-	imageViewCI.subresourceRange.levelCount = 1;
-	imageViewCI.subresourceRange.baseArrayLayer = 0;
-	imageViewCI.subresourceRange.layerCount = 1;
-	imageViewCI.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-	// Stencil aspect should only be set on depth + stencil formats (VK_FORMAT_D16_UNORM_S8_UINT..VK_FORMAT_D32_SFLOAT_S8_UINT
-	if (depthFormat >= VK_FORMAT_D16_UNORM_S8_UINT) {
-		imageViewCI.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
-	}
-	VK_CHECK_RESULT(vkCreateImageView(device, &imageViewCI, nullptr, &depthStencil.view));
+    VkImageViewCreateInfo imageViewCI{};
+    imageViewCI.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    imageViewCI.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    imageViewCI.image = depthStencil.image;
+    imageViewCI.format = depthFormat;
+    imageViewCI.subresourceRange.baseMipLevel = 0;
+    imageViewCI.subresourceRange.levelCount = 1;
+    imageViewCI.subresourceRange.baseArrayLayer = 0;
+    imageViewCI.subresourceRange.layerCount = 1;
+    imageViewCI.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    // Stencil aspect should only be set on depth + stencil formats (VK_FORMAT_D16_UNORM_S8_UINT..VK_FORMAT_D32_SFLOAT_S8_UINT
+    if (depthFormat >= VK_FORMAT_D16_UNORM_S8_UINT)
+    {
+        imageViewCI.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+    }
+    VK_CHECK_RESULT(vkCreateImageView(device, &imageViewCI, nullptr, &depthStencil.view));
 }
 
 void VulkanExampleBase::setupFrameBuffer()
 {
-	VkImageView attachments[2];
+    VkImageView attachments[2];
 
-	// Depth/Stencil attachment is the same for all frame buffers
-	attachments[1] = depthStencil.view;
+    // Depth/Stencil attachment is the same for all frame buffers
+    attachments[1] = depthStencil.view;
 
-	VkFramebufferCreateInfo frameBufferCreateInfo = {};
-	frameBufferCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-	frameBufferCreateInfo.pNext = NULL;
-	frameBufferCreateInfo.renderPass = renderPass;
-	frameBufferCreateInfo.attachmentCount = 2;
-	frameBufferCreateInfo.pAttachments = attachments;
-	frameBufferCreateInfo.width = width;
-	frameBufferCreateInfo.height = height;
-	frameBufferCreateInfo.layers = 1;
+    VkFramebufferCreateInfo frameBufferCreateInfo = {};
+    frameBufferCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+    frameBufferCreateInfo.pNext = NULL;
+    frameBufferCreateInfo.renderPass = renderPass;
+    frameBufferCreateInfo.attachmentCount = 2;
+    frameBufferCreateInfo.pAttachments = attachments;
+    frameBufferCreateInfo.width = width;
+    frameBufferCreateInfo.height = height;
+    frameBufferCreateInfo.layers = 1;
 
-	// Create frame buffers for every swap chain image
-	frameBuffers.resize(swapChain.imageCount);
-	for (uint32_t i = 0; i < frameBuffers.size(); i++)
-	{
-		attachments[0] = swapChain.buffers[i].view;
-		VK_CHECK_RESULT(vkCreateFramebuffer(device, &frameBufferCreateInfo, nullptr, &frameBuffers[i]));
-	}
+    // Create frame buffers for every swap chain image
+    frameBuffers.resize(swapChain.imageCount);
+    for (uint32_t i = 0; i < frameBuffers.size(); i++)
+    {
+        attachments[0] = swapChain.buffers[i].view;
+        VK_CHECK_RESULT(vkCreateFramebuffer(device, &frameBufferCreateInfo, nullptr, &frameBuffers[i]));
+    }
 }
 
 void VulkanExampleBase::setupRenderPass()
 {
-	std::array<VkAttachmentDescription, 2> attachments = {};
-	// Color attachment
-	attachments[0].format = swapChain.colorFormat;
-	attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
-	attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-	attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-	attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-	// Depth attachment
-	attachments[1].format = depthFormat;
-	attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
-	attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-	attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-	attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    std::array<VkAttachmentDescription, 2> attachments = {};
+    // Color attachment
+    attachments[0].format = swapChain.colorFormat;
+    attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
+    attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    // Depth attachment
+    attachments[1].format = depthFormat;
+    attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
+    attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-	VkAttachmentReference colorReference = {};
-	colorReference.attachment = 0;
-	colorReference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    VkAttachmentReference colorReference = {};
+    colorReference.attachment = 0;
+    colorReference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-	VkAttachmentReference depthReference = {};
-	depthReference.attachment = 1;
-	depthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    VkAttachmentReference depthReference = {};
+    depthReference.attachment = 1;
+    depthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-	VkSubpassDescription subpassDescription = {};
-	subpassDescription.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-	subpassDescription.colorAttachmentCount = 1;
-	subpassDescription.pColorAttachments = &colorReference;
-	subpassDescription.pDepthStencilAttachment = &depthReference;
-	subpassDescription.inputAttachmentCount = 0;
-	subpassDescription.pInputAttachments = nullptr;
-	subpassDescription.preserveAttachmentCount = 0;
-	subpassDescription.pPreserveAttachments = nullptr;
-	subpassDescription.pResolveAttachments = nullptr;
+    VkSubpassDescription subpassDescription = {};
+    subpassDescription.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpassDescription.colorAttachmentCount = 1;
+    subpassDescription.pColorAttachments = &colorReference;
+    subpassDescription.pDepthStencilAttachment = &depthReference;
+    subpassDescription.inputAttachmentCount = 0;
+    subpassDescription.pInputAttachments = nullptr;
+    subpassDescription.preserveAttachmentCount = 0;
+    subpassDescription.pPreserveAttachments = nullptr;
+    subpassDescription.pResolveAttachments = nullptr;
 
-	// Subpass dependencies for layout transitions
-	std::array<VkSubpassDependency, 2> dependencies;
+    // Subpass dependencies for layout transitions
+    std::array<VkSubpassDependency, 2> dependencies;
 
-	dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-	dependencies[0].dstSubpass = 0;
-	dependencies[0].srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-	dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-	dependencies[0].srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-	dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-	dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+    dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+    dependencies[0].dstSubpass = 0;
+    dependencies[0].srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependencies[0].srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+    dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 
-	dependencies[1].srcSubpass = 0;
-	dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
-	dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-	dependencies[1].dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-	dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-	dependencies[1].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-	dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+    dependencies[1].srcSubpass = 0;
+    dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+    dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependencies[1].dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    dependencies[1].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+    dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 
-	VkRenderPassCreateInfo renderPassInfo = {};
-	renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-	renderPassInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
-	renderPassInfo.pAttachments = attachments.data();
-	renderPassInfo.subpassCount = 1;
-	renderPassInfo.pSubpasses = &subpassDescription;
-	renderPassInfo.dependencyCount = static_cast<uint32_t>(dependencies.size());
-	renderPassInfo.pDependencies = dependencies.data();
+    VkRenderPassCreateInfo renderPassInfo = {};
+    renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    renderPassInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
+    renderPassInfo.pAttachments = attachments.data();
+    renderPassInfo.subpassCount = 1;
+    renderPassInfo.pSubpasses = &subpassDescription;
+    renderPassInfo.dependencyCount = static_cast<uint32_t>(dependencies.size());
+    renderPassInfo.pDependencies = dependencies.data();
 
-	VK_CHECK_RESULT(vkCreateRenderPass(device, &renderPassInfo, nullptr, &renderPass));
+    VK_CHECK_RESULT(vkCreateRenderPass(device, &renderPassInfo, nullptr, &renderPass));
 }
 
 void VulkanExampleBase::getEnabledFeatures()
 {
-	// Can be overriden in derived class
+    // Can be overriden in derived class
 }
 
 void VulkanExampleBase::windowResize()
 {
-	if (!prepared)
-	{
-		return;
-	}
-	prepared = false;
+    if (!prepared)
+    {
+        return;
+    }
+    prepared = false;
 
-	// Ensure all operations on the device have been finished before destroying resources
-	vkDeviceWaitIdle(device);
+    // Ensure all operations on the device have been finished before destroying resources
+    vkDeviceWaitIdle(device);
 
-	// Recreate swap chain
-	width = destWidth;
-	height = destHeight;
-	setupSwapChain();
+    // Recreate swap chain
+    width = destWidth;
+    height = destHeight;
+    setupSwapChain();
 
-	// Recreate the frame buffers
-	vkDestroyImageView(device, depthStencil.view, nullptr);
-	vkDestroyImage(device, depthStencil.image, nullptr);
-	vkFreeMemory(device, depthStencil.mem, nullptr);
-	setupDepthStencil();	
-	for (uint32_t i = 0; i < frameBuffers.size(); i++) {
-		vkDestroyFramebuffer(device, frameBuffers[i], nullptr);
-	}
-	setupFrameBuffer();
+    // Recreate the frame buffers
+    vkDestroyImageView(device, depthStencil.view, nullptr);
+    vkDestroyImage(device, depthStencil.image, nullptr);
+    vkFreeMemory(device, depthStencil.mem, nullptr);
+    setupDepthStencil();
+    for (uint32_t i = 0; i < frameBuffers.size(); i++)
+    {
+        vkDestroyFramebuffer(device, frameBuffers[i], nullptr);
+    }
+    setupFrameBuffer();
 
-	if ((width > 0.0f) && (height > 0.0f)) {
-		if (settings.overlay) {
-			UIOverlay.resize(width, height);
-		}
-	}
+    if ((width > 0.0f) && (height > 0.0f))
+    {
+        if (settings.overlay)
+        {
+            UIOverlay.resize(width, height);
+        }
+    }
 
-	// Command buffers need to be recreated as they may store
-	// references to the recreated frame buffer
-	destroyCommandBuffers();
-	createCommandBuffers();
-	buildCommandBuffers();
+    // Command buffers need to be recreated as they may store
+    // references to the recreated frame buffer
+    destroyCommandBuffers();
+    createCommandBuffers();
+    buildCommandBuffers();
 
-	vkDeviceWaitIdle(device);
+    vkDeviceWaitIdle(device);
 
-	if ((width > 0.0f) && (height > 0.0f)) {
-		camera.updateAspectRatio((float)width / (float)height);
-	}
+    if ((width > 0.0f) && (height > 0.0f))
+    {
+        camera.updateAspectRatio((float)width / (float)height);
+    }
 
-	// Notify derived class
-	windowResized();
-	viewChanged();
+    // Notify derived class
+    windowResized();
+    viewChanged();
 
-	prepared = true;
+    prepared = true;
 }
 
 void VulkanExampleBase::handleMouseMove(int32_t x, int32_t y)
 {
-	int32_t dx = (int32_t)mousePos.x - x;
-	int32_t dy = (int32_t)mousePos.y - y;
+    int32_t dx = (int32_t)mousePos.x - x;
+    int32_t dy = (int32_t)mousePos.y - y;
 
-	bool handled = false;
+    bool handled = false;
 
-	if (settings.overlay) {
-		ImGuiIO& io = ImGui::GetIO();
-		handled = io.WantCaptureMouse;
-	}
-	mouseMoved((float)x, (float)y, handled);
+    if (settings.overlay)
+    {
+        ImGuiIO& io = ImGui::GetIO();
+        handled = io.WantCaptureMouse;
+    }
+    mouseMoved((float)x, (float)y, handled);
 
-	if (handled) {
-		mousePos = glm::vec2((float)x, (float)y);
-		return;
-	}
+    if (handled)
+    {
+        mousePos = glm::vec2((float)x, (float)y);
+        return;
+    }
 
-	if (mouseButtons.left) {
-		rotation.x += dy * 1.25f * rotationSpeed;
-		rotation.y -= dx * 1.25f * rotationSpeed;
-		camera.rotate(glm::vec3(dy * camera.rotationSpeed, -dx * camera.rotationSpeed, 0.0f));
-		viewUpdated = true;
-	}
-	if (mouseButtons.right) {
-		zoom += dy * .005f * zoomSpeed;
-		camera.translate(glm::vec3(-0.0f, 0.0f, dy * .005f * zoomSpeed));
-		viewUpdated = true;
-	}
-	if (mouseButtons.middle) {
-		cameraPos.x -= dx * 0.01f;
-		cameraPos.y -= dy * 0.01f;
-		camera.translate(glm::vec3(-dx * 0.01f, -dy * 0.01f, 0.0f));
-		viewUpdated = true;
-	}
-	mousePos = glm::vec2((float)x, (float)y);
+    if (mouseButtons.left)
+    {
+        rotation.x += dy * 1.25f * rotationSpeed;
+        rotation.y -= dx * 1.25f * rotationSpeed;
+        camera.rotate(glm::vec3(dy * camera.rotationSpeed, -dx * camera.rotationSpeed, 0.0f));
+        viewUpdated = true;
+    }
+    if (mouseButtons.right)
+    {
+        zoom += dy * .005f * zoomSpeed;
+        camera.translate(glm::vec3(-0.0f, 0.0f, dy * .005f * zoomSpeed));
+        viewUpdated = true;
+    }
+    if (mouseButtons.middle)
+    {
+        cameraPos.x -= dx * 0.01f;
+        cameraPos.y -= dy * 0.01f;
+        camera.translate(glm::vec3(-dx * 0.01f, -dy * 0.01f, 0.0f));
+        viewUpdated = true;
+    }
+    mousePos = glm::vec2((float)x, (float)y);
 }
 
 void VulkanExampleBase::windowResized()
 {
-	// Can be overriden in derived class
+    // Can be overriden in derived class
 }
 
 void VulkanExampleBase::initSwapchain()
 {
 #if defined(_WIN32)
-	swapChain.initSurface(windowInstance, window);
-#elif defined(VK_USE_PLATFORM_ANDROID_KHR)	
-	swapChain.initSurface(androidApp->window);
+    swapChain.initSurface(windowInstance, window);
+#elif defined(VK_USE_PLATFORM_ANDROID_KHR)
+    swapChain.initSurface(androidApp->window);
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-	swapChain.initSurface(view);
+    swapChain.initSurface(view);
 #elif defined(_DIRECT2DISPLAY)
-	swapChain.initSurface(width, height);
+    swapChain.initSurface(width, height);
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	swapChain.initSurface(display, surface);
+    swapChain.initSurface(display, surface);
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-	swapChain.initSurface(connection, window);
+    swapChain.initSurface(connection, window);
 #endif
 }
 
 void VulkanExampleBase::setupSwapChain()
 {
-	swapChain.create(&width, &height, settings.vsync);
+    swapChain.create(&width, &height, settings.vsync);
 }
 
-void VulkanExampleBase::OnUpdateUIOverlay(vks::UIOverlay *overlay) {}
+void VulkanExampleBase::OnUpdateUIOverlay(vks::UIOverlay* overlay)
+{}

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -56,445 +56,450 @@
 
 class VulkanExampleBase
 {
-private:	
-	// Get window title with example name, device, et.
-	std::string getWindowTitle();
-	/** brief Indicates that the view (position, rotation) has changed and buffers containing camera matrices need to be updated */
-	bool viewUpdated = false;
-	// Destination dimensions for resizing the window
-	uint32_t destWidth;
-	uint32_t destHeight;
-	bool resizing = false;
-	// Called if the window is resized and some resources have to be recreatesd
-	void windowResize();
-	void handleMouseMove(int32_t x, int32_t y);
+private:
+    // Get window title with example name, device, et.
+    std::string getWindowTitle();
+    /** brief Indicates that the view (position, rotation) has changed and buffers containing camera matrices need to be updated */
+    bool viewUpdated = false;
+    // Destination dimensions for resizing the window
+    uint32_t destWidth;
+    uint32_t destHeight;
+    bool resizing = false;
+    // Called if the window is resized and some resources have to be recreatesd
+    void windowResize();
+    void handleMouseMove(int32_t x, int32_t y);
+
 protected:
-	// Frame counter to display fps
-	uint32_t frameCounter = 0;
-	uint32_t lastFPS = 0;
-	std::chrono::time_point<std::chrono::high_resolution_clock> lastTimestamp;
-	// Vulkan instance, stores all per-application states
-	VkInstance instance;
-	// Physical device (GPU) that Vulkan will ise
-	VkPhysicalDevice physicalDevice;
-	// Stores physical device properties (for e.g. checking device limits)
-	VkPhysicalDeviceProperties deviceProperties;
-	// Stores the features available on the selected physical device (for e.g. checking if a feature is available)
-	VkPhysicalDeviceFeatures deviceFeatures;
-	// Stores all available memory (type) properties for the physical device
-	VkPhysicalDeviceMemoryProperties deviceMemoryProperties;
-	/** @brief Set of physical device features to be enabled for this example (must be set in the derived constructor) */
-	VkPhysicalDeviceFeatures enabledFeatures{};
-	/** @brief Set of device extensions to be enabled for this example (must be set in the derived constructor) */
-	std::vector<const char*> enabledDeviceExtensions;
-	std::vector<const char*> enabledInstanceExtensions;
-	/** @brief Optional pNext structure for passing extension structures to device creation */
-	void* deviceCreatepNextChain = nullptr;
-	/** @brief Logical device, application's view of the physical device (GPU) */
-	VkDevice device;
-	// Handle to the device graphics queue that command buffers are submitted to
-	VkQueue queue;
-	// Depth buffer format (selected during Vulkan initialization)
-	VkFormat depthFormat;
-	// Command buffer pool
-	VkCommandPool cmdPool;
-	/** @brief Pipeline stages used to wait at for graphics queue submissions */
-	VkPipelineStageFlags submitPipelineStages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-	// Contains command buffers and semaphores to be presented to the queue
-	VkSubmitInfo submitInfo;
-	// Command buffers used for rendering
-	std::vector<VkCommandBuffer> drawCmdBuffers;
-	// Global render pass for frame buffer writes
-	VkRenderPass renderPass;
-	// List of available frame buffers (same as number of swap chain images)
-	std::vector<VkFramebuffer>frameBuffers;
-	// Active frame buffer index
-	uint32_t currentBuffer = 0;
-	// Descriptor set pool
-	VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
-	// List of shader modules created (stored for cleanup)
-	std::vector<VkShaderModule> shaderModules;
-	// Pipeline cache object
-	VkPipelineCache pipelineCache;
-	// Wraps the swap chain to present images (framebuffers) to the windowing system
-	VulkanSwapChain swapChain;
-	// Synchronization semaphores
-	struct {
-		// Swap chain image presentation
-		VkSemaphore presentComplete;
-		// Command buffer submission and execution
-		VkSemaphore renderComplete;
-	} semaphores;
-	std::vector<VkFence> waitFences;
-public: 
-	bool prepared = false;
-	uint32_t width = 1280;
-	uint32_t height = 720;
+    // Frame counter to display fps
+    uint32_t frameCounter = 0;
+    uint32_t lastFPS = 0;
+    std::chrono::time_point<std::chrono::high_resolution_clock> lastTimestamp;
+    // Vulkan instance, stores all per-application states
+    VkInstance instance;
+    // Physical device (GPU) that Vulkan will ise
+    VkPhysicalDevice physicalDevice;
+    // Stores physical device properties (for e.g. checking device limits)
+    VkPhysicalDeviceProperties deviceProperties;
+    // Stores the features available on the selected physical device (for e.g. checking if a feature is available)
+    VkPhysicalDeviceFeatures deviceFeatures;
+    // Stores all available memory (type) properties for the physical device
+    VkPhysicalDeviceMemoryProperties deviceMemoryProperties;
+    /** @brief Set of physical device features to be enabled for this example (must be set in the derived constructor) */
+    VkPhysicalDeviceFeatures enabledFeatures{};
+    /** @brief Set of device extensions to be enabled for this example (must be set in the derived constructor) */
+    std::vector<const char*> enabledDeviceExtensions;
+    std::vector<const char*> enabledInstanceExtensions;
+    /** @brief Optional pNext structure for passing extension structures to device creation */
+    void* deviceCreatepNextChain = nullptr;
+    /** @brief Logical device, application's view of the physical device (GPU) */
+    VkDevice device;
+    // Handle to the device graphics queue that command buffers are submitted to
+    VkQueue queue;
+    // Depth buffer format (selected during Vulkan initialization)
+    VkFormat depthFormat;
+    // Command buffer pool
+    VkCommandPool cmdPool;
+    /** @brief Pipeline stages used to wait at for graphics queue submissions */
+    VkPipelineStageFlags submitPipelineStages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    // Contains command buffers and semaphores to be presented to the queue
+    VkSubmitInfo submitInfo;
+    // Command buffers used for rendering
+    std::vector<VkCommandBuffer> drawCmdBuffers;
+    // Global render pass for frame buffer writes
+    VkRenderPass renderPass;
+    // List of available frame buffers (same as number of swap chain images)
+    std::vector<VkFramebuffer> frameBuffers;
+    // Active frame buffer index
+    uint32_t currentBuffer = 0;
+    // Descriptor set pool
+    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    // List of shader modules created (stored for cleanup)
+    std::vector<VkShaderModule> shaderModules;
+    // Pipeline cache object
+    VkPipelineCache pipelineCache;
+    // Wraps the swap chain to present images (framebuffers) to the windowing system
+    VulkanSwapChain swapChain;
+    // Synchronization semaphores
+    struct
+    {
+        // Swap chain image presentation
+        VkSemaphore presentComplete;
+        // Command buffer submission and execution
+        VkSemaphore renderComplete;
+    } semaphores;
+    std::vector<VkFence> waitFences;
 
-	vks::UIOverlay UIOverlay;
+public:
+    bool prepared = false;
+    uint32_t width = 1280;
+    uint32_t height = 720;
 
-	/** @brief Last frame time measured using a high performance timer (if available) */
-	float frameTimer = 1.0f;
-	/** @brief Returns os specific base asset path (for shaders, models, textures) */
-	const std::string getAssetPath();
+    vks::UIOverlay UIOverlay;
 
-	vks::Benchmark benchmark;
+    /** @brief Last frame time measured using a high performance timer (if available) */
+    float frameTimer = 1.0f;
+    /** @brief Returns os specific base asset path (for shaders, models, textures) */
+    const std::string getAssetPath();
 
-	/** @brief Encapsulated physical and logical vulkan device */
-	vks::VulkanDevice *vulkanDevice;
+    vks::Benchmark benchmark;
 
-	/** @brief Example settings that can be changed e.g. by command line arguments */
-	struct Settings {
-		/** @brief Activates validation layers (and message output) when set to true */
-		bool validation = false;
-		/** @brief Set to true if fullscreen mode has been requested via command line */
-		bool fullscreen = false;
-		/** @brief Set to true if v-sync will be forced for the swapchain */
-		bool vsync = false;
-		/** @brief Enable UI overlay */
-		bool overlay = false;
-	} settings;
+    /** @brief Encapsulated physical and logical vulkan device */
+    vks::VulkanDevice* vulkanDevice;
 
-	VkClearColorValue defaultClearColor = { { 0.025f, 0.025f, 0.025f, 1.0f } };
+    /** @brief Example settings that can be changed e.g. by command line arguments */
+    struct Settings
+    {
+        /** @brief Activates validation layers (and message output) when set to true */
+        bool validation = false;
+        /** @brief Set to true if fullscreen mode has been requested via command line */
+        bool fullscreen = false;
+        /** @brief Set to true if v-sync will be forced for the swapchain */
+        bool vsync = false;
+        /** @brief Enable UI overlay */
+        bool overlay = false;
+    } settings;
 
-	float zoom = 0;
+    VkClearColorValue defaultClearColor = { { 0.025f, 0.025f, 0.025f, 1.0f } };
 
-	static std::vector<const char*> args;
+    float zoom = 0;
 
-	// Defines a frame rate independent timer value clamped from -1.0...1.0
-	// For use in animations, rotations, etc.
-	float timer = 0.0f;
-	// Multiplier for speeding up (or slowing down) the global timer
-	float timerSpeed = 0.25f;
-	
-	bool paused = false;
+    static std::vector<const char*> args;
 
-	// Use to adjust mouse rotation speed
-	float rotationSpeed = 1.0f;
-	// Use to adjust mouse zoom speed
-	float zoomSpeed = 1.0f;
+    // Defines a frame rate independent timer value clamped from -1.0...1.0
+    // For use in animations, rotations, etc.
+    float timer = 0.0f;
+    // Multiplier for speeding up (or slowing down) the global timer
+    float timerSpeed = 0.25f;
 
-	Camera camera;
+    bool paused = false;
 
-	glm::vec3 rotation = glm::vec3();
-	glm::vec3 cameraPos = glm::vec3();
-	glm::vec2 mousePos;
+    // Use to adjust mouse rotation speed
+    float rotationSpeed = 1.0f;
+    // Use to adjust mouse zoom speed
+    float zoomSpeed = 1.0f;
 
-	std::string title = "Vulkan Example";
-	std::string name = "vulkanExample";
-	uint32_t apiVersion = VK_API_VERSION_1_0;
+    Camera camera;
 
-	struct 
-	{
-		VkImage image;
-		VkDeviceMemory mem;
-		VkImageView view;
-	} depthStencil;
+    glm::vec3 rotation = glm::vec3();
+    glm::vec3 cameraPos = glm::vec3();
+    glm::vec2 mousePos;
 
-	struct {
-		glm::vec2 axisLeft = glm::vec2(0.0f);
-		glm::vec2 axisRight = glm::vec2(0.0f);
-	} gamePadState;
+    std::string title = "Vulkan Example";
+    std::string name = "vulkanExample";
+    uint32_t apiVersion = VK_API_VERSION_1_0;
 
-	struct {
-		bool left = false;
-		bool right = false;
-		bool middle = false;
-	} mouseButtons;
+    struct
+    {
+        VkImage image;
+        VkDeviceMemory mem;
+        VkImageView view;
+    } depthStencil;
 
-	// OS specific 
+    struct
+    {
+        glm::vec2 axisLeft = glm::vec2(0.0f);
+        glm::vec2 axisRight = glm::vec2(0.0f);
+    } gamePadState;
+
+    struct
+    {
+        bool left = false;
+        bool right = false;
+        bool middle = false;
+    } mouseButtons;
+
+    // OS specific
 #if defined(_WIN32)
-	HWND window;
-	HINSTANCE windowInstance;
+    HWND window;
+    HINSTANCE windowInstance;
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-	// true if application has focused, false if moved to background
-	bool focused = false;
-	struct TouchPos {
-		int32_t x;
-		int32_t y;
-	} touchPos;
-	bool touchDown = false;
-	double touchTimer = 0.0;
-	int64_t lastTapTime = 0;
-	/** @brief Product model and manufacturer of the Android device (via android.Product*) */
-	std::string androidProduct;
+    // true if application has focused, false if moved to background
+    bool focused = false;
+    struct TouchPos
+    {
+        int32_t x;
+        int32_t y;
+    } touchPos;
+    bool touchDown = false;
+    double touchTimer = 0.0;
+    int64_t lastTapTime = 0;
+    /** @brief Product model and manufacturer of the Android device (via android.Product*) */
+    std::string androidProduct;
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-	void* view;
+    void* view;
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	wl_display *display = nullptr;
-	wl_registry *registry = nullptr;
-	wl_compositor *compositor = nullptr;
-	struct xdg_wm_base *shell = nullptr;
-	wl_seat *seat = nullptr;
-	wl_pointer *pointer = nullptr;
-	wl_keyboard *keyboard = nullptr;
-	wl_surface *surface = nullptr;
-	struct xdg_surface *xdg_surface;
-	struct xdg_toplevel *xdg_toplevel;
-	bool quit = false;
-	bool configured = false;
+    wl_display* display = nullptr;
+    wl_registry* registry = nullptr;
+    wl_compositor* compositor = nullptr;
+    struct xdg_wm_base* shell = nullptr;
+    wl_seat* seat = nullptr;
+    wl_pointer* pointer = nullptr;
+    wl_keyboard* keyboard = nullptr;
+    wl_surface* surface = nullptr;
+    struct xdg_surface* xdg_surface;
+    struct xdg_toplevel* xdg_toplevel;
+    bool quit = false;
+    bool configured = false;
 
 #elif defined(_DIRECT2DISPLAY)
-	bool quit = false;
+    bool quit = false;
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-	bool quit = false;
-	xcb_connection_t *connection;
-	xcb_screen_t *screen;
-	xcb_window_t window;
-	xcb_intern_atom_reply_t *atom_wm_delete_window;
+    bool quit = false;
+    xcb_connection_t* connection;
+    xcb_screen_t* screen;
+    xcb_window_t window;
+    xcb_intern_atom_reply_t* atom_wm_delete_window;
 #endif
 
-	// Default ctor
-	VulkanExampleBase(bool enableValidation = false);
+    // Default ctor
+    VulkanExampleBase(bool enableValidation = false);
 
-	// dtor
-	virtual ~VulkanExampleBase();
+    // dtor
+    virtual ~VulkanExampleBase();
 
-	// Setup the vulkan instance, enable required extensions and connect to the physical device (GPU)
-	bool initVulkan();
+    // Setup the vulkan instance, enable required extensions and connect to the physical device (GPU)
+    bool initVulkan();
 
 #if defined(_WIN32)
-	void setupConsole(std::string title);
-	void setupDPIAwareness();
-	HWND setupWindow(HINSTANCE hinstance, WNDPROC wndproc);
-	void handleMessages(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+    void setupConsole(std::string title);
+    void setupDPIAwareness();
+    HWND setupWindow(HINSTANCE hinstance, WNDPROC wndproc);
+    void handleMessages(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-	static int32_t handleAppInput(struct android_app* app, AInputEvent* event);
-	static void handleAppCommand(android_app* app, int32_t cmd);
+    static int32_t handleAppInput(struct android_app* app, AInputEvent* event);
+    static void handleAppCommand(android_app* app, int32_t cmd);
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-	void* setupWindow(void* view);
+    void* setupWindow(void* view);
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-	struct xdg_surface *setupWindow();
-	void initWaylandConnection();
-	void setSize(int width, int height);
-	static void registryGlobalCb(void *data, struct wl_registry *registry,
-			uint32_t name, const char *interface, uint32_t version);
-	void registryGlobal(struct wl_registry *registry, uint32_t name,
-			const char *interface, uint32_t version);
-	static void registryGlobalRemoveCb(void *data, struct wl_registry *registry,
-			uint32_t name);
-	static void seatCapabilitiesCb(void *data, wl_seat *seat, uint32_t caps);
-	void seatCapabilities(wl_seat *seat, uint32_t caps);
-	static void pointerEnterCb(void *data, struct wl_pointer *pointer,
-			uint32_t serial, struct wl_surface *surface, wl_fixed_t sx,
-			wl_fixed_t sy);
-	static void pointerLeaveCb(void *data, struct wl_pointer *pointer,
-			uint32_t serial, struct wl_surface *surface);
-	static void pointerMotionCb(void *data, struct wl_pointer *pointer,
-			uint32_t time, wl_fixed_t sx, wl_fixed_t sy);
-	void pointerMotion(struct wl_pointer *pointer,
-			uint32_t time, wl_fixed_t sx, wl_fixed_t sy);
-	static void pointerButtonCb(void *data, struct wl_pointer *wl_pointer,
-			uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
-	void pointerButton(struct wl_pointer *wl_pointer,
-			uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
-	static void pointerAxisCb(void *data, struct wl_pointer *wl_pointer,
-			uint32_t time, uint32_t axis, wl_fixed_t value);
-	void pointerAxis(struct wl_pointer *wl_pointer,
-			uint32_t time, uint32_t axis, wl_fixed_t value);
-	static void keyboardKeymapCb(void *data, struct wl_keyboard *keyboard,
-			uint32_t format, int fd, uint32_t size);
-	static void keyboardEnterCb(void *data, struct wl_keyboard *keyboard,
-			uint32_t serial, struct wl_surface *surface, struct wl_array *keys);
-	static void keyboardLeaveCb(void *data, struct wl_keyboard *keyboard,
-			uint32_t serial, struct wl_surface *surface);
-	static void keyboardKeyCb(void *data, struct wl_keyboard *keyboard,
-			uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
-	void keyboardKey(struct wl_keyboard *keyboard,
-			uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
-	static void keyboardModifiersCb(void *data, struct wl_keyboard *keyboard,
-			uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched,
-			uint32_t mods_locked, uint32_t group);
+    struct xdg_surface* setupWindow();
+    void initWaylandConnection();
+    void setSize(int width, int height);
+    static void registryGlobalCb(void* data, struct wl_registry* registry, uint32_t name, const char* interface, uint32_t version);
+    void registryGlobal(struct wl_registry* registry, uint32_t name, const char* interface, uint32_t version);
+    static void registryGlobalRemoveCb(void* data, struct wl_registry* registry, uint32_t name);
+    static void seatCapabilitiesCb(void* data, wl_seat* seat, uint32_t caps);
+    void seatCapabilities(wl_seat* seat, uint32_t caps);
+    static void pointerEnterCb(void* data, struct wl_pointer* pointer, uint32_t serial, struct wl_surface* surface, wl_fixed_t sx, wl_fixed_t sy);
+    static void pointerLeaveCb(void* data, struct wl_pointer* pointer, uint32_t serial, struct wl_surface* surface);
+    static void pointerMotionCb(void* data, struct wl_pointer* pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy);
+    void pointerMotion(struct wl_pointer* pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy);
+    static void pointerButtonCb(void* data, struct wl_pointer* wl_pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
+    void pointerButton(struct wl_pointer* wl_pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
+    static void pointerAxisCb(void* data, struct wl_pointer* wl_pointer, uint32_t time, uint32_t axis, wl_fixed_t value);
+    void pointerAxis(struct wl_pointer* wl_pointer, uint32_t time, uint32_t axis, wl_fixed_t value);
+    static void keyboardKeymapCb(void* data, struct wl_keyboard* keyboard, uint32_t format, int fd, uint32_t size);
+    static void keyboardEnterCb(void* data, struct wl_keyboard* keyboard, uint32_t serial, struct wl_surface* surface, struct wl_array* keys);
+    static void keyboardLeaveCb(void* data, struct wl_keyboard* keyboard, uint32_t serial, struct wl_surface* surface);
+    static void keyboardKeyCb(void* data, struct wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
+    void keyboardKey(struct wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
+    static void keyboardModifiersCb(void* data,
+                                    struct wl_keyboard* keyboard,
+                                    uint32_t serial,
+                                    uint32_t mods_depressed,
+                                    uint32_t mods_latched,
+                                    uint32_t mods_locked,
+                                    uint32_t group);
 
 #elif defined(_DIRECT2DISPLAY)
 //
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-	xcb_window_t setupWindow();
-	void initxcbConnection();
-	void handleEvent(const xcb_generic_event_t *event);
+    xcb_window_t setupWindow();
+    void initxcbConnection();
+    void handleEvent(const xcb_generic_event_t* event);
 #endif
-	/**
+    /**
 	* Create the application wide Vulkan instance
 	*
 	* @note Virtual, can be overriden by derived example class for custom instance creation
 	*/
-	virtual VkResult createInstance(bool enableValidation);
+    virtual VkResult createInstance(bool enableValidation);
 
-	// Pure virtual render function (override in derived class)
-	virtual void render() = 0;
-	// Called when view change occurs
-	// Can be overriden in derived class to e.g. update uniform buffers 
-	// Containing view dependant matrices
-	virtual void viewChanged();
-	/** @brief (Virtual) Called after a key was pressed, can be used to do custom key handling */
-	virtual void keyPressed(uint32_t);
-	/** @brief (Virtual) Called after th mouse cursor moved and before internal events (like camera rotation) is handled */
-	virtual void mouseMoved(double x, double y, bool &handled);
-	// Called when the window has been resized
-	// Can be overriden in derived class to recreate or rebuild resources attached to the frame buffer / swapchain
-	virtual void windowResized();
-	// Pure virtual function to be overriden by the dervice class
-	// Called in case of an event where e.g. the framebuffer has to be rebuild and thus
-	// all command buffers that may reference this
-	virtual void buildCommandBuffers();
+    // Pure virtual render function (override in derived class)
+    virtual void render() = 0;
+    // Called when view change occurs
+    // Can be overriden in derived class to e.g. update uniform buffers
+    // Containing view dependant matrices
+    virtual void viewChanged();
+    /** @brief (Virtual) Called after a key was pressed, can be used to do custom key handling */
+    virtual void keyPressed(uint32_t);
+    /** @brief (Virtual) Called after th mouse cursor moved and before internal events (like camera rotation) is handled */
+    virtual void mouseMoved(double x, double y, bool& handled);
+    // Called when the window has been resized
+    // Can be overriden in derived class to recreate or rebuild resources attached to the frame buffer / swapchain
+    virtual void windowResized();
+    // Pure virtual function to be overriden by the dervice class
+    // Called in case of an event where e.g. the framebuffer has to be rebuild and thus
+    // all command buffers that may reference this
+    virtual void buildCommandBuffers();
 
-	void createSynchronizationPrimitives();
+    void createSynchronizationPrimitives();
 
-	// Creates a new (graphics) command pool object storing command buffers
-	void createCommandPool();
-	// Setup default depth and stencil views
-	virtual void setupDepthStencil();
-	// Create framebuffers for all requested swap chain images
-	// Can be overriden in derived class to setup a custom framebuffer (e.g. for MSAA)
-	virtual void setupFrameBuffer();
-	// Setup a default render pass
-	// Can be overriden in derived class to setup a custom render pass (e.g. for MSAA)
-	virtual void setupRenderPass();
+    // Creates a new (graphics) command pool object storing command buffers
+    void createCommandPool();
+    // Setup default depth and stencil views
+    virtual void setupDepthStencil();
+    // Create framebuffers for all requested swap chain images
+    // Can be overriden in derived class to setup a custom framebuffer (e.g. for MSAA)
+    virtual void setupFrameBuffer();
+    // Setup a default render pass
+    // Can be overriden in derived class to setup a custom render pass (e.g. for MSAA)
+    virtual void setupRenderPass();
 
-	/** @brief (Virtual) Called after the physical device features have been read, can be used to set features to enable on the device */
-	virtual void getEnabledFeatures();
+    /** @brief (Virtual) Called after the physical device features have been read, can be used to set features to enable on the device */
+    virtual void getEnabledFeatures();
 
-	// Connect and prepare the swap chain
-	void initSwapchain();
-	// Create swap chain images
-	void setupSwapChain();
+    // Connect and prepare the swap chain
+    void initSwapchain();
+    // Create swap chain images
+    void setupSwapChain();
 
-	// Check if command buffers are valid (!= VK_NULL_HANDLE)
-	bool checkCommandBuffers();
-	// Create command buffers for drawing commands
-	void createCommandBuffers();
-	// Destroy all command buffers and set their handles to VK_NULL_HANDLE
-	// May be necessary during runtime if options are toggled 
-	void destroyCommandBuffers();
+    // Check if command buffers are valid (!= VK_NULL_HANDLE)
+    bool checkCommandBuffers();
+    // Create command buffers for drawing commands
+    void createCommandBuffers();
+    // Destroy all command buffers and set their handles to VK_NULL_HANDLE
+    // May be necessary during runtime if options are toggled
+    void destroyCommandBuffers();
 
-	// Command buffer creation
-	// Creates and returns a new command buffer
-	VkCommandBuffer createCommandBuffer(VkCommandBufferLevel level, bool begin);
-	// End the command buffer, submit it to the queue and free (if requested)
-	// Note : Waits for the queue to become idle
-	void flushCommandBuffer(VkCommandBuffer commandBuffer, VkQueue queue, bool free);
+    // Command buffer creation
+    // Creates and returns a new command buffer
+    VkCommandBuffer createCommandBuffer(VkCommandBufferLevel level, bool begin);
+    // End the command buffer, submit it to the queue and free (if requested)
+    // Note : Waits for the queue to become idle
+    void flushCommandBuffer(VkCommandBuffer commandBuffer, VkQueue queue, bool free);
 
-	// Create a cache pool for rendering pipelines
-	void createPipelineCache();
+    // Create a cache pool for rendering pipelines
+    void createPipelineCache();
 
-	// Prepare commonly used Vulkan functions
-	virtual void prepare();
+    // Prepare commonly used Vulkan functions
+    virtual void prepare();
 
-	// Load a SPIR-V shader
-	VkPipelineShaderStageCreateInfo loadShader(std::string fileName, VkShaderStageFlagBits stage);
-	
-	// Start the main render loop
-	void renderLoop();
+    // Load a SPIR-V shader
+    VkPipelineShaderStageCreateInfo loadShader(std::string fileName, VkShaderStageFlagBits stage);
 
-	// Render one frame of a render loop on platforms that sync rendering
-	void renderFrame();
+    // Start the main render loop
+    void renderLoop();
 
-	void updateOverlay();
-	void drawUI(const VkCommandBuffer commandBuffer);
+    // Render one frame of a render loop on platforms that sync rendering
+    void renderFrame();
 
-	// Prepare the frame for workload submission
-	// - Acquires the next image from the swap chain 
-	// - Sets the default wait and signal semaphores
-	void prepareFrame();
+    void updateOverlay();
+    void drawUI(const VkCommandBuffer commandBuffer);
 
-	// Submit the frames' workload 
-	void submitFrame();
+    // Prepare the frame for workload submission
+    // - Acquires the next image from the swap chain
+    // - Sets the default wait and signal semaphores
+    void prepareFrame();
 
-	/** @brief (Virtual) Called when the UI overlay is updating, can be used to add custom elements to the overlay */
-	virtual void OnUpdateUIOverlay(vks::UIOverlay *overlay);
+    // Submit the frames' workload
+    void submitFrame();
+
+    /** @brief (Virtual) Called when the UI overlay is updating, can be used to add custom elements to the overlay */
+    virtual void OnUpdateUIOverlay(vks::UIOverlay* overlay);
 };
 
 // OS specific macros for the example main entry points
 #if defined(_WIN32)
 // Windows entry point
-#define VULKAN_EXAMPLE_MAIN()																		\
-VulkanExample *vulkanExample;																		\
-LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)						\
-{																									\
-	if (vulkanExample != NULL)																		\
-	{																								\
-		vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);									\
-	}																								\
-	return (DefWindowProc(hWnd, uMsg, wParam, lParam));												\
-}																									\
-int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)									\
-{																									\
-	for (int32_t i = 0; i < __argc; i++) { VulkanExample::args.push_back(__argv[i]); };  			\
-	vulkanExample = new VulkanExample();															\
-	vulkanExample->initVulkan();																	\
-	vulkanExample->setupWindow(hInstance, WndProc);													\
-	vulkanExample->prepare();																		\
-	vulkanExample->renderLoop();																	\
-	delete(vulkanExample);																			\
-	return 0;																						\
-}																									
+#define VULKAN_EXAMPLE_MAIN()                                                    \
+    VulkanExample* vulkanExample;                                                \
+    LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) \
+    {                                                                            \
+        if (vulkanExample != NULL)                                               \
+        {                                                                        \
+            vulkanExample->handleMessages(hWnd, uMsg, wParam, lParam);           \
+        }                                                                        \
+        return (DefWindowProc(hWnd, uMsg, wParam, lParam));                      \
+    }                                                                            \
+    int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)             \
+    {                                                                            \
+        for (int32_t i = 0; i < __argc; i++)                                     \
+        {                                                                        \
+            VulkanExample::args.push_back(__argv[i]);                            \
+        };                                                                       \
+        vulkanExample = new VulkanExample();                                     \
+        vulkanExample->initVulkan();                                             \
+        vulkanExample->setupWindow(hInstance, WndProc);                          \
+        vulkanExample->prepare();                                                \
+        vulkanExample->renderLoop();                                             \
+        delete (vulkanExample);                                                  \
+        return 0;                                                                \
+    }
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
 // Android entry point
-#define VULKAN_EXAMPLE_MAIN()																		\
-VulkanExample *vulkanExample;																		\
-void android_main(android_app* state)																\
-{																									\
-	vulkanExample = new VulkanExample();															\
-	state->userData = vulkanExample;																\
-	state->onAppCmd = VulkanExample::handleAppCommand;												\
-	state->onInputEvent = VulkanExample::handleAppInput;											\
-	androidApp = state;																				\
-	vks::android::getDeviceConfig();																\
-	vulkanExample->renderLoop();																	\
-	delete(vulkanExample);																			\
-}
+#define VULKAN_EXAMPLE_MAIN()                                \
+    VulkanExample* vulkanExample;                            \
+    void android_main(android_app* state)                    \
+    {                                                        \
+        vulkanExample = new VulkanExample();                 \
+        state->userData = vulkanExample;                     \
+        state->onAppCmd = VulkanExample::handleAppCommand;   \
+        state->onInputEvent = VulkanExample::handleAppInput; \
+        androidApp = state;                                  \
+        vks::android::getDeviceConfig();                     \
+        vulkanExample->renderLoop();                         \
+        delete (vulkanExample);                              \
+    }
 #elif defined(_DIRECT2DISPLAY)
 // Linux entry point with direct to display wsi
-#define VULKAN_EXAMPLE_MAIN()																		\
-VulkanExample *vulkanExample;																		\
-static void handleEvent()                                											\
-{																									\
-}																									\
-int main(const int argc, const char *argv[])													    \
-{																									\
-	for (size_t i = 0; i < argc; i++) { VulkanExample::args.push_back(argv[i]); };  				\
-	vulkanExample = new VulkanExample();															\
-	vulkanExample->initVulkan();																	\
-	vulkanExample->prepare();																		\
-	vulkanExample->renderLoop();																	\
-	delete(vulkanExample);																			\
-	return 0;																						\
-}
+#define VULKAN_EXAMPLE_MAIN()                       \
+    VulkanExample* vulkanExample;                   \
+    static void handleEvent()                       \
+    {}                                              \
+    int main(const int argc, const char* argv[])    \
+    {                                               \
+        for (size_t i = 0; i < argc; i++)           \
+        {                                           \
+            VulkanExample::args.push_back(argv[i]); \
+        };                                          \
+        vulkanExample = new VulkanExample();        \
+        vulkanExample->initVulkan();                \
+        vulkanExample->prepare();                   \
+        vulkanExample->renderLoop();                \
+        delete (vulkanExample);                     \
+        return 0;                                   \
+    }
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-#define VULKAN_EXAMPLE_MAIN()																		\
-VulkanExample *vulkanExample;																		\
-int main(const int argc, const char *argv[])													    \
-{																									\
-	for (size_t i = 0; i < argc; i++) { VulkanExample::args.push_back(argv[i]); };  				\
-	vulkanExample = new VulkanExample();															\
-	vulkanExample->initVulkan();																	\
-	vulkanExample->setupWindow();					 												\
-	vulkanExample->prepare();																		\
-	vulkanExample->renderLoop();																	\
-	delete(vulkanExample);																			\
-	return 0;																						\
-}
+#define VULKAN_EXAMPLE_MAIN()                       \
+    VulkanExample* vulkanExample;                   \
+    int main(const int argc, const char* argv[])    \
+    {                                               \
+        for (size_t i = 0; i < argc; i++)           \
+        {                                           \
+            VulkanExample::args.push_back(argv[i]); \
+        };                                          \
+        vulkanExample = new VulkanExample();        \
+        vulkanExample->initVulkan();                \
+        vulkanExample->setupWindow();               \
+        vulkanExample->prepare();                   \
+        vulkanExample->renderLoop();                \
+        delete (vulkanExample);                     \
+        return 0;                                   \
+    }
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-#define VULKAN_EXAMPLE_MAIN()																		\
-VulkanExample *vulkanExample;																		\
-static void handleEvent(const xcb_generic_event_t *event)											\
-{																									\
-	if (vulkanExample != NULL)																		\
-	{																								\
-		vulkanExample->handleEvent(event);															\
-	}																								\
-}																									\
-int main(const int argc, const char *argv[])													    \
-{																									\
-	for (size_t i = 0; i < argc; i++) { VulkanExample::args.push_back(argv[i]); };  				\
-	vulkanExample = new VulkanExample();															\
-	vulkanExample->initVulkan();																	\
-	vulkanExample->setupWindow();					 												\
-	vulkanExample->prepare();																		\
-	vulkanExample->renderLoop();																	\
-	delete(vulkanExample);																			\
-	return 0;																						\
-}
+#define VULKAN_EXAMPLE_MAIN()                                 \
+    VulkanExample* vulkanExample;                             \
+    static void handleEvent(const xcb_generic_event_t* event) \
+    {                                                         \
+        if (vulkanExample != NULL)                            \
+        {                                                     \
+            vulkanExample->handleEvent(event);                \
+        }                                                     \
+    }                                                         \
+    int main(const int argc, const char* argv[])              \
+    {                                                         \
+        for (size_t i = 0; i < argc; i++)                     \
+        {                                                     \
+            VulkanExample::args.push_back(argv[i]);           \
+        };                                                    \
+        vulkanExample = new VulkanExample();                  \
+        vulkanExample->initVulkan();                          \
+        vulkanExample->setupWindow();                         \
+        vulkanExample->prepare();                             \
+        vulkanExample->renderLoop();                          \
+        delete (vulkanExample);                               \
+        return 0;                                             \
+    }
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
 #define VULKAN_EXAMPLE_MAIN()
 #endif


### PR DESCRIPTION
This PR adds a .clang-format file to the root of the repository, and also reformats the contents of the `base` directory based on this file.  

I've attempted to setup the format file to produce the minimal possible changes, although I wasn't able to produce one that created NO changes, mostly due to 

* inconsistent use of spaces vs tabs in the code... clang format will reformat to one or the other
* inconsistent use of brace positioning in the code
* some small items I don't know how to tell clang-format to do

