### PR TITLE
Add missing gltf assets to 'build.gradle'

### DIFF
--- a/android/examples/displacement/build.gradle
+++ b/android/examples/displacement/build.gradle
@@ -57,7 +57,7 @@ task copyTask {
     copy {
        from '../../../data/models'
        into 'assets/models'
-       include 'displacement_plane.obj'
+       include 'displacement_plane.gltf'
     }
 
     copy {

--- a/android/examples/particlefire/build.gradle
+++ b/android/examples/particlefire/build.gradle
@@ -57,7 +57,7 @@ task copyTask {
     copy {
        from '../../../data/models'
        into 'assets/models'
-       include 'fireplace.obj'
+       include 'fireplace.gltf'
     }
 
     copy {

--- a/android/examples/pushconstants/build.gradle
+++ b/android/examples/pushconstants/build.gradle
@@ -57,6 +57,12 @@ task copyTask {
     copy {
        from '../../../data/models'
        into 'assets/models'
+       include 'sphere.gltf'
+    }
+
+    copy {
+       from '../../../data/models'
+       into 'assets/models'
        include 'samplescene.gltf'
     }
 


### PR DESCRIPTION
Vulkan applications: displacement, particlefire, pushconstants.