### PR TITLE
Change scope of validationExt and validationLayerName variables

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -95,11 +95,12 @@ VkResult VulkanExampleBase::createInstance(bool enableValidation)
 		instanceCreateInfo.enabledExtensionCount = (uint32_t)instanceExtensions.size();
 		instanceCreateInfo.ppEnabledExtensionNames = instanceExtensions.data();
 	}
+
+	// The VK_LAYER_KHRONOS_validation contains all current validation functionality.
+	// Note that on Android this layer requires at least NDK r20
+	const char* validationLayerName = "VK_LAYER_KHRONOS_validation";
 	if (settings.validation)
 	{
-		// The VK_LAYER_KHRONOS_validation contains all current validation functionality.
-		// Note that on Android this layer requires at least NDK r20
-		const char* validationLayerName = "VK_LAYER_KHRONOS_validation";
 		// Check if this layer is available at instance level
 		uint32_t instanceLayerCount;
 		vkEnumerateInstanceLayerProperties(&instanceLayerCount, nullptr);

--- a/examples/computeheadless/computeheadless.cpp
+++ b/examples/computeheadless/computeheadless.cpp
@@ -170,9 +170,9 @@ public:
 			}
 		}
 
+		const char *validationExt = VK_EXT_DEBUG_REPORT_EXTENSION_NAME;
 		if (layersAvailable) {
 			instanceCreateInfo.ppEnabledLayerNames = validationLayers;
-			const char *validationExt = VK_EXT_DEBUG_REPORT_EXTENSION_NAME;
 			instanceCreateInfo.enabledLayerCount = layerCount;
 			instanceCreateInfo.enabledExtensionCount = 1;
 			instanceCreateInfo.ppEnabledExtensionNames = &validationExt;

--- a/examples/renderheadless/renderheadless.cpp
+++ b/examples/renderheadless/renderheadless.cpp
@@ -200,9 +200,9 @@ public:
 			}
 		}
 
+		const char *validationExt = VK_EXT_DEBUG_REPORT_EXTENSION_NAME;
 		if (layersAvailable) {
 			instanceCreateInfo.ppEnabledLayerNames = validationLayers;
-			const char *validationExt = VK_EXT_DEBUG_REPORT_EXTENSION_NAME;
 			instanceCreateInfo.enabledLayerCount = layerCount;
 			instanceCreateInfo.enabledExtensionCount = 1;
 			instanceCreateInfo.ppEnabledExtensionNames = &validationExt;


### PR DESCRIPTION
Pointer to a variable declared into a block statement is stored and used outside of the block by vkCreateInstance. This can lead to segmentation fault.
Move the declaration of validationExt/validationLayerName outside of the block to fix the crash.