### PR TITLE
Fix Android build of computecloth demo

### DIFF
--- a/examples/computecloth/computecloth.cpp
+++ b/examples/computecloth/computecloth.cpp
@@ -68,8 +68,8 @@ public:
 			vks::Buffer output;
 		} storageBuffers;
 		struct Semaphores {
-			VkSemaphore ready{ nullptr };
-			VkSemaphore complete{ nullptr };
+			VkSemaphore ready{ 0L };
+			VkSemaphore complete{ 0L };
 		} semaphores;
 		vks::Buffer uniformBuffer;
 		VkQueue queue;


### PR DESCRIPTION
The NDK compiler currently fails with:

```
examples/computecloth/computecloth.cpp:71:23: error: cannot
initialize a member subobject of type 'VkSemaphore' (aka 'unsigned
long long') with an rvalue of type 'nullptr_t'
                          VkSemaphore ready{ nullptr };
```