### PR TITLE
Compile all shaders and count errors

### DIFF
--- a/examples/ssao/ssao.cpp
+++ b/examples/ssao/ssao.cpp
@@ -14,9 +14,9 @@
 
 // We use a smaller noise kernel size on Android due to lower computational power
 #if defined(__ANDROID__)
-#define SSAO_NOISE_DIM 8
-#else
 #define SSAO_NOISE_DIM 4
+#else
+#define SSAO_NOISE_DIM 8
 #endif
 
 class VulkanExample : public VulkanExampleBase

--- a/shaders/glsl/compileshaders.py
+++ b/shaders/glsl/compileshaders.py
@@ -30,6 +30,7 @@ def findGlslang():
 glslang_path = findGlslang()
 dir_path = os.path.dirname(os.path.realpath(__file__))
 dir_path = dir_path.replace('\\', '/')
+errors_count = 0
 for root, dirs, files in os.walk(dir_path):
     for file in files:
         if file.endswith(".vert") or file.endswith(".frag") or file.endswith(".comp") or file.endswith(".geom") or file.endswith(".tesc") or file.endswith(".tese") or file.endswith(".rgen") or file.endswith(".rchit") or file.endswith(".rmiss"):
@@ -43,7 +44,12 @@ for root, dirs, files in os.walk(dir_path):
             if file.endswith(".rgen") or file.endswith(".rchit") or file.endswith(".rmiss"):
                add_params = add_params + " --target-env vulkan1.2"
 
-            res = subprocess.call("%s -V %s -o %s %s" % (glslang_path, input_file, output_file, add_params), shell=True)
-            # res = subprocess.call([glslang_path, '-V', input_file, '-o', output_file, add_params], shell=True)
-            if res != 0:
-                sys.exit()
+            result = subprocess.call("%s -V %s -o %s %s" % (glslang_path, input_file, output_file, add_params), shell=True)
+            if result != 0:
+                print('Error compiling %s' % (input_file))
+                errors_count += 1
+
+if errors_count == 0:
+    print('All shaders compiled successfully!')
+else:
+    print('%i shaders failed to compile' % errors_count)

--- a/shaders/hlsl/compile.py
+++ b/shaders/hlsl/compile.py
@@ -32,6 +32,7 @@ def findDXC():
 dxc_path = findDXC()
 dir_path = os.path.dirname(os.path.realpath(__file__))
 dir_path = dir_path.replace('\\', '/')
+errors_count = 0
 for root, dirs, files in os.walk(dir_path):
     for file in files:
         if file.endswith(".vert") or file.endswith(".frag") or file.endswith(".comp") or file.endswith(".geom") or file.endswith(".tesc") or file.endswith(".tese") or file.endswith(".rgen") or file.endswith(".rchit") or file.endswith(".rmiss") or file.endswith(".mesh") :
@@ -62,7 +63,7 @@ for root, dirs, files in os.walk(dir_path):
                 profile = 'ms_6_6'                
 
             print('Compiling %s' % (hlsl_file))
-            subprocess.check_output([
+            result = subprocess.run([
                 dxc_path,
                 '-spirv',
                 '-T', profile,
@@ -76,3 +77,11 @@ for root, dirs, files in os.walk(dir_path):
                 target,
                 hlsl_file,
                 '-Fo', spv_out])
+            if result.returncode != 0:
+                print('Error compiling %s' % (hlsl_file))
+                errors_count += 1
+
+if errors_count == 0:
+    print('All shaders compiled successfully!')
+else:
+    print('%i shaders failed to compile' % errors_count)


### PR DESCRIPTION
Try to compile as many shaders as possible. If any of them are not compiled, just output error and skip it. At the end, print out how many errors occurred.
This makes life easier if you have some testing in one shader and broke it, but want to compile another one. Or, if you don't have glslang compiler that supports ray tracing extensions, it will just skip it and compile all other shaders.
Without this fix, I need to remove ray tracing shaders because my glslang compiler doesn't support it, otherwise I won't be able to compile SSAO shaders.