### PR TITLE
Fix incorrect left/right viewport locations

### DIFF
--- a/examples/viewportarray/viewportarray.cpp
+++ b/examples/viewportarray/viewportarray.cpp
@@ -101,16 +101,16 @@ public:
 			vkCmdBeginRenderPass(drawCmdBuffers[i], &renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
 			VkViewport viewports[2];
-			// Left
-			viewports[0] = { 0, 0, (float)width / 2.0f, (float)height, 0.0, 1.0f };
 			// Right
-			viewports[1] = { (float)width / 2.0f, 0, (float)width / 2.0f, (float)height, 0.0, 1.0f };
+			viewports[0] = { (float)width / 2.0f, 0, (float)width / 2.0f, (float)height, 0.0, 1.0f };
+			// Left
+			viewports[1] = { 0, 0, (float)width / 2.0f, (float)height, 0.0, 1.0f };
 
 			vkCmdSetViewport(drawCmdBuffers[i], 0, 2, viewports);
 
 			VkRect2D scissorRects[2] = {
-				vks::initializers::rect2D(width/2, height, 0, 0),
 				vks::initializers::rect2D(width/2, height, width / 2, 0),
+				vks::initializers::rect2D(width/2, height, 0, 0),
 			};
 			vkCmdSetScissor(drawCmdBuffers[i], 0, 2, scissorRects);
 


### PR DESCRIPTION
The left/right viewports are incorrectly swapped in the [viewport array](https://github.com/SaschaWillems/Vulkan/blob/master/examples/viewportarray/viewportarray.cpp#L105) example

Before (incorrect)
![wrong](https://github.com/SaschaWillems/Vulkan/assets/44799922/ebd02ede-7cd4-4835-86af-fa3e487408f5)

After (correct)
![correct](https://github.com/SaschaWillems/Vulkan/assets/44799922/4e018be0-7b88-4fc1-b7f9-7c737bb78057)
