### PR TITLE
Don't set VK_IMAGE_ASPECT_STENCIL_BIT bit if format is depth only

### DIFF
--- a/examples/triangle/triangle.cpp
+++ b/examples/triangle/triangle.cpp
@@ -661,7 +661,11 @@ public:
 		depthStencilView.viewType = VK_IMAGE_VIEW_TYPE_2D;
 		depthStencilView.format = depthFormat;
 		depthStencilView.subresourceRange = {};
-		depthStencilView.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+		depthStencilView.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+		// Stencil aspect should only be set on depth + stencil formats (VK_FORMAT_D16_UNORM_S8_UINT..VK_FORMAT_D32_SFLOAT_S8_UINT)
+		if (depthFormat >= VK_FORMAT_D16_UNORM_S8_UINT)
+			depthStencilView.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+
 		depthStencilView.subresourceRange.baseMipLevel = 0;
 		depthStencilView.subresourceRange.levelCount = 1;
 		depthStencilView.subresourceRange.baseArrayLayer = 0;


### PR DESCRIPTION
The fix is already present in VulkanExampleBase::setupDepthStencil. The problem with the current code is when creating a depth image with `VK_FORMAT_D32_SFLOAT` format, the image->aspect is set to `VK_IMAGE_ASPECT_DEPTH_BIT` only based on the format. In other terms image will only support `VK_IMAGE_ASPECT_DEPTH_BIT` aspect if format is  `VK_FORMAT_D32_SFLOAT`. While creating image_view it's not right to pass aspects that are not supported by the image, the view is being created from. 

The change checks if the format has the stencil part in it and only set `VK_IMAGE_ASPECT_STENCIL_BIT` bit then.

> aspectMask is a bitmask of [VkImageAspectFlagBits](https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#VkImageAspectFlagBits) specifying which aspect(s) of the image are included in the view.