### PR TITLE
Enable debugPrintf example on macOS using validation layer

### DIFF
--- a/examples/debugprintf/debugprintf.cpp
+++ b/examples/debugprintf/debugprintf.cpp
@@ -45,6 +45,15 @@ public:
 
 		// Using printf requires the non semantic info extension to be enabled
 		enabledDeviceExtensions.push_back(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
+
+#if (defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_METAL_EXT)) && defined(VK_EXAMPLE_XCODE_GENERATED)
+		// SRS - Force validation on since debugPrintfEXT provided by VK_LAYER_KHRONOS_validation on macOS
+		settings.validation = true;
+		setenv("VK_LAYER_ENABLES", "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT", 1);
+
+		// SRS - RenderDoc not available on macOS so redirect debugPrintfEXT output to stdout
+		setenv("VK_KHRONOS_VALIDATION_PRINTF_TO_STDOUT", "1", 1);
+#endif
 	}
 
 	~VulkanExample()


### PR DESCRIPTION
This small PR adds basic support for the debugprintf example on macOS.  The shader `debugPrintfEXT ` capability is not native on macOS/MoltenVK, but can be provided by **VK_LAYER_KHRONOS_validation** instead.  This change forces validation on for this example and enables the layer's `debugPrintfEXT ` feature when running on macOS.  Without this change, the example's shaders will not cross compile to MSL and will not run on macOS.

Also, since **RenderDoc** is not available on macOS, and native graphics debuggers are Metal-centric (not Vulkan), this PR also enables the validation layer's printf to stdout feature which redirects output to the console window.  Since the example is free running, you will see a continuous stream of printf output to the console, and periodically will observe a buffer overflow warning from the validation layer.  This is a result of the layer using a fixed size internal printf buffer and can be safely ignored.

Fixes #1133