### PR TITLE
Output warning to stderr if an extension is not supported

### DIFF
--- a/base/VulkanDevice.cpp
+++ b/base/VulkanDevice.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <VulkanDevice.h>
+#include <unordered_set>
 
 namespace vks
 {	
@@ -272,6 +273,12 @@ namespace vks
 
 		if (deviceExtensions.size() > 0)
 		{
+			for (const char* ext : deviceExtensions)
+			{
+				if (!extensionSupported(ext))
+					std::cerr << ext << " device extension support seems to be missing" << std::endl;
+			}
+
 			deviceCreateInfo.enabledExtensionCount = (uint32_t)deviceExtensions.size();
 			deviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.data();
 		}

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -7,6 +7,7 @@
 */
 
 #include "vulkanexamplebase.h"
+#include <unordered_set>
 
 std::vector<const char*> VulkanExampleBase::args;
 
@@ -44,8 +45,24 @@ VkResult VulkanExampleBase::createInstance(bool enableValidation)
 	instanceExtensions.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
 #endif
 
+	std::uint32_t extCount = 0;
+	vkEnumerateInstanceExtensionProperties(nullptr, &extCount, nullptr);
+
+	std::unordered_set<std::string> supportedExtensions;
+	if (extCount > 0)
+	{
+		std::vector<VkExtensionProperties> instanceExtensions(extCount);
+		vkEnumerateInstanceExtensionProperties(nullptr, &extCount, instanceExtensions.data());
+
+		for (const auto &ext : instanceExtensions)
+			supportedExtensions.emplace(ext.extensionName);
+	}
+
 	if (enabledInstanceExtensions.size() > 0) {
 		for (auto enabledExtension : enabledInstanceExtensions) {
+			if (supportedExtensions.find(enabledExtension) == supportedExtensions.end())
+				std::cerr << enabledExtension << " instance extension support seems to be missing" << std::endl;
+
 			instanceExtensions.push_back(enabledExtension);
 		}
 	}


### PR DESCRIPTION
Hi,

I was trying to run some raytracing examples and got an error box saying "Could not create Vulkan device: ERROR_EXTENSION_NOT_PRESENT". 

Since the raytracing examples enable a lot of extensions, I added a check before creating the instance / device to output to stderr what extensions are missing.

not related to this PR: is it normal that I'm missing VK_KHR_pipeline_library VK_KHR_deferred_host_operations and VK_KHR_ray_tracing with a RTX 2080 Ti and latest NVidia driver (452.06)?