### PR TITLE
fix example oit build for Android failed

### DIFF
--- a/base/VulkanAndroid.cpp
+++ b/base/VulkanAndroid.cpp
@@ -123,6 +123,7 @@ PFN_vkCmdCopyQueryPoolResults vkCmdCopyQueryPoolResults;
 
 PFN_vkCreateAndroidSurfaceKHR vkCreateAndroidSurfaceKHR;
 PFN_vkDestroySurfaceKHR vkDestroySurfaceKHR;
+PFN_vkCmdFillBuffer vkCmdFillBuffer;
 
 int32_t vks::android::screenDensity;
 
@@ -286,6 +287,8 @@ namespace vks
 
 			vkCreateAndroidSurfaceKHR = reinterpret_cast<PFN_vkCreateAndroidSurfaceKHR>(vkGetInstanceProcAddr(instance, "vkCreateAndroidSurfaceKHR"));
 			vkDestroySurfaceKHR = reinterpret_cast<PFN_vkDestroySurfaceKHR>(vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+
+			vkCmdFillBuffer = reinterpret_cast<PFN_vkCmdFillBuffer>(vkGetInstanceProcAddr(instance, "vkCmdFillBuffer"));
 		}
 
 		void freeVulkanLibrary()

--- a/base/VulkanAndroid.h
+++ b/base/VulkanAndroid.h
@@ -156,6 +156,7 @@ extern PFN_vkCmdCopyQueryPoolResults vkCmdCopyQueryPoolResults;
 
 extern PFN_vkCreateAndroidSurfaceKHR vkCreateAndroidSurfaceKHR;
 extern PFN_vkDestroySurfaceKHR vkDestroySurfaceKHR;
+extern PFN_vkCmdFillBuffer vkCmdFillBuffer;
 
 namespace vks
 {


### PR DESCRIPTION
[Why]
Example oit build for Android failed with error _"examples/oit/oit.cpp:552:4: error: use of undeclared identifier 'vkCmdFillBuffer'"_.
For Android, it build with parameter "-DVK_NO_PROTOTYPES". So, it will not use the vkCmdFillBuffer declaration under external/vulkan/vulkan_core.h.

[How]
Declare vkCmdFillBuffer in file base/VulkanAndroid.hpp&cpp as others did.