### PR TITLE
Invalid VkSpecializationInfo passed into vkCreateRayTracingPipelinesKHR

### DIFF
--- a/examples/raytracingreflections/raytracingreflections.cpp
+++ b/examples/raytracingreflections/raytracingreflections.cpp
@@ -374,13 +374,14 @@ public:
 		*/
 		std::vector<VkPipelineShaderStageCreateInfo> shaderStages;
 
+		VkSpecializationMapEntry specializationMapEntry = vks::initializers::specializationMapEntry(0, 0, sizeof(uint32_t));
+		uint32_t maxRecursion = 4;
+		VkSpecializationInfo specializationInfo = vks::initializers::specializationInfo(1, &specializationMapEntry, sizeof(maxRecursion), &maxRecursion);
+
 		// Ray generation group
 		{
 			shaderStages.push_back(loadShader(getShadersPath() + "raytracingreflections/raygen.rgen.spv", VK_SHADER_STAGE_RAYGEN_BIT_KHR));
 			// Pass recursion depth for reflections to ray generation shader via specialization constant
-			VkSpecializationMapEntry specializationMapEntry = vks::initializers::specializationMapEntry(0, 0, sizeof(uint32_t));
-			uint32_t maxRecursion = 4;
-			VkSpecializationInfo specializationInfo = vks::initializers::specializationInfo(1, &specializationMapEntry, sizeof(maxRecursion), &maxRecursion);
 			shaderStages.back().pSpecializationInfo = &specializationInfo;
 			VkRayTracingShaderGroupCreateInfoKHR shaderGroup{};
 			shaderGroup.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;


### PR DESCRIPTION
The test declares VkSpecializationInfo in a localized scope and calls vkCreateRayTracingPipelinesKHR outside of that scope. Thus, by the time vkCreateRayTracingPipelinesKHR is called, VkSpecializationInfo has been destroyed.