### PR TITLE
Fix the validation error for buffer copy

### DIFF
--- a/base/VulkanDevice.hpp
+++ b/base/VulkanDevice.hpp
@@ -416,7 +416,7 @@ namespace vks
 			VK_CHECK_RESULT(vkAllocateMemory(logicalDevice, &memAlloc, nullptr, &buffer->memory));
 
 			buffer->alignment = memReqs.alignment;
-			buffer->size = memAlloc.allocationSize;
+			buffer->size = size;
 			buffer->usageFlags = usageFlags;
 			buffer->memoryPropertyFlags = memoryPropertyFlags;
 


### PR DESCRIPTION
vulkanDevice->copyBuffer use the size from the buffer creation for copy, this size was set the the memory size, which will cause following validation error for the `conservativeraster` sample

```shell
VUID-vkCmdCopyBuffer-size-00115(ERROR / SPEC): msgNum: 0 - vkCmdCopyBuffer(): pRegions[0].size (256) is greater than the source buffer size (72) minus pRegions[0].srcOffset (0). The Vulkan spec states: The size member of each element of pRegions must be less than or equal to the size of srcBuffer minus srcOffset (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkCmdCopyBuffer-size-00115)
    Objects: 1
        [0] 0x260000000026, type: 9, name: NULL
VUID-vkCmdCopyBuffer-size-00116(ERROR / SPEC): msgNum: 0 - vkCmdCopyBuffer(): pRegions[0].size (256) is greater than the destination buffer size (72) minus pRegions[0].dstOffset (0). The Vulkan spec states: The size member of each element of pRegions must be less than or equal to the size of dstBuffer minus dstOffset (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkCmdCopyBuffer-size-00116)
    Objects: 1
        [0] 0x2a000000002a, type: 9, name: NULL
VUID-vkCmdCopyBuffer-size-00115(ERROR / SPEC): msgNum: 0 - vkCmdCopyBuffer(): pRegions[0].size (256) is greater than the source buffer size (12) minus pRegions[0].srcOffset (0). The Vulkan spec states: The size member of each element of pRegions must be less than or equal to the size of srcBuffer minus srcOffset (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkCmdCopyBuffer-size-00115)
    Objects: 1
        [0] 0x280000000028, type: 9, name: NULL
VUID-vkCmdCopyBuffer-size-00116(ERROR / SPEC): msgNum: 0 - vkCmdCopyBuffer(): pRegions[0].size (256) is greater than the destination buffer size (12) minus pRegions[0].dstOffset (0). The Vulkan spec states: The size member of each element of pRegions must be less than or equal to the size of dstBuffer minus dstOffset (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkCmdCopyBuffer-size-00116)
    Objects: 1
        [0] 0x2c000000002c, type: 9, name: NULL
``` 