### PR TITLE
Some cleanup in base

### DIFF
--- a/base/VulkanDevice.hpp
+++ b/base/VulkanDevice.hpp
@@ -13,6 +13,7 @@
 #include <exception>
 #include <assert.h>
 #include <algorithm>
+
 #include "vulkan/vulkan.h"
 #include "VulkanTools.h"
 #include "VulkanBuffer.hpp"
@@ -53,14 +54,14 @@ namespace vks
 		} queueFamilyIndices;
 
 		/**  @brief Typecast to VkDevice */
-		operator VkDevice() { return logicalDevice; };
+		operator VkDevice() const { return logicalDevice; };
 
 		/**
 		* Default constructor
 		*
 		* @param physicalDevice Physical device that is to be used
 		*/
-		VulkanDevice(VkPhysicalDevice physicalDevice)
+		explicit VulkanDevice(VkPhysicalDevice physicalDevice)
 		{
 			assert(physicalDevice);
 			this->physicalDevice = physicalDevice;
@@ -81,16 +82,16 @@ namespace vks
 
 			// Get list of supported extensions
 			uint32_t extCount = 0;
-			vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, nullptr);
+			VK_CHECK_RESULT(vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, nullptr));
 			if (extCount > 0)
 			{
 				std::vector<VkExtensionProperties> extensions(extCount);
 				if (vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, &extensions.front()) == VK_SUCCESS)
 				{
-					for (auto ext : extensions)
-					{
-						supportedExtensions.push_back(ext.extensionName);
-					}
+					supportedExtensions.reserve(extensions.size());
+					std::transform(extensions.cbegin(), extensions.cend(),
+					std::back_inserter(supportedExtensions),
+					[](const VkExtensionProperties& ext){ return ext.extensionName;});
 				}
 			}
 		}
@@ -123,7 +124,7 @@ namespace vks
 		*
 		* @throw Throws an exception if memTypeFound is null and no memory type could be found that supports the requested properties
 		*/
-		uint32_t getMemoryType(uint32_t typeBits, VkMemoryPropertyFlags properties, VkBool32 *memTypeFound = nullptr)
+		uint32_t getMemoryType(uint32_t typeBits, VkMemoryPropertyFlags properties, VkBool32 *memTypeFound = nullptr) const
 		{
 			for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; i++)
 			{
@@ -161,7 +162,7 @@ namespace vks
 		*
 		* @throw Throws an exception if no queue family index could be found that supports the requested flags
 		*/
-		uint32_t getQueueFamilyIndex(VkQueueFlagBits queueFlags)
+		uint32_t getQueueFamilyIndex(VkQueueFlagBits queueFlags) const
 		{
 			// Dedicated queue for compute
 			// Try to find a queue family index that supports compute but not graphics
@@ -172,7 +173,6 @@ namespace vks
 					if ((queueFamilyProperties[i].queueFlags & queueFlags) && ((queueFamilyProperties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0))
 					{
 						return i;
-						break;
 					}
 				}
 			}
@@ -186,7 +186,6 @@ namespace vks
 					if ((queueFamilyProperties[i].queueFlags & queueFlags) && ((queueFamilyProperties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0) && ((queueFamilyProperties[i].queueFlags & VK_QUEUE_COMPUTE_BIT) == 0))
 					{
 						return i;
-						break;
 					}
 				}
 			}
@@ -197,7 +196,6 @@ namespace vks
 				if (queueFamilyProperties[i].queueFlags & queueFlags)
 				{
 					return i;
-					break;
 				}
 			}
 

--- a/base/VulkanSwapChain.hpp
+++ b/base/VulkanSwapChain.hpp
@@ -52,10 +52,10 @@ typedef struct _SwapChainBuffers {
 class VulkanSwapChain
 {
 private: 
-	VkInstance instance;
-	VkDevice device;
-	VkPhysicalDevice physicalDevice;
-	VkSurfaceKHR surface;
+	VkInstance instance = VK_NULL_HANDLE;
+	VkDevice device = VK_NULL_HANDLE;
+	VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+	VkSurfaceKHR surface = VK_NULL_HANDLE;
 	// Function pointers
 	PFN_vkGetPhysicalDeviceSurfaceSupportKHR fpGetPhysicalDeviceSurfaceSupportKHR;
 	PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR fpGetPhysicalDeviceSurfaceCapabilitiesKHR; 
@@ -67,11 +67,11 @@ private:
 	PFN_vkAcquireNextImageKHR fpAcquireNextImageKHR;
 	PFN_vkQueuePresentKHR fpQueuePresentKHR;
 public:
-	VkFormat colorFormat;
-	VkColorSpaceKHR colorSpace;
+	VkFormat colorFormat = VK_FORMAT_UNDEFINED;
+	VkColorSpaceKHR colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 	/** @brief Handle to the current swap chain, required for recreation */
 	VkSwapchainKHR swapChain = VK_NULL_HANDLE;	
-	uint32_t imageCount;
+	uint32_t imageCount = 0;
 	std::vector<VkImage> images;
 	std::vector<SwapChainBuffer> buffers;
 	/** @brief Queue family index of the detected graphics and presenting device queue */
@@ -225,13 +225,12 @@ public:
 		{
 			// Check for the presence of VK_FORMAT_B8G8R8A8_UNORM
 			auto found_unorm = std::find_if(
-				std::cbegin(surfaceFormats),
-				std::cend(surfaceFormats),
+				surfaceFormats.cbegin(), surfaceFormats.cend(),
 				[](const VkSurfaceFormatKHR& surfaceFormat){
 					return surfaceFormat.format == VK_FORMAT_B8G8R8_UNORM;
 				});
 			
-			if (found_unorm != std::cend(surfaceFormats)) {
+			if (found_unorm != surfaceFormats.cend()) {
 				colorFormat = found_unorm->format;
 				colorSpace = found_unorm->colorSpace;
 			} else {
@@ -365,14 +364,14 @@ public:
 		};
 
 		auto findCompositeAlphaFlag = std::find_if(
-			std::cbegin(compositeAlphaFlags),
-			std::cend(compositeAlphaFlags),
+			compositeAlphaFlags.cbegin(),
+			compositeAlphaFlags.cend(),
 			[&](const VkCompositeAlphaFlagBitsKHR& compositeAlphaFlag) {
 				return compositeAlphaFlag & surfCaps.supportedCompositeAlpha;
 			}
 		);
 
-		if (findCompositeAlphaFlag != std::cend(compositeAlphaFlags)) {
+		if (findCompositeAlphaFlag != compositeAlphaFlags.cend()) {
 			compositeAlpha = *findCompositeAlphaFlag;
 		}
 

--- a/base/VulkanTools.cpp
+++ b/base/VulkanTools.cpp
@@ -352,7 +352,7 @@ namespace vks
 			}
 			else
 			{
-				std::cerr << "Error: Could not open shader file \"" << fileName << "\"" << std::endl;
+				std::cerr << "Error: Could not open shader file \"" << fileName << "\"" << "\n";
 				return VK_NULL_HANDLE;
 			}
 		}

--- a/base/VulkanTools.h
+++ b/base/VulkanTools.h
@@ -53,7 +53,7 @@
 	VkResult res = (f);																					\
 	if (res != VK_SUCCESS)																				\
 	{																									\
-		std::cout << "Fatal : VkResult is \"" << vks::tools::errorString(res) << "\" in " << __FILE__ << " at line " << __LINE__ << std::endl; \
+		std::cout << "Fatal : VkResult is \"" << vks::tools::errorString(res) << "\" in " << __FILE__ << " at line " << __LINE__ << "\n"; \
 		assert(res == VK_SUCCESS);																		\
 	}																									\
 }

--- a/base/VulkanUIOverlay.cpp
+++ b/base/VulkanUIOverlay.cpp
@@ -318,7 +318,6 @@ namespace vks
 		}
 
 		// Index buffer
-		VkDeviceSize indexSize = imDrawData->TotalIdxCount * sizeof(ImDrawIdx);
 		if ((indexBuffer.buffer == VK_NULL_HANDLE) || (indexCount < imDrawData->TotalIdxCount)) {
 			indexBuffer.unmap();
 			indexBuffer.destroy();
@@ -329,8 +328,8 @@ namespace vks
 		}
 
 		// Upload data
-		ImDrawVert* vtxDst = (ImDrawVert*)vertexBuffer.mapped;
-		ImDrawIdx* idxDst = (ImDrawIdx*)indexBuffer.mapped;
+		ImDrawVert* vtxDst = static_cast<ImDrawVert*>(vertexBuffer.mapped);
+		ImDrawIdx* idxDst = static_cast<ImDrawIdx*>(indexBuffer.mapped);
 
 		for (int n = 0; n < imDrawData->CmdListsCount; n++) {
 			const ImDrawList* cmd_list = imDrawData->CmdLists[n];
@@ -357,7 +356,7 @@ namespace vks
 			return;
 		}
 
-		ImGuiIO& io = ImGui::GetIO();
+		const ImGuiIO& io = ImGui::GetIO();
 
 		vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
 		vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &descriptorSet, 0, NULL);

--- a/base/VulkanUIOverlay.h
+++ b/base/VulkanUIOverlay.h
@@ -33,7 +33,7 @@ namespace vks
 	class UIOverlay 
 	{
 	public:
-		vks::VulkanDevice *device;
+		vks::VulkanDevice *device = nullptr;
 		VkQueue queue;
 
 		VkSampleCountFlagBits rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
@@ -74,11 +74,11 @@ namespace vks
 
 		bool update();
 		void draw(const VkCommandBuffer commandBuffer);
-		void resize(uint32_t width, uint32_t height);
+		static void resize(uint32_t width, uint32_t height);
 
 		void freeResources();
 
-		bool header(const char* caption);
+		static bool header(const char* caption);
 		bool checkBox(const char* caption, bool* value);
 		bool checkBox(const char* caption, int32_t* value);
 		bool inputFloat(const char* caption, float* value, float step, uint32_t precision);
@@ -86,6 +86,6 @@ namespace vks
 		bool sliderInt(const char* caption, int32_t* value, int32_t min, int32_t max);
 		bool comboBox(const char* caption, int32_t* itemindex, std::vector<std::string> items);
 		bool button(const char* caption);
-		void text(const char* formatstr, ...);
+		static void text(const char* formatstr, ...);
 	};
 }

--- a/base/VulkanglTFModel.hpp
+++ b/base/VulkanglTFModel.hpp
@@ -779,7 +779,7 @@ namespace vkglTF
 							break;
 						}
 						default:
-							std::cerr << "Index component type " << accessor.componentType << " not supported!" << std::endl;
+							std::cerr << "Index component type " << accessor.componentType << " not supported!" << "\n";
 							return;
 						}
 					}
@@ -959,7 +959,7 @@ namespace vkglTF
 							break;
 						}
 						default: {
-							std::cout << "unknown type" << std::endl;
+							std::cout << "unknown type" << "\n";
 							break;
 						}
 						}
@@ -982,7 +982,7 @@ namespace vkglTF
 						channel.path = AnimationChannel::PathType::SCALE;
 					}
 					if (source.target_path == "weights") {
-						std::cout << "weights not yet supported, skipping channel" << std::endl;
+						std::cout << "weights not yet supported, skipping channel" << "\n";
 						continue;
 					}
 					channel.samplerIndex = source.sampler;
@@ -1049,7 +1049,7 @@ namespace vkglTF
 			}
 			else {
 				// TODO: throw
-				std::cerr << "Could not load gltf file: " << error << std::endl;
+				std::cerr << "Could not load gltf file: " << error << "\n";
 				return;
 			}
 
@@ -1236,7 +1236,7 @@ namespace vkglTF
 		void updateAnimation(uint32_t index, float time) 
 		{
 			if (index > static_cast<uint32_t>(animations.size()) - 1) {
-				std::cout << "No animation with index " << index << std::endl;
+				std::cout << "No animation with index " << index << "\n";
 				return;
 			}
 			Animation &animation = animations[index];

--- a/base/benchmark.hpp
+++ b/base/benchmark.hpp
@@ -66,11 +66,11 @@ namespace vks
 					frameTimes.push_back(tDiff);
 					frameCount++;
 				};
-				std::cout << "Benchmark finished" << std::endl;
-				std::cout << "device : " << deviceProps.deviceName << " (driver version: " << deviceProps.driverVersion << ")" << std::endl;
-				std::cout << "runtime: " << (runtime / 1000.0) << std::endl;
-				std::cout << "frames : " << frameCount << std::endl;
-				std::cout << "fps    : " << frameCount / (runtime / 1000.0) << std::endl;
+				std::cout << "Benchmark finished" << "\n";
+				std::cout << "device : " << deviceProps.deviceName << " (driver version: " << deviceProps.driverVersion << ")" << "\n";
+				std::cout << "runtime: " << (runtime / 1000.0) << "\n";
+				std::cout << "frames : " << frameCount << "\n";
+				std::cout << "fps    : " << frameCount / (runtime / 1000.0) << "\n";
 			}
 		}
 
@@ -79,21 +79,21 @@ namespace vks
 			if (result.is_open()) {
 				result << std::fixed << std::setprecision(4);
 
-				result << "device,driverversion,duration (ms),frames,fps" << std::endl;
-				result << deviceProps.deviceName << "," << deviceProps.driverVersion << "," << runtime << "," << frameCount << "," << frameCount / (runtime / 1000.0) << std::endl;
+				result << "device,driverversion,duration (ms),frames,fps" << "\n";
+				result << deviceProps.deviceName << "," << deviceProps.driverVersion << "," << runtime << "," << frameCount << "," << frameCount / (runtime / 1000.0) << "\n";
 
 				if (outputFrameTimes) {
-					result << std::endl << "frame,ms" << std::endl;
+					result << std::endl << "frame,ms" << "\n";
 					for (size_t i = 0; i < frameTimes.size(); i++) {
-						result << i << "," << frameTimes[i] << std::endl;
+						result << i << "," << frameTimes[i] << "\n";
 					}
 					double tMin = *std::min_element(frameTimes.begin(), frameTimes.end());
 					double tMax = *std::max_element(frameTimes.begin(), frameTimes.end());
 					double tAvg = std::accumulate(frameTimes.begin(), frameTimes.end(), 0.0) / (double)frameTimes.size();
-					std::cout << "best   : " << (1000.0 / tMin) << " fps (" << tMin << " ms)" << std::endl;
-					std::cout << "worst  : " << (1000.0 / tMax) << " fps (" << tMax << " ms)" << std::endl;
-					std::cout << "avg    : " << (1000.0 / tAvg) << " fps (" << tAvg << " ms)" << std::endl;
-					std::cout << std::endl;
+					std::cout << "best   : " << (1000.0 / tMin) << " fps (" << tMin << " ms)" << "\n";
+					std::cout << "worst  : " << (1000.0 / tMax) << " fps (" << tMax << " ms)" << "\n";
+					std::cout << "avg    : " << (1000.0 / tAvg) << " fps (" << tAvg << " ms)" << "\n";
+					std::cout << "\n";
 				}
 
 				result.flush();

--- a/base/benchmark.hpp
+++ b/base/benchmark.hpp
@@ -18,7 +18,7 @@ namespace vks
 {
 	class Benchmark {
 	private:
-		FILE *stream;
+		FILE *stream = nullptr;
 		VkPhysicalDeviceProperties deviceProps;
 	public:
 		bool active = false;
@@ -36,8 +36,12 @@ namespace vks
 			this->deviceProps = deviceProps;
 #if defined(_WIN32)
 			AttachConsole(ATTACH_PARENT_PROCESS);
-			freopen_s(&stream, "CONOUT$", "w+", stdout);
-			freopen_s(&stream, "CONOUT$", "w+", stderr);
+			if (freopen_s(&stream, "CONOUT$", "w+", stdout)) {
+				std::cerr << "Unable to redirect stdout to file" << "\n";
+			}
+			if (freopen_s(&stream, "CONOUT$", "w+", stderr)) {
+				std::cerr << "Unable to redirect stdout to file" << "\n";
+			}
 #endif
 			std::cout << std::fixed << std::setprecision(3);
 

--- a/base/camera.hpp
+++ b/base/camera.hpp
@@ -15,8 +15,9 @@
 class Camera
 {
 private:
-	float fov;
-	float znear, zfar;
+	float fov = 0.0f;
+	float znear = 0.0f;
+	float zfar = 0.0f;
 
 	void updateViewMatrix()
 	{
@@ -74,16 +75,18 @@ public:
 		bool down = false;
 	} keys;
 
-	bool moving()
+	bool moving() const
 	{
 		return keys.left || keys.right || keys.up || keys.down;
 	}
 
-	float getNearClip() { 
+	float getNearClip() const 
+	{ 
 		return znear;
 	}
 
-	float getFarClip() {
+	float getFarClip() const 
+	{
 		return zfar;
 	}
 

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -59,8 +59,8 @@ class VulkanExampleBase
 private:
 	std::string getWindowTitle();
 	bool viewUpdated = false;
-	uint32_t destWidth;
-	uint32_t destHeight;
+	uint32_t destWidth = 0;
+	uint32_t destHeight = 0;
 	bool resizing = false;
 	void windowResize();
 	void handleMouseMove(int32_t x, int32_t y);
@@ -144,7 +144,7 @@ public:
 	vks::Benchmark benchmark;
 
 	/** @brief Encapsulated physical and logical vulkan device */
-	vks::VulkanDevice *vulkanDevice;
+	vks::VulkanDevice *vulkanDevice = nullptr;
 
 	/** @brief Example settings that can be changed e.g. by command line arguments */
 	struct Settings {
@@ -201,8 +201,8 @@ public:
 	// true if application has focused, false if moved to background
 	bool focused = false;
 	struct TouchPos {
-		int32_t x;
-		int32_t y;
+		int32_t x = 0;
+		int32_t y = 0;
 	} touchPos;
 	bool touchDown = false;
 	double touchTimer = 0.0;
@@ -210,7 +210,7 @@ public:
 	/** @brief Product model and manufacturer of the Android device (via android.Product*) */
 	std::string androidProduct;
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-	void* view;
+	void* view = nullptr;
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
 	wl_display *display = nullptr;
 	wl_registry *registry = nullptr;
@@ -229,10 +229,10 @@ public:
 	bool quit = false;
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
 	bool quit = false;
-	xcb_connection_t *connection;
-	xcb_screen_t *screen;
+	xcb_connection_t *connection = nullptr;
+	xcb_screen_t *screen = nullptr;
 	xcb_window_t window;
-	xcb_intern_atom_reply_t *atom_wm_delete_window;
+	xcb_intern_atom_reply_t *atom_wm_delete_window = nullptr;
 #endif
 
 	VulkanExampleBase(bool enableValidation = false);

--- a/examples/inlineuniformblocks/inlineuniformblocks.cpp
+++ b/examples/inlineuniformblocks/inlineuniformblocks.cpp
@@ -30,7 +30,8 @@
 #define OBJ_DIM 0.025f
 
 float rnd() {
-	return ((float)rand() / (RAND_MAX));
+	return (static_cast<float>(rand()) / 
+			static_cast<float>(RAND_MAX));
 }
 
 class VulkanExample : public VulkanExampleBase


### PR DESCRIPTION
While reading through the codebase and learning about Vulkan, I noticed the following changes in base/

Edit: This PR is turning out to be more than just using STL.

Edit 2: Comprehensive list from my second commit:

```
1. Some member functions can be made `const`.
2. Avoid using C-style casting.
3. explicit constructors for constructor with 1 argument.
4. Use STL algorithms whenever possible. Also pre-allocate buffer before pushing.
5. Removed unreachable code (like `break` after `return` and `exit` after `return`).
6. Initialized many previously uninitialized variables.
7. Handle error return codes (mostly from freopen_s in Windows).
8. Avoid flushing with every print statement by replacing `std::endl` with "\n".
9. Some off-by-one error involving finding a random ratio algorithms. Mostly just avoid the warning by explicitly casting RAND_MAX to float.
```