### PR TITLE
Don't flush at every print statement.

### DIFF
--- a/base/VulkanTools.cpp
+++ b/base/VulkanTools.cpp
@@ -352,7 +352,7 @@ namespace vks
 			}
 			else
 			{
-				std::cerr << "Error: Could not open shader file \"" << fileName << "\"" << std::endl;
+				std::cerr << "Error: Could not open shader file \"" << fileName << "\"" << "\n";
 				return VK_NULL_HANDLE;
 			}
 		}

--- a/base/VulkanTools.h
+++ b/base/VulkanTools.h
@@ -53,7 +53,7 @@
 	VkResult res = (f);																					\
 	if (res != VK_SUCCESS)																				\
 	{																									\
-		std::cout << "Fatal : VkResult is \"" << vks::tools::errorString(res) << "\" in " << __FILE__ << " at line " << __LINE__ << std::endl; \
+		std::cout << "Fatal : VkResult is \"" << vks::tools::errorString(res) << "\" in " << __FILE__ << " at line " << __LINE__ << "\n"; \
 		assert(res == VK_SUCCESS);																		\
 	}																									\
 }

--- a/base/VulkanglTFModel.hpp
+++ b/base/VulkanglTFModel.hpp
@@ -779,7 +779,7 @@ namespace vkglTF
 							break;
 						}
 						default:
-							std::cerr << "Index component type " << accessor.componentType << " not supported!" << std::endl;
+							std::cerr << "Index component type " << accessor.componentType << " not supported!" << "\n";
 							return;
 						}
 					}
@@ -959,7 +959,7 @@ namespace vkglTF
 							break;
 						}
 						default: {
-							std::cout << "unknown type" << std::endl;
+							std::cout << "unknown type" << "\n";
 							break;
 						}
 						}
@@ -982,7 +982,7 @@ namespace vkglTF
 						channel.path = AnimationChannel::PathType::SCALE;
 					}
 					if (source.target_path == "weights") {
-						std::cout << "weights not yet supported, skipping channel" << std::endl;
+						std::cout << "weights not yet supported, skipping channel" << "\n";
 						continue;
 					}
 					channel.samplerIndex = source.sampler;
@@ -1049,7 +1049,7 @@ namespace vkglTF
 			}
 			else {
 				// TODO: throw
-				std::cerr << "Could not load gltf file: " << error << std::endl;
+				std::cerr << "Could not load gltf file: " << error << "\n";
 				return;
 			}
 
@@ -1236,7 +1236,7 @@ namespace vkglTF
 		void updateAnimation(uint32_t index, float time) 
 		{
 			if (index > static_cast<uint32_t>(animations.size()) - 1) {
-				std::cout << "No animation with index " << index << std::endl;
+				std::cout << "No animation with index " << index << "\n";
 				return;
 			}
 			Animation &animation = animations[index];

--- a/base/benchmark.hpp
+++ b/base/benchmark.hpp
@@ -62,11 +62,11 @@ namespace vks
 					frameTimes.push_back(tDiff);
 					frameCount++;
 				};
-				std::cout << "Benchmark finished" << std::endl;
-				std::cout << "device : " << deviceProps.deviceName << " (driver version: " << deviceProps.driverVersion << ")" << std::endl;
-				std::cout << "runtime: " << (runtime / 1000.0) << std::endl;
-				std::cout << "frames : " << frameCount << std::endl;
-				std::cout << "fps    : " << frameCount / (runtime / 1000.0) << std::endl;
+				std::cout << "Benchmark finished" << "\n";
+				std::cout << "device : " << deviceProps.deviceName << " (driver version: " << deviceProps.driverVersion << ")" << "\n";
+				std::cout << "runtime: " << (runtime / 1000.0) << "\n";
+				std::cout << "frames : " << frameCount << "\n";
+				std::cout << "fps    : " << frameCount / (runtime / 1000.0) << "\n";
 			}
 		}
 
@@ -75,21 +75,21 @@ namespace vks
 			if (result.is_open()) {
 				result << std::fixed << std::setprecision(4);
 
-				result << "device,driverversion,duration (ms),frames,fps" << std::endl;
-				result << deviceProps.deviceName << "," << deviceProps.driverVersion << "," << runtime << "," << frameCount << "," << frameCount / (runtime / 1000.0) << std::endl;
+				result << "device,driverversion,duration (ms),frames,fps" << "\n";
+				result << deviceProps.deviceName << "," << deviceProps.driverVersion << "," << runtime << "," << frameCount << "," << frameCount / (runtime / 1000.0) << "\n";
 
 				if (outputFrameTimes) {
-					result << std::endl << "frame,ms" << std::endl;
+					result << "\n" << "frame,ms" << "\n";
 					for (size_t i = 0; i < frameTimes.size(); i++) {
-						result << i << "," << frameTimes[i] << std::endl;
+						result << i << "," << frameTimes[i] << "\n";
 					}
 					double tMin = *std::min_element(frameTimes.begin(), frameTimes.end());
 					double tMax = *std::max_element(frameTimes.begin(), frameTimes.end());
 					double tAvg = std::accumulate(frameTimes.begin(), frameTimes.end(), 0.0) / (double)frameTimes.size();
-					std::cout << "best   : " << (1000.0 / tMin) << " fps (" << tMin << " ms)" << std::endl;
-					std::cout << "worst  : " << (1000.0 / tMax) << " fps (" << tMax << " ms)" << std::endl;
-					std::cout << "avg    : " << (1000.0 / tAvg) << " fps (" << tAvg << " ms)" << std::endl;
-					std::cout << std::endl;
+					std::cout << "best   : " << (1000.0 / tMin) << " fps (" << tMin << " ms)" << "\n";
+					std::cout << "worst  : " << (1000.0 / tMax) << " fps (" << tMax << " ms)" << "\n";
+					std::cout << "avg    : " << (1000.0 / tAvg) << " fps (" << tAvg << " ms)" << "\n";
+					std::cout << "\n";
 				}
 
 				result.flush();

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -612,7 +612,7 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 		std::string msg = "Could not locate asset path in \"" + getAssetPath() + "\" !";
 		MessageBox(NULL, msg.c_str(), "Fatal error", MB_OK | MB_ICONERROR);
 #else
-		std::cerr << "Error: Could not find asset path in " << getAssetPath() << std::endl;
+		std::cerr << "Error: Could not find asset path in " << getAssetPath() << "\n";
 #endif
 		exit(-1);
 	}
@@ -654,7 +654,7 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 				if (numConvPtr != args[i + 1]) {
 					benchmark.warmup = num;
 				} else {
-					std::cerr << "Warmup time for benchmark mode must be specified as a number!" << std::endl;
+					std::cerr << "Warmup time for benchmark mode must be specified as a number!" << "\n";
 				}
 			}
 		}
@@ -666,7 +666,7 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 					benchmark.duration = num;
 				}
 				else {
-					std::cerr << "Benchmark run duration must be specified as a number!" << std::endl;
+					std::cerr << "Benchmark run duration must be specified as a number!" << "\n";
 				}
 			}
 		}
@@ -674,7 +674,7 @@ VulkanExampleBase::VulkanExampleBase(bool enableValidation)
 		if ((args[i] == std::string("-bf")) || (args[i] == std::string("--benchfilename"))) {
 			if (args.size() > i + 1) {
 				if (args[i + 1][0] == '-') {
-					std::cerr << "Filename for benchmark results must not start with a hyphen!" << std::endl;
+					std::cerr << "Filename for benchmark results must not start with a hyphen!" << "\n";
 				} else {
 					benchmark.filename = args[i + 1];
 				}
@@ -835,11 +835,11 @@ bool VulkanExampleBase::initVulkan()
 			{ 
 				if (index > gpuCount - 1)
 				{
-					std::cerr << "Selected device index " << index << " is out of range, reverting to device 0 (use -listgpus to show available Vulkan devices)" << std::endl;
+					std::cerr << "Selected device index " << index << " is out of range, reverting to device 0 (use -listgpus to show available Vulkan devices)" << "\n";
 				} 
 				else
 				{
-					std::cout << "Selected Vulkan device " << index << std::endl;
+					std::cout << "Selected Vulkan device " << index << "\n";
 					selectedDevice = index;
 				}
 			};
@@ -852,20 +852,20 @@ bool VulkanExampleBase::initVulkan()
 			VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, nullptr));
 			if (gpuCount == 0)
 			{
-				std::cerr << "No Vulkan devices found!" << std::endl;
+				std::cerr << "No Vulkan devices found!" << "\n";
 			}
 			else
 			{
 				// Enumerate devices
-				std::cout << "Available Vulkan devices" << std::endl;
+				std::cout << "Available Vulkan devices" << "\n";
 				std::vector<VkPhysicalDevice> devices(gpuCount);
 				VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, devices.data()));
 				for (uint32_t i = 0; i < gpuCount; i++) {
 					VkPhysicalDeviceProperties deviceProperties;
 					vkGetPhysicalDeviceProperties(devices[i], &deviceProperties);
-					std::cout << "Device [" << i << "] : " << deviceProperties.deviceName << std::endl;
-					std::cout << " Type: " << vks::tools::physicalDeviceTypeString(deviceProperties.deviceType) << std::endl;
-					std::cout << " API: " << (deviceProperties.apiVersion >> 22) << "." << ((deviceProperties.apiVersion >> 12) & 0x3ff) << "." << (deviceProperties.apiVersion & 0xfff) << std::endl;
+					std::cout << "Device [" << i << "] : " << deviceProperties.deviceName << "\n";
+					std::cout << " Type: " << vks::tools::physicalDeviceTypeString(deviceProperties.deviceType) << "\n";
+					std::cout << " API: " << (deviceProperties.apiVersion >> 22) << "." << ((deviceProperties.apiVersion >> 12) & 0x3ff) << "." << (deviceProperties.apiVersion & 0xfff) << "\n";
 				}
 			}
 		}


### PR DESCRIPTION
std::endl causes the buffer to be flushed.
This is highly inefficient.
Prefer "\n" instead.