### PR TITLE
fixed 'descriptor set layout' bug for textures in 'gltfloading' example

### DIFF
--- a/examples/gltfloading/gltfloading.cpp
+++ b/examples/gltfloading/gltfloading.cpp
@@ -617,6 +617,7 @@ public:
 		VK_CHECK_RESULT(vkCreateDescriptorSetLayout(device, &descriptorSetLayoutCI, nullptr, &descriptorSetLayouts.matrices));
 		// Descriptor set layout for passing material textures
 		setLayoutBinding = vks::initializers::descriptorSetLayoutBinding(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT, 0);
+		descriptorSetLayoutCI = vks::initializers::descriptorSetLayoutCreateInfo(&setLayoutBinding, 1);
 		VK_CHECK_RESULT(vkCreateDescriptorSetLayout(device, &descriptorSetLayoutCI, nullptr, &descriptorSetLayouts.textures));
 		// Pipeline layout using both descriptor sets (set 0 = matrices, set 1 = material)
 		std::array<VkDescriptorSetLayout, 2> setLayouts = { descriptorSetLayouts.matrices, descriptorSetLayouts.textures };


### PR DESCRIPTION
In "gltfloading" example 'descriptor set layout' for textures was being created with the same 'descriptor set layout create info' as matrices(UBO) which is wrong.
It seems that line of code was missing. 