### PR TITLE
Add a build script

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2021, Dror Smolarsky
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Build Wascha Williems Vulkan samples
+
+This script will
+- Download assets
+- Update git submodules - assumes that git submodule init was executed already
+- Generate build files
+- Build the project
+
+The scripts assumes the CMake version is equal or greater than 3.13.
+
+This script only supports desktop builds.
+'''
+
+import argparse
+import importlib
+import os
+import platform
+import subprocess
+import sys
+
+sys.path.insert(0, os.getcwd())
+download_assets = importlib.import_module('download_assets')
+
+BUILD_DIR = 'build'
+
+
+def get_output_dir(build_subdir, architecture, config=''):
+    '''Return the output directory for the given architecture and configuration
+    '''
+    return os.path.join(
+        os.getcwd(), BUILD_DIR, build_subdir, architecture, config)
+
+
+def update_git_submodules():
+    '''Update the Git submodules in the repository
+    '''
+    print('Updating Git submodules')
+    update_git_submodule_output = subprocess.run(
+        ['git', 'submodule', 'update'])
+    if 0 != update_git_submodule_output.returncode:
+        raise Exception('Failed to update git submodules')
+
+
+def gen_build_files(architecture, config):
+    '''Use CMake to generate build files
+    '''
+    print(get_output_dir('cmake_output', architecture, config))
+    print(get_output_dir('output', architecture))
+    output_dir = get_output_dir('output', architecture, config)
+    cmake_gen_output = subprocess.run([
+        'cmake',
+        '-S', '.',
+        '-B', get_output_dir('cmake_output', architecture, config),
+        '-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{0}={1}'.format(
+            config.upper(), os.path.join(output_dir, 'lib')),
+        '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{0}={1}'.format(
+            config.upper(), os.path.join(output_dir, 'bin')),
+        '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{0}={1}'.format(
+            config.upper(), os.path.join(output_dir, 'bin')),
+    ])
+    if 0 != cmake_gen_output.returncode:
+        raise Exception('Failed to generate CMake build files')
+
+
+def build(architecture, config):
+    '''Use CMake to build all the samples
+    '''
+    build_args = [
+        'cmake',
+        '--build', '.',
+    ]
+    if 'windows' == platform.system().lower():
+        build_args.extend(['--config', config.capitalize()])
+    build_output = subprocess.run(
+        build_args,
+        cwd=get_output_dir('cmake_output', architecture, config))
+    if 0 != build_output.returncode:
+        raise Exception('Build failed')
+
+
+if '__main__' == __name__:
+    arg_parser = argparse.ArgumentParser(description=__doc__)
+    arg_parser.add_argument(
+        '--force-download-assets', dest='force_download_assets',
+        action='store_true', default=False,
+        help='Force asset download, even if assets were already downloaded')
+    arg_parser.add_argument(
+        '--skip-submodule-update', dest='skip_submodule_update',
+        action='store_true', default=False,
+        help='Skip updating the git sub modules')
+    arg_parser.add_argument(
+        '-a', '--arch', dest='architecture',
+        action='store', choices=['x64', 'x86'], default='x64',
+        help='Target architecture')
+    arg_parser.add_argument(
+        '-c', '--config', dest='config',
+        action='store', choices=['debug', 'release'], default='release',
+        help='Target configuration')
+    args = arg_parser.parse_args()
+    download_assets.download_assets(args.force_download_assets)
+    if not args.skip_submodule_update:
+        update_git_submodules()
+    gen_build_files(args.architecture, args.config)
+    build(args.architecture, args.config)

--- a/download_assets.py
+++ b/download_assets.py
@@ -1,31 +1,58 @@
 #!/usr/bin/env python3
 
+import argparse
+import datetime
+import os
 import sys
 from urllib.request import urlretrieve
 from zipfile import ZipFile
 
 ASSET_PACK_URL = 'http://vulkan.gpuinfo.org/downloads/vulkan_asset_pack_gltf.zip'
 ASSET_PACK_FILE_NAME = 'vulkan_asset_pack_gltf.zip'
+ASSET_DOWNLOAD_COMPLETE_FILE = os.path.join('data', 'asset_download_complete')
 
-print("Downloading asset pack from '%s'" % ASSET_PACK_URL)    
 
 def reporthook(blocknum, blocksize, totalsize):
     bytesread = blocknum * blocksize
     if totalsize > 0:
         percent = bytesread * 1e2 / totalsize
-        s = "\r%5.1f%% (%*d / %d bytes)" % (percent, len(str(totalsize)), bytesread, totalsize)
+        s = "\r%5.1f%% (%*d / %d bytes)" % (percent,
+                                            len(str(totalsize)), bytesread, totalsize)
         sys.stderr.write(s)
         if bytesread >= totalsize:
             sys.stderr.write("\n")
     else:
         sys.stderr.write("read %d\n" % (bytesread,))
 
-urlretrieve(ASSET_PACK_URL, ASSET_PACK_FILE_NAME, reporthook)
 
-print("Download finished")
+def download_assets(force_download=False):
+    '''Download the assets archive and extract it to the data directory
 
-print("Extracting assets")
+    :param force_download: If true force the download, if false only download
+                           the assets if they have not be downloaded already.
+    '''
+    if (not force_download) and os.path.isfile(ASSET_DOWNLOAD_COMPLETE_FILE):
+        print('Assets were already downloaded')
+        return
+    print("Downloading asset pack from '%s'" % ASSET_PACK_URL)
+    urlretrieve(ASSET_PACK_URL, ASSET_PACK_FILE_NAME, reporthook)
+    print("Download finished")
+    print("Extracting assets")
+    zip = ZipFile(ASSET_PACK_FILE_NAME, 'r')
+    zip.extractall("./")
+    zip.close()
+    print("Extract finished")
+    asset_download_complete = open(ASSET_DOWNLOAD_COMPLETE_FILE, mode='w')
+    asset_download_complete.write(str(datetime.datetime.now()))
+    asset_download_complete.close()
 
-zip = ZipFile(ASSET_PACK_FILE_NAME, 'r')
-zip.extractall("./")
-zip.close()
+
+if '__main__' == __name__:
+    arg_parser = argparse.ArgumentParser(
+        'Download Sascha Williems Vulkan samples asset files')
+    arg_parser.add_argument(
+        '--force', dest='force',
+        action='store_true', default=False,
+        help='Force asset download, even assets were already downloaded')
+    arg_parser.parse_args()
+    download_assets()

--- a/download_assets.py
+++ b/download_assets.py
@@ -49,10 +49,10 @@ def download_assets(force_download=False):
 
 if '__main__' == __name__:
     arg_parser = argparse.ArgumentParser(
-        'Download Sascha Williems Vulkan samples asset files')
+        description='Download Sascha Williems Vulkan samples asset files')
     arg_parser.add_argument(
         '--force', dest='force',
         action='store_true', default=False,
-        help='Force asset download, even assets were already downloaded')
+        help='Force asset download, even if assets were already downloaded')
     arg_parser.parse_args()
     download_assets()


### PR DESCRIPTION
The build script will

1. Update submodules
2. Download assets
3. Generate build files
4. Build

This change also modifies the download assets script

1. The download code is in a function, and is called from the script main. This is done to enable calling this script from the build script
2. Skip downloading the dependencies if they were already downloaded

For this script only supports desktop builds.