### PR TITLE
Remove some unused variables, less verbose animation logic

### DIFF
--- a/base/random.hpp
+++ b/base/random.hpp
@@ -1,0 +1,62 @@
+/*
+* Basic C++11 random number helper
+*
+* Copyright (C) 2024 by Bradley Austin Davis
+*
+* This code is licensed under the MIT license (MIT) (http://opensource.org/licenses/MIT)
+*/
+#pragma once
+#include <random>
+#include <cmath>
+#include <glm/glm.hpp>
+
+namespace vkx {
+
+	constexpr float M_TAU = static_cast<float>(M_PI * 2.0f);
+
+	class Random {
+		std::default_random_engine gen;
+
+
+	public:
+		Random(uint32_t seed = std::random_device{}())
+			: gen{ seed } {};
+
+		void seed(uint32_t seed = std::random_device{}()) {
+			gen = std::default_random_engine{ seed };
+		}
+
+		float real(float range = 1.0f) { return real(0.0f, range); }
+
+		float real(float min, float max) {
+			std::uniform_real_distribution<float> dst{ min, max };
+			return dst(gen);
+		}
+
+		float radian() { return real(M_TAU); }
+
+		float degree() { return real(360.0f); }
+
+		bool boolean() {
+			std::uniform_int_distribution<unsigned int> dst{ 0, 1 };
+			return dst(gen) == 1;
+		}
+
+		glm::vec3 color() { return glm::vec3(real(), real(), real()); }
+
+		glm::vec2 polar() {
+			float theta = radian();
+			float phi = acos(real(-1.0, 1.0));
+			return glm::vec2(phi, theta);
+		}
+
+		glm::vec3 sphere(const glm::vec3& scale = glm::vec3{ 1.0f }) {
+			const auto phiTheta = polar();
+			const auto& phi = phiTheta.x;
+			const auto& theta = phiTheta.y;
+			const auto sinPhi = sin(phi);
+			return glm::vec3{ sinPhi* cos(theta), sinPhi* sin(theta), cos(phi) } *scale;
+		}
+
+	};
+}

--- a/examples/multithreading/multithreading.cpp
+++ b/examples/multithreading/multithreading.cpp
@@ -126,7 +126,6 @@ public:
 
 	VulkanExample() : VulkanExampleBase()
 	{
-		// settings.validation = true;
 		title = "Multi threaded command buffer";
 		camera.type = Camera::CameraType::lookat;
 		camera.setPosition(glm::vec3(0.0f, -0.0f, -32.5f));
@@ -135,6 +134,7 @@ public:
 		camera.setPerspective(60.0f, (float)width / (float)height, 0.1f, 256.0f);
 		// Get number of max. concurrent threads
 		numThreads = std::thread::hardware_concurrency();
+		assert(numThreads > 0);
 #if defined(__ANDROID__)
 		LOGD("numThreads = %d", numThreads);
 #else

--- a/examples/multithreading/multithreading.cpp
+++ b/examples/multithreading/multithreading.cpp
@@ -53,13 +53,6 @@ public:
 	// Max. number of concurrent threads
 	uint32_t numThreads{ 0 };
 
-	// Use push constants to update shader
-	// parameters on a per-thread base
-	struct ThreadPushConstantBlock {
-		glm::mat4 mvp;
-		glm::vec3 color;
-	};
-
 	struct ObjectData {
 		glm::vec3 pos;
 		float rotationAxis;
@@ -69,6 +62,8 @@ public:
 		float deltaT;
 		bool visible = true;
 
+		// Use push constants to update shader
+		// parameters on a per-thread base
 		struct PushConstant {
 			glm::mat4 mvp;
 			glm::vec3 color;
@@ -208,7 +203,7 @@ public:
 	}
 
 	// Builds the secondary command buffer for each thread
-	void threadRenderCode(uint32_t threadIndex, uint32_t cmdBufferIndex, VkCommandBufferInheritanceInfo inheritanceInfo)
+	void threadRenderCode(uint32_t threadIndex, uint32_t cmdBufferIndex, const VkCommandBufferInheritanceInfo& inheritanceInfo)
 	{
 		ThreadData *thread = &threadData[threadIndex];
 		ObjectData *objectData = &thread->objectData[cmdBufferIndex];


### PR DESCRIPTION
This adds a `Random` utility class that provides more functionality than the existing `rnd()` function used in the multithreaded example.  

It does some minor cleanup on the animation logic.  

* `glm::vec3 rotation` replaced by `float rotationAxis;` because the X and Z values are never read or written.
* `glm::mat4 model` removed as it's only used as an intermediate value to write to the push constant structure
* The push constant structure is absorbed by ObjectData because there's no reason for separate storage, they're always 1:1
* Logic to initialize `ObjectData`, update it per-frame and extract the mat4 are moved into the structure itself, reducing the verbosity and amount of indirection required to access all the variables
* Where possible convert values to radians at initialization time rather than each update
* In a couple places where the logic was something like `x = a + rnd(b)` I've updated it to be `random.real(a, a+b)` which provides the same range of values but feels easier to read
* Eliminated unused variables stateT, posX and posZ
