### PR TITLE
Replace VK_VERSION_1_1 with VK_API_VERSION_1_1

### DIFF
--- a/examples/variablerateshading/variablerateshading.cpp
+++ b/examples/variablerateshading/variablerateshading.cpp
@@ -11,7 +11,7 @@
 VulkanExample::VulkanExample() : VulkanExampleBase(ENABLE_VALIDATION)
 {
 	title = "Variable rate shading";
-	apiVersion = VK_VERSION_1_1;
+	apiVersion = VK_API_VERSION_1_1;
 	camera.type = Camera::CameraType::firstperson;
 	camera.flipY = true;
 	camera.setPosition(glm::vec3(0.0f, 1.0f, 0.0f));


### PR DESCRIPTION
VkApplicationInfo::apiVersion must be encoded as major, minor and patch version of the Vulkan API Specification: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#extendingvulkan-coreversions-versionnumbers.