### PR TITLE
Allow setting benchmarking warmup time to 0 seconds to skip warmup phase

### DIFF
--- a/base/benchmark.hpp
+++ b/base/benchmark.hpp
@@ -24,7 +24,7 @@ namespace vks
 		bool active = false;
 		bool outputFrameTimes = false;
 		int outputFrames = -1; // -1 means no frames limit
-		uint32_t warmup = 1;
+		uint32_t warmup = 1;   // Default to 1 sec of warm-up
 		uint32_t duration = 10;
 		std::vector<double> frameTimes;
 		std::string filename = "";

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -849,7 +849,7 @@ VulkanExampleBase::VulkanExampleBase()
 		vks::tools::errorModeSilent = true;
 	}
 	if (commandLineParser.isSet("benchmarkwarmup")) {
-		benchmark.warmup = commandLineParser.getValueAsInt("benchmarkwarmup", benchmark.warmup);
+		benchmark.warmup = commandLineParser.getValueAsInt("benchmarkwarmup", 0);
 	}
 	if (commandLineParser.isSet("benchmarkruntime")) {
 		benchmark.duration = commandLineParser.getValueAsInt("benchmarkruntime", benchmark.duration);


### PR DESCRIPTION
Sometimes it's desired to render exactly N (--bfs N) frames.