### PR TITLE
Fix SSAO_NOISE_DIM for android

### DIFF
--- a/examples/ssao/ssao.cpp
+++ b/examples/ssao/ssao.cpp
@@ -14,9 +14,9 @@
 
 // We use a smaller noise kernel size on Android due to lower computational power
 #if defined(__ANDROID__)
-#define SSAO_NOISE_DIM 8
-#else
 #define SSAO_NOISE_DIM 4
+#else
+#define SSAO_NOISE_DIM 8
 #endif
 
 class VulkanExample : public VulkanExampleBase


### PR DESCRIPTION
Comment states that it should be "smaller", but its the opposite I think