### PR TITLE
Fix: group INDEX_SHADOW_HIT 

### DIFF
--- a/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
+++ b/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
@@ -595,9 +595,8 @@ public:
 		groups[INDEX_CLOSEST_HIT].closestHitShader = shaderIndexClosestHit;
 		// Shadow closest hit shader group
 		groups[INDEX_SHADOW_HIT].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_NV;
-		groups[INDEX_SHADOW_HIT].generalShader = VK_SHADER_UNUSED_NV;
 		// Reuse shadow miss shader
-		groups[INDEX_SHADOW_HIT].closestHitShader = shaderIndexShadowMiss;
+		groups[INDEX_SHADOW_HIT].generalShader = shaderIndexClosestHit;
 
 		VkRayTracingPipelineCreateInfoNV rayPipelineInfo{};
 		rayPipelineInfo.sType = VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV;

--- a/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
+++ b/examples/nv_ray_tracing_shadows/nv_ray_tracing_shadows.cpp
@@ -596,7 +596,7 @@ public:
 		// Shadow closest hit shader group
 		groups[INDEX_SHADOW_HIT].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_NV;
 		// Reuse shadow miss shader
-		groups[INDEX_SHADOW_HIT].generalShader = shaderIndexClosestHit;
+		groups[INDEX_SHADOW_HIT].generalShader = shaderIndexShadowMiss;
 
 		VkRayTracingPipelineCreateInfoNV rayPipelineInfo{};
 		rayPipelineInfo.sType = VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV;


### PR DESCRIPTION
Assign `shaderIndexShadowMiss` to `.generalShader` instead of `closestHitShader`, because:

closestHitShader must be either VK_SHADER_UNUSED_NV or a valid index into VkRayTracingPipelineCreateInfoNV::pStages referring to a shader of VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV

( https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkRayTracingShaderGroupCreateInfoNV-closestHitShader-02417 )

