### PR TITLE
Fix frustum corner calculation for cascading shadows (Vulkan's clip space has a [0,1] z range instead of [-1,1])

### DIFF
--- a/examples/shadowmappingcascade/shadowmappingcascade.cpp
+++ b/examples/shadowmappingcascade/shadowmappingcascade.cpp
@@ -663,10 +663,10 @@ public:
 			float splitDist = cascadeSplits[i];
 
 			glm::vec3 frustumCorners[8] = {
-				glm::vec3(-1.0f,  1.0f, -1.0f),
-				glm::vec3( 1.0f,  1.0f, -1.0f),
-				glm::vec3( 1.0f, -1.0f, -1.0f),
-				glm::vec3(-1.0f, -1.0f, -1.0f),
+				glm::vec3(-1.0f,  1.0f, 0.0f),
+				glm::vec3( 1.0f,  1.0f, 0.0f),
+				glm::vec3( 1.0f, -1.0f, 0.0f),
+				glm::vec3(-1.0f, -1.0f, 0.0f),
 				glm::vec3(-1.0f,  1.0f,  1.0f),
 				glm::vec3( 1.0f,  1.0f,  1.0f),
 				glm::vec3( 1.0f, -1.0f,  1.0f),


### PR DESCRIPTION
The article it's based on is regarding OpenGL, so they had a [-1,1] range:
https://johanmedestrom.wordpress.com/2016/03/18/opengl-cascaded-shadow-maps/

I noticed this issue, when trying out cascading shadows with an orthographic projection instead of a perspective one. There, some parts of the scene were missing, which I backtraced to these calculations. But if my understanding is correct, this will also improve the shadow quality for perspective projection. :)

Oh, and thank you so much @SaschaWillems for this great repository and all the resources you provide - They are an immense help getting into Vulkan! Also, let me know if there is anything else I have to do in this PR, as this is my first time opening one in this repo.