### PR TITLE
Fix 2 separate issues. 

### DIFF
--- a/base/VulkanTools.cpp
+++ b/base/VulkanTools.cpp
@@ -430,16 +430,15 @@ namespace vks
 			std::ifstream f(filename.c_str());
 			return !f.fail();
 		}
-
+#if defined(_WIN64)
 		uint32_t alignedSize(uint32_t value, uint32_t alignment)
         {
 	        return (value + alignment - 1) & ~(alignment - 1);
 		}
-
+#endif
 		size_t alignedSize(size_t value, size_t alignment)
 		{
 			return (value + alignment - 1) & ~(alignment - 1);
 		}
-
 	}
 }

--- a/base/VulkanTools.cpp
+++ b/base/VulkanTools.cpp
@@ -430,10 +430,10 @@ namespace vks
 			std::ifstream f(filename.c_str());
 			return !f.fail();
 		}
-#if defined(_WIN64)
+#if !(defined(_WIN32) && !defined(_WIN64))
 		uint32_t alignedSize(uint32_t value, uint32_t alignment)
-        {
-	        return (value + alignment - 1) & ~(alignment - 1);
+                {
+	                return (value + alignment - 1) & ~(alignment - 1);
 		}
 #endif
 		size_t alignedSize(size_t value, size_t alignment)

--- a/examples/computeraytracing/computeraytracing.cpp
+++ b/examples/computeraytracing/computeraytracing.cpp
@@ -740,7 +740,7 @@ public:
 		VK_CHECK_RESULT(vkAllocateCommandBuffers(device, &cmdBufAllocateInfo, &compute.commandBuffer));
 
 		// Fence for compute CB sync
-		VkFenceCreateInfo fenceCreateInfo = vks::initializers::fenceCreateInfo(VK_FENCE_CREATE_SIGNALED_BIT);
+		VkFenceCreateInfo fenceCreateInfo = vks::initializers::fenceCreateInfo();
 		VK_CHECK_RESULT(vkCreateFence(device, &fenceCreateInfo, nullptr, &compute.fence));
 
 		// Build a single command buffer containing the compute dispatch commands
@@ -775,15 +775,15 @@ public:
 	{
 		// Submit compute commands
 		// Use a fence to ensure that compute command buffer has finished executing before using it again
-		vkWaitForFences(device, 1, &compute.fence, VK_TRUE, UINT64_MAX);
-		vkResetFences(device, 1, &compute.fence);
-
 		VkSubmitInfo computeSubmitInfo = vks::initializers::submitInfo();
 		computeSubmitInfo.commandBufferCount = 1;
 		computeSubmitInfo.pCommandBuffers = &compute.commandBuffer;
 
 		VK_CHECK_RESULT(vkQueueSubmit(compute.queue, 1, &computeSubmitInfo, compute.fence));
 		
+                vkWaitForFences(device, 1, &compute.fence, VK_TRUE, UINT64_MAX);
+                vkResetFences(device, 1, &compute.fence);
+
 		VulkanExampleBase::prepareFrame();
 
 		// Command buffer to be submitted to the queue


### PR DESCRIPTION
1st commit:
This project's default build config is x64. When building with 32-bit Windows config, there will be the following errors:
"Vulkan\base\VulkanTools.cpp(440): error C2084: function 'uint32_t vks::tools::alignedSize(uint32_t,uint32_t)' already has a body"
This change fixed it, however if there is no plan to support 32-bit Windows build, this change is not necessary.

2nd commit:
Fixed some render problems on certain platforms.