### PR TITLE
Fix parallaxmapping asset missing on Android

### DIFF
--- a/android/examples/parallaxmapping/build.gradle
+++ b/android/examples/parallaxmapping/build.gradle
@@ -57,7 +57,7 @@ task copyTask {
     copy {
        from rootProject.ext.assetPath + 'models'
        into 'assets/models'
-       include 'planecd.gltf'
+       include 'plane.gltf'
     }
 
     copy {


### PR DESCRIPTION
[Why]
Asset name plane.gltf is not corrected in gradle copyTask on Android.

[How]
Correct the sample parallaxmapping's asset name plane.gltf in build.gradle.