### PR TITLE
[Minor] Remove small duplication in triangle.cpp

### DIFF
--- a/examples/triangle/triangle.cpp
+++ b/examples/triangle/triangle.cpp
@@ -999,7 +999,6 @@ public:
 		pipelineCreateInfo.pMultisampleState = &multisampleState;
 		pipelineCreateInfo.pViewportState = &viewportState;
 		pipelineCreateInfo.pDepthStencilState = &depthStencilState;
-		pipelineCreateInfo.renderPass = renderPass;
 		pipelineCreateInfo.pDynamicState = &dynamicState;
 
 		// Create rendering pipeline using the specified states


### PR DESCRIPTION
Remove a line of duplication in `void preparePipelines()` in triangle.cpp, which makes the structure of code a little prettier.