### PR TITLE
Make it Compile on FreeBSD

### DIFF
--- a/base/keycodes.hpp
+++ b/base/keycodes.hpp
@@ -96,7 +96,7 @@
 #define KEY_KPADD KEY_KPPLUS
 #define KEY_KPSUB KEY_KPMINUS
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
 #define KEY_ESCAPE 0x9
 #define KEY_F1 0x43
 #define KEY_F2 0x44

--- a/examples/triangle/triangle.cpp
+++ b/examples/triangle/triangle.cpp
@@ -1164,7 +1164,7 @@ int main(const int argc, const char *argv[])
 	delete(vulkanExample);
 	return 0;
 }
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
 
 // Linux entry point
 VulkanExample *vulkanExample;


### PR DESCRIPTION
FreeBSD's current graphics stack for open source drivers is just linux DRM/+Mesa just like linux, they run basically the same code, so the only reason it didn't compile without erroring out is because of those two __linux__ checks, this just adds `|| defined(FreeBSD)` to the checks.

Signed-off-by: Lucas Francesco <uramekus@cirno.dev>