### PR TITLE
Fixed GLTF memory leak

### DIFF
--- a/base/VulkanglTFModel.cpp
+++ b/base/VulkanglTFModel.cpp
@@ -906,6 +906,7 @@ void vkglTF::Model::loadNode(vkglTF::Node *parent, const tinygltf::Node &node, u
 					for (size_t index = 0; index < accessor.count; index++) {
 						indexBuffer.push_back(buf[index] + vertexStart);
 					}
+                    delete[] buf;
 					break;
 				}
 				case TINYGLTF_PARAMETER_TYPE_UNSIGNED_SHORT: {
@@ -914,7 +915,8 @@ void vkglTF::Model::loadNode(vkglTF::Node *parent, const tinygltf::Node &node, u
 					for (size_t index = 0; index < accessor.count; index++) {
 						indexBuffer.push_back(buf[index] + vertexStart);
 					}
-					break;
+                    delete[] buf;
+                    break;
 				}
 				case TINYGLTF_PARAMETER_TYPE_UNSIGNED_BYTE: {
 					uint8_t *buf = new uint8_t[accessor.count];
@@ -922,7 +924,8 @@ void vkglTF::Model::loadNode(vkglTF::Node *parent, const tinygltf::Node &node, u
 					for (size_t index = 0; index < accessor.count; index++) {
 						indexBuffer.push_back(buf[index] + vertexStart);
 					}
-					break;
+                    delete[] buf;
+                    break;
 				}
 				default:
 					std::cerr << "Index component type " << accessor.componentType << " not supported!" << std::endl;

--- a/base/VulkanglTFModel.cpp
+++ b/base/VulkanglTFModel.cpp
@@ -1074,7 +1074,7 @@ void vkglTF::Model::loadAnimations(tinygltf::Model &gltfModel)
 				for (size_t index = 0; index < accessor.count; index++) {
 					sampler.inputs.push_back(buf[index]);
 				}
-
+                delete[] buf;
 				for (auto input : sampler.inputs) {
 					if (input < animation.start) {
 						animation.start = input;
@@ -1100,7 +1100,8 @@ void vkglTF::Model::loadAnimations(tinygltf::Model &gltfModel)
 					for (size_t index = 0; index < accessor.count; index++) {
 						sampler.outputsVec4.push_back(glm::vec4(buf[index], 0.0f));
 					}
-					break;
+                    delete[] buf;
+                    break;
 				}
 				case TINYGLTF_TYPE_VEC4: {
 					glm::vec4 *buf = new glm::vec4[accessor.count];
@@ -1108,7 +1109,8 @@ void vkglTF::Model::loadAnimations(tinygltf::Model &gltfModel)
 					for (size_t index = 0; index < accessor.count; index++) {
 						sampler.outputsVec4.push_back(buf[index]);
 					}
-					break;
+                    delete[] buf;
+                    break;
 				}
 				default: {
 					std::cout << "unknown type" << std::endl;

--- a/base/VulkanglTFModel.cpp
+++ b/base/VulkanglTFModel.cpp
@@ -499,6 +499,10 @@ vkglTF::Mesh::Mesh(vks::VulkanDevice *device, glm::mat4 matrix) {
 vkglTF::Mesh::~Mesh() {
 	vkDestroyBuffer(device->logicalDevice, uniformBuffer.buffer, nullptr);
 	vkFreeMemory(device->logicalDevice, uniformBuffer.memory, nullptr);
+    for(auto primitive : primitives)
+    {
+        delete primitive;
+    }
 }
 
 /*
@@ -735,6 +739,9 @@ vkglTF::Model::~Model()
 	for (auto node : nodes) {
 		delete node;
 	}
+    for (auto skin : skins) {
+        delete skin;
+    }
 	if (descriptorSetLayoutUbo != VK_NULL_HANDLE) {
 		vkDestroyDescriptorSetLayout(device->logicalDevice, descriptorSetLayoutUbo, nullptr);
 		descriptorSetLayoutUbo = VK_NULL_HANDLE;


### PR DESCRIPTION
The loadNode function has three memory leaks.Destruct function of Mesh class and Model class has memory leak. 