### PR TITLE
Added descriptorindexing sample to CMake and fixed variable descriptor size validation errors

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -75,6 +75,7 @@ set(EXAMPLES
 	deferred
 	deferredmultisampling
 	deferredshadows
+	descriptorindexing
 	descriptorsets
 	displacement
 	distancefieldfonts

--- a/examples/descriptorindexing/descriptorindexing.cpp
+++ b/examples/descriptorindexing/descriptorindexing.cpp
@@ -292,11 +292,11 @@ public:
 			Descriptor sets
 		*/
 
-		VkDescriptorSetVariableDescriptorCountAllocateInfo variableDescriptorCountAllocInfo = {};
+		VkDescriptorSetVariableDescriptorCountAllocateInfoEXT variableDescriptorCountAllocInfo = {};
 
 		uint32_t variableDescCounts[] = {textures.size()};
 
-		variableDescriptorCountAllocInfo.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO;
+		variableDescriptorCountAllocInfo.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT;
 		variableDescriptorCountAllocInfo.descriptorSetCount = 1;
 		variableDescriptorCountAllocInfo.pDescriptorCounts  = variableDescCounts;
 

--- a/examples/descriptorindexing/descriptorindexing.cpp
+++ b/examples/descriptorindexing/descriptorindexing.cpp
@@ -292,7 +292,17 @@ public:
 			Descriptor sets
 		*/
 
+		VkDescriptorSetVariableDescriptorCountAllocateInfo variableDescriptorCountAllocInfo = {};
+
+		uint32_t variableDescCounts[] = {textures.size()};
+
+		variableDescriptorCountAllocInfo.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO;
+		variableDescriptorCountAllocInfo.descriptorSetCount = 1;
+		variableDescriptorCountAllocInfo.pDescriptorCounts  = variableDescCounts;
+
 		VkDescriptorSetAllocateInfo allocInfo = vks::initializers::descriptorSetAllocateInfo(descriptorPool, &descriptorSetLayout, 1);
+		allocInfo.pNext = &variableDescriptorCountAllocInfo;
+		
 		VK_CHECK_RESULT(vkAllocateDescriptorSets(device, &allocInfo, &descriptorSet));
 
 		std::vector<VkWriteDescriptorSet> writeDescriptorSets(2);


### PR DESCRIPTION
The descriptorindexing sample was not added to CMake. Assets are missing as well so I used some temporary textures, I'm not sure how to go about fixing that. Also the following validation error was displayed since Vulkan SDK 1.2.162.0:

`ERROR: [-1862672269][VUID-VkWriteDescriptorSet-dstArrayElement-00321] : Validation Error: [ VUID-VkWriteDescriptorSet-dstArrayElement-00321 ] Object 0: handle = 0x37de50000000060, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0x90f9e073 | vkUpdateDescriptorSets() failed write update validation for VkDescriptorSet 0x37de50000000060[] with error: Attempting write update to VkDescriptorSet 0x37de50000000060[] allocated with VkDescriptorSetLayout 0x7d20db000000005e[] binding index #1 array element 0 with 7 writes but variable descriptor size is 0. The Vulkan spec states: The sum of dstArrayElement and descriptorCount must be less than or equal to the number of array elements in the descriptor set binding specified by dstBinding, and all applicable consecutive bindings, as described by consecutive binding updates (https://vulkan.lunarg.com/doc/view/1.2.162.0/windows/1.2-extensions/vkspec.html#VUID-VkWriteDescriptorSet-dstArrayElement-00321)` 

Adding the _VkDescriptorSetVariableDescriptorCountAllocateInfoEXT_ struct to the pNext chain of  _VkDescriptorSetAllocateInfo_ with the right number of variable descriptors fixes the error. If only a partial range of descriptors are updated, then the _VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT_EXT_ flag must be added to the binding flags in _VkDescriptorSetLayoutBindingFlagsCreateInfoEXT_.