### PR TITLE
Correct shadersPath for computeheadless project

### DIFF
--- a/examples/computeheadless/computeheadless.cpp
+++ b/examples/computeheadless/computeheadless.cpp
@@ -364,7 +364,7 @@ public:
 			// TODO: There is no command line arguments parsing (nor Android settings) for this
 			// example, so we have no way of picking between GLSL or HLSL shaders.
 			// Hard-code to glsl for now.
-			const std::string shadersPath = getAssetPath() + "/shaders/glsl/computeheadless";
+			const std::string shadersPath = getAssetPath() + "shaders/glsl/computeheadless/";
 
 			VkPipelineShaderStageCreateInfo shaderStage = {};
 			shaderStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;

--- a/examples/renderheadless/renderheadless.cpp
+++ b/examples/renderheadless/renderheadless.cpp
@@ -594,7 +594,7 @@ public:
 			// TODO: There is no command line arguments parsing (nor Android settings) for this
 			// example, so we have no way of picking between GLSL or HLSL shaders.
 			// Hard-code to glsl for now.
-			const std::string shadersPath = getAssetPath() + "/shaders/glsl/renderheadless";
+			const std::string shadersPath = getAssetPath() + "shaders/glsl/renderheadless/";
 
 			shaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
 			shaderStages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;


### PR DESCRIPTION
The example "computeheadless" fails with the following error:

Error: Could not open shader file "D:/Workspace/cpp/SaschaWillems/Vulkan/data//shaders/glsl/computeheadlessheadless.comp.spv"
Assertion failed: shaderStage.module != VK_NULL_HANDLE, file D:\Workspace\cpp\SaschaWillems\Vulkan\examples\computeheadless\computeheadless.cpp, line 381

Fixing forward slashes in the 'shadersPath' variable solves the problem.

---

The example "renderheadless" fails with following errors:
Error: Could not open shader file "D:/Workspace/cpp/SaschaWillems/Vulkan/data//shaders/glsl/renderheadlesstriangle.vert.spv"
Error: Could not open shader file "D:/Workspace/cpp/SaschaWillems/Vulkan/data//shaders/glsl/renderheadlesstriangle.frag.spv"
