### PR TITLE
Ray Query example: shader optimization

### DIFF
--- a/data/shaders/glsl/rayquery/scene.frag
+++ b/data/shaders/glsl/rayquery/scene.frag
@@ -25,10 +25,10 @@ void main()
 	outFragColor = vec4(diffuse, 1.0);
 
 	rayQueryEXT rayQuery;
-	rayQueryInitializeEXT(rayQuery, topLevelAS, gl_RayFlagsTerminateOnFirstHitEXT, 0xFF, inWorldPos, 0.01, L, 1000.0);
+	rayQueryInitializeEXT(rayQuery, topLevelAS, gl_RayFlagsTerminateOnFirstHitEXT | gl_RayFlagsSkipAABBEXT, 0xFF, inWorldPos, 0.01, L, 1000.0);
 
-	// Start the ray traversal, rayQueryProceedEXT returns false if the traversal is complete
-	while (rayQueryProceedEXT(rayQuery)) { }
+	// Traverse the acceleration structure and store information about the first intersection (if any)
+	rayQueryProceedEXT(rayQuery);
 
 	// If the intersection has hit a triangle, the fragment is shadowed
 	if (rayQueryGetIntersectionTypeEXT(rayQuery, true) == gl_RayQueryCommittedIntersectionTriangleEXT ) {


### PR DESCRIPTION
Calling rayQueryProceedEXT in a loop can prevent certain shader optimizations. By setting the TerminateOnFirstHit and SkipAABB flags, there is no scenario where rayQueryProceedEXT will return true, hence the loop can be removed. 

This way the implementation has a guarantee that the traversal can be completed without returning control to the shader, which improves performance.