### PR TITLE
[NFC] Fix clang 10 warnings

### DIFF
--- a/examples/inlineuniformblocks/inlineuniformblocks.cpp
+++ b/examples/inlineuniformblocks/inlineuniformblocks.cpp
@@ -16,7 +16,7 @@
 #define ENABLE_VALIDATION false
 
 float rnd() {
-	return ((float)rand() / (RAND_MAX));
+	return static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
 }
 
 class VulkanExample : public VulkanExampleBase

--- a/examples/oit/oit.cpp
+++ b/examples/oit/oit.cpp
@@ -498,7 +498,7 @@ private:
 		vkUpdateDescriptorSets(device, writeDescriptorSets.size(), writeDescriptorSets.data(), 0, NULL);
 	}
 
-	void buildCommandBuffers()
+	void buildCommandBuffers() override
 	{
 		if (resized)
 			return;

--- a/examples/pushconstants/pushconstants.cpp
+++ b/examples/pushconstants/pushconstants.cpp
@@ -21,7 +21,7 @@
 
 float rnd()
 {
-	return ((float) rand() / (RAND_MAX));
+	return static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
 }
 
 class VulkanExample : public VulkanExampleBase


### PR DESCRIPTION
Resolves the following clang-10 compiler warnings:

```
$ ninja
[65/177] Building CXX object examples/CMakeFiles/oit.dir/oit/oit.cpp.o
../examples/oit/oit.cpp:501:7: warning: 'buildCommandBuffers' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        void buildCommandBuffers()
             ^
../base/vulkanexamplebase.h:351:15: note: overridden virtual function is here
        virtual void buildCommandBuffers();
                     ^
1 warning generated.
[78/177] Building CXX object examples/CMakeFiles/inlineuniformblocks.dir/inlineuniformblocks/inlineuniformblocks.cpp.o
../examples/inlineuniformblocks/inlineuniformblocks.cpp:19:27: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-int-float-conversion]
        return ((float)rand() / (RAND_MAX));
                              ~  ^~~~~~~~
/usr/include/stdlib.h:86:18: note: expanded from macro 'RAND_MAX'
                        ^~~~~~~~~~
1 warning generated.

[84/177] Building CXX object examples/CMakeFiles/pushconstants.dir/pushconstants/pushconstants.cpp.o
../examples/pushconstants/pushconstants.cpp:24:28: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-int-float-conversion]
        return ((float) rand() / (RAND_MAX));
                               ~  ^~~~~~~~
/usr/include/stdlib.h:86:18: note: expanded from macro 'RAND_MAX'
                        ^~~~~~~~~~
```