### PR TITLE
validation: fix VUID-vkAllocateMemory 02790

### DIFF
--- a/examples/computeheadless/computeheadless.cpp
+++ b/examples/computeheadless/computeheadless.cpp
@@ -103,6 +103,7 @@ public:
 				if ((deviceMemoryProperties.memoryTypes[i].propertyFlags & memoryPropertyFlags) == memoryPropertyFlags) {
 					memAlloc.memoryTypeIndex = i;
 					memTypeFound = true;
+					break;
 				}
 			}
 			memReqs.memoryTypeBits >>= 1;


### PR DESCRIPTION
Related to #876.
On AMD RX 5700 XT, heaps with MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD are present. Because the heap selection doesn't break early, the code ends up selecting one of the 'late' heaps, which contains more property bits than required. Including this one which causes validation error.

Breaking early should solve this on all GPUs, as the Vulkan specs specifies the order of heap declarations:
```
For each pair of elements X and Y returned in memoryTypes, X must be
placed at a lower index position than Y if:
    - the set of bit flags returned in the propertyFlags member of X is
      a strict subset of the set of bit flags returned in the
      propertyFlags member of Y;
```

So if my understanding is correct, by breaking early we should always select the most basic heap that meets the sample needs.

reference: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceMemoryProperties.html#_description