### PR TITLE
correction to yoffset char positions in distance field fonts example

### DIFF
--- a/examples/distancefieldfonts/distancefieldfonts.cpp
+++ b/examples/distancefieldfonts/distancefieldfonts.cpp
@@ -285,7 +285,6 @@ public:
 			float dimx = 1.0f * charw;
 			float charh = ((float)(charInfo->height) / 36.0f);
 			float dimy = 1.0f * charh;
-			posy = 1.0f - charh;
 
 			float us = charInfo->x / w;
 			float ue = (charInfo->x + charInfo->width) / w;
@@ -294,6 +293,8 @@ public:
 
 			float xo = charInfo->xoffset / 36.0f;
 			float yo = charInfo->yoffset / 36.0f;
+
+			posy = yo;
 
 			vertices.push_back({ { posx + dimx + xo,  posy + dimy, 0.0f }, { ue, te } });
 			vertices.push_back({ { posx + xo,         posy + dimy, 0.0f }, { us, te } });


### PR DESCRIPTION
While playing with the distanceFieldFont example I noticed the vertical alignment of characters seemed off. The text "Vulkan" does not seem affected but some charaters are, like "log":

![rsz_screenshot_from_2020-06-29_20-57-56](https://user-images.githubusercontent.com/1618811/86047242-e75bf400-ba4e-11ea-9ca2-267744bfdd60.jpg)

After a lot of fiddling and trying to think upside down it seems this does the trick, but i'm not sure it's absolutely correct wrt baseline:

![rsz_screenshot_from_2020-06-29_20-57-32](https://user-images.githubusercontent.com/1618811/86047512-44f04080-ba4f-11ea-8041-ca3304f4c819.jpg)

Please excuse such an insignificant pull request. I thought it worthwhile because it took me a good while to 'get right' and it otherwise confused me from the intent of the example.