### PR TITLE
Fix the cmake_minimum_required for the libktx

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 2.8)
 
 project(external LANGUAGES C CXX)
 


### PR DESCRIPTION
I believe that 3.8 was a mistake. I am running 3.5, but all other CmakeFiles have 2.8 as minimum.