### PR TITLE
Fix an error in benchmark mode using wayland

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -299,6 +299,16 @@ void VulkanExampleBase::renderLoop()
 //     - for macOS, handle benchmarking within NSApp rendering loop via displayLinkOutputCb()
 #if !(defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
 	if (benchmark.active) {
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+		while (!configured)
+			wl_display_dispatch(display);
+		while (wl_display_prepare_read(display) != 0)
+			wl_display_dispatch_pending(display);
+		wl_display_flush(display);
+		wl_display_read_events(display);
+		wl_display_dispatch_pending(display);
+#endif
+
 		benchmark.run([=] { render(); }, vulkanDevice->properties);
 		vkDeviceWaitIdle(device);
 		if (benchmark.filename != "") {


### PR DESCRIPTION
Hi Sascha:

I met an error in running benchmark mode using wayland compositor on Mali-G52 gpu.

_root@odroidN2:/opt/build_yocto_aarch64/bin# ./triangle -b
[14:13:54.974] libwayland: error in client communication (pid 2660)
xdg_surface@9: error 3: xdg_surface has never been configured
Fatal : VkResult is "ERROR_DEVICE_LOST" in /home/tianyuan/temp/Vulkan/examples/triangle/triangle.cpp at line 350
triangle: /home/tianyuan/temp/Vulkan/examples/triangle/triangle.cpp:350: void VulkanExample::draw(): Assertion `res == VK_SUCCESS' failed.
Aborted

root@odroidN2:/opt/build_yocto_aarch64/bin# ./bloom -b
[14:24:18.188] libwayland: error in client communication (pid 2749)
Fatal : VkResult is "ERROR_SURFACE_LOST_KHR" in /home/tianyuan/temp/Vulkan/base/vulkanexamplebase.cpp at line 742
bloom: /home/tianyuan/temp/Vulkan/base/vulkanexamplebase.cpp:742: void VulkanExampleBase::prepareFrame(): Assertion `res == VK_SUCCESS' failed.
Aborted_

The patch was verified well on my platform.

Could you please help to review the pull request and accept it?