### PR TITLE
Fix barrier issues in computecloth

### DIFF
--- a/base/VulkanInitializers.hpp
+++ b/base/VulkanInitializers.hpp
@@ -90,7 +90,7 @@ namespace vks
 			return imageMemoryBarrier;
 		}
 
-		/** @brief Initialize a buffer memory barrier with no image transfer ownership */
+		/** @brief Initialize a buffer memory barrier with no buffer transfer ownership */
 		inline VkBufferMemoryBarrier bufferMemoryBarrier()
 		{
 			VkBufferMemoryBarrier bufferMemoryBarrier {};


### PR DESCRIPTION
This is to fix #1097

Notes inline

The updated sample passes with the Vulkan Configurator set to enable the validation profile and with it set to the synchronization profile, with no errors or warnings.