### PR TITLE
Removed duplicate local_size_x from computecullandlod/cull.comp

### DIFF
--- a/data/shaders/glsl/computecullandlod/cull.comp
+++ b/data/shaders/glsl/computecullandlod/cull.comp
@@ -74,8 +74,6 @@ bool frustumCheck(vec4 pos, float radius)
 	return true;
 }
 
-layout (local_size_x = 16) in;
-
 void main()
 {
 	uint idx = gl_GlobalInvocationID.x + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x;


### PR DESCRIPTION
`layout (local_size_x = 16) in;` directive was used 2 times on lines 62 and 77 of computecullandlod/cull.comp shader. Removed the latter which is unneeded.