### PR TITLE
Apply a random seed when NOT in benchmark mode to have 100% deterministic runs in all samples

### DIFF
--- a/examples/descriptorindexing/descriptorindexing.cpp
+++ b/examples/descriptorindexing/descriptorindexing.cpp
@@ -2,9 +2,9 @@
 * Vulkan Example - Descriptor indexing (VK_EXT_descriptor_indexing)
 *
 * Demonstrates use of descriptor indexing to dynamically index into a variable sized array of images
-* 
+*
 * The sample renders multiple objects with the index of the texture (descriptor) to use passed as a vertex attribute (aka "descriptor indexing")
-* 
+*
 * Relevant code parts are marked with [POI]
 *
 * Copyright (C) 2021-2023 Sascha Willems - www.saschawillems.de
@@ -67,7 +67,7 @@ public:
 		physicalDeviceDescriptorIndexingFeatures.descriptorBindingVariableDescriptorCount = VK_TRUE;
 
 		deviceCreatepNextChain = &physicalDeviceDescriptorIndexingFeatures;
-		
+
 #if (defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_METAL_EXT))
 		// SRS - on macOS set environment variable to configure MoltenVK for using Metal argument buffers (needed for descriptor indexing)
 		//     - MoltenVK supports Metal argument buffers on macOS, iOS possible in future (see https://github.com/KhronosGroup/MoltenVK/issues/1651)
@@ -96,7 +96,7 @@ public:
 		textures.resize(32);
 		for (size_t i = 0; i < textures.size(); i++) {
 			std::random_device rndDevice;
-			std::default_random_engine rndEngine(rndDevice());
+			std::default_random_engine rndEngine(benchmark.active ? 0 : rndDevice());
 			std::uniform_int_distribution<> rndDist(50, UCHAR_MAX);
 			const int32_t dim = 3;
 			const size_t bufferSize = dim * dim * 4;
@@ -119,7 +119,7 @@ public:
 
 		// Generate random per-face texture indices
 		std::random_device rndDevice;
-		std::default_random_engine rndEngine(rndDevice());
+		std::default_random_engine rndEngine(benchmark.active ? 0 : rndDevice());
 		std::uniform_int_distribution<int32_t> rndDist(0, static_cast<uint32_t>(textures.size()) - 1);
 
 		// Generate cubes with random per-face texture indices
@@ -253,7 +253,7 @@ public:
 
 		// [POI] Descriptor sets
 		// We need to provide the descriptor counts for bindings with variable counts using a new structure
-		std::vector<uint32_t> variableDesciptorCounts = { 
+		std::vector<uint32_t> variableDesciptorCounts = {
 			static_cast<uint32_t>(textures.size())
 		};
 
@@ -264,7 +264,7 @@ public:
 
 		VkDescriptorSetAllocateInfo allocInfo = vks::initializers::descriptorSetAllocateInfo(descriptorPool, &descriptorSetLayout, 1);
 		allocInfo.pNext = &variableDescriptorCountAllocInfo;
-		
+
 		VK_CHECK_RESULT(vkAllocateDescriptorSets(device, &allocInfo, &descriptorSet));
 
 		std::vector<VkWriteDescriptorSet> writeDescriptorSets(2);

--- a/examples/graphicspipelinelibrary/graphicspipelinelibrary.cpp
+++ b/examples/graphicspipelinelibrary/graphicspipelinelibrary.cpp
@@ -1,6 +1,6 @@
 /*
 * Vulkan Example - Using VK_EXT_graphics_pipeline_library
-* 
+*
 * Copyright (C) 2022-2023 by Sascha Willems - www.saschawillems.de
 *
 * This code is licensed under the MIT license (MIT) (http://opensource.org/licenses/MIT)
@@ -374,7 +374,7 @@ public:
 		shaderStageCI.pName = "main";
 
 		// Select lighting model using a specialization constant
-		srand((unsigned int)time(NULL));
+		srand(benchmark.active ? 0 : ((unsigned int)time(NULL)));
 		uint32_t lighting_model = (int)(rand() % 4);
 
 		// Each shader constant of a shader stage corresponds to one map entry

--- a/examples/inlineuniformblocks/inlineuniformblocks.cpp
+++ b/examples/inlineuniformblocks/inlineuniformblocks.cpp
@@ -28,9 +28,9 @@ public:
 			float ambient;
 		} material;
 		VkDescriptorSet descriptorSet;
-		void setRandomMaterial() {
+		void setRandomMaterial(bool applyRandomSeed) {
 			std::random_device rndDevice;
-			std::default_random_engine rndEngine(rndDevice());
+			std::default_random_engine rndEngine(applyRandomSeed ? rndDevice() : 0);
 			std::uniform_real_distribution<float> rndDist(0.1f, 1.0f);
 			material.r = rndDist(rndEngine);
 			material.g = rndDist(rndEngine);
@@ -161,7 +161,7 @@ public:
 
 		// Setup random materials for every object in the scene
 		for (uint32_t i = 0; i < objects.size(); i++) {
-			objects[i].setRandomMaterial();
+			objects[i].setRandomMaterial(!benchmark.active);
 		}
 	}
 
@@ -342,7 +342,7 @@ public:
 	void updateMaterials() {
 		// Setup random materials for every object in the scene
 		for (uint32_t i = 0; i < objects.size(); i++) {
-			objects[i].setRandomMaterial();
+			objects[i].setRandomMaterial(!benchmark.active);
 		}
 
 		for (auto &object : objects) {

--- a/examples/pushconstants/pushconstants.cpp
+++ b/examples/pushconstants/pushconstants.cpp
@@ -64,7 +64,7 @@ public:
 	{
 		// Setup random colors and fixed positions for every sphere in the scene
 		std::random_device rndDevice;
-		std::default_random_engine rndEngine(rndDevice());
+		std::default_random_engine rndEngine(benchmark.active ? 0 : rndDevice());
 		std::uniform_real_distribution<float> rndDist(0.1f, 1.0f);
 		for (uint32_t i = 0; i < spheres.size(); i++) {
 			spheres[i].color = glm::vec4(rndDist(rndEngine), rndDist(rndEngine), rndDist(rndEngine), 1.0f);
@@ -149,7 +149,7 @@ public:
 			vks::initializers::descriptorSetLayoutBinding(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_VERTEX_BIT, 0),
 		};
 		VkDescriptorSetLayoutCreateInfo descriptorLayout = vks::initializers::descriptorSetLayoutCreateInfo(setLayoutBindings);
-		VK_CHECK_RESULT(vkCreateDescriptorSetLayout(device, &descriptorLayout, nullptr, &descriptorSetLayout)); 
+		VK_CHECK_RESULT(vkCreateDescriptorSetLayout(device, &descriptorLayout, nullptr, &descriptorSetLayout));
 
 		// Set
 		VkDescriptorSetAllocateInfo allocInfo = vks::initializers::descriptorSetAllocateInfo(descriptorPool, &descriptorSetLayout, 1);

--- a/examples/texture3d/texture3d.cpp
+++ b/examples/texture3d/texture3d.cpp
@@ -38,7 +38,6 @@ private:
 		return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
 	}
 public:
-	PerlinNoise() {}
 	PerlinNoise(bool applyRandomSeed)
 	{
 		// Generate random lookup for permutations containing all numbers from 0..255
@@ -90,15 +89,15 @@ template <typename T>
 class FractalNoise
 {
 private:
-	PerlinNoise<float> perlinNoise;
+	PerlinNoise<T> perlinNoise;
 	uint32_t octaves;
 	T frequency;
 	T amplitude;
 	T persistence;
 public:
-	FractalNoise(const PerlinNoise<T> &perlinNoise)
+	FractalNoise(const PerlinNoise<T> &perlinNoiseIn) :
+		perlinNoise(perlinNoiseIn)
 	{
-		this->perlinNoise = perlinNoise;
 		octaves = 6;
 		persistence = (T)0.5;
 	}

--- a/examples/texture3d/texture3d.cpp
+++ b/examples/texture3d/texture3d.cpp
@@ -38,13 +38,14 @@ private:
 		return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
 	}
 public:
-	PerlinNoise()
+	PerlinNoise() {}
+	PerlinNoise(bool applyRandomSeed)
 	{
 		// Generate random lookup for permutations containing all numbers from 0..255
 		std::vector<uint8_t> plookup;
 		plookup.resize(256);
 		std::iota(plookup.begin(), plookup.end(), 0);
-		std::default_random_engine rndEngine(std::random_device{}());
+		std::default_random_engine rndEngine(applyRandomSeed ? std::random_device{}() : 0);
 		std::shuffle(plookup.begin(), plookup.end(), rndEngine);
 
 		for (uint32_t i = 0; i < 256; i++)
@@ -95,7 +96,6 @@ private:
 	T amplitude;
 	T persistence;
 public:
-
 	FractalNoise(const PerlinNoise<T> &perlinNoise)
 	{
 		this->perlinNoise = perlinNoise;
@@ -166,7 +166,7 @@ public:
 		camera.setPosition(glm::vec3(0.0f, 0.0f, -2.5f));
 		camera.setRotation(glm::vec3(0.0f, 15.0f, 0.0f));
 		camera.setPerspective(60.0f, (float)width / (float)height, 0.1f, 256.0f);
-		srand((unsigned int)time(NULL));
+		srand(benchmark.active ? 0 : (unsigned int)time(NULL));
 	}
 
 	~VulkanExample()
@@ -287,7 +287,7 @@ public:
 
 		auto tStart = std::chrono::high_resolution_clock::now();
 
-		PerlinNoise<float> perlinNoise;
+		PerlinNoise<float> perlinNoise(!benchmark.active);
 		FractalNoise<float> fractalNoise(perlinNoise);
 
 		const float noiseScale = static_cast<float>(rand() % 10) + 4.0f;

--- a/examples/texturesparseresidency/texturesparseresidency.cpp
+++ b/examples/texturesparseresidency/texturesparseresidency.cpp
@@ -13,7 +13,7 @@
 #include "texturesparseresidency.h"
 
 /*
-	Virtual texture page 
+	Virtual texture page
 	Contains all functions and objects for a single page of a virtual texture
  */
 
@@ -69,7 +69,7 @@ bool VirtualTexturePage::release(VkDevice device)
 }
 
 /*
-	Virtual texture 
+	Virtual texture
 	Contains the virtual pages and memory binding information for a whole virtual texture
  */
 
@@ -714,7 +714,7 @@ void VulkanExample::fillRandomPages()
 {
 	vkDeviceWaitIdle(device);
 
-	std::default_random_engine rndEngine(std::random_device{}());
+	std::default_random_engine rndEngine(benchmark.active ? 0 : std::random_device{}());
 	std::uniform_real_distribution<float> rndDist(0.0f, 1.0f);
 
 	std::vector<VirtualTexturePage> updatedPages;
@@ -810,7 +810,7 @@ void VulkanExample::flushRandomPages()
 {
 	vkDeviceWaitIdle(device);
 
-	std::default_random_engine rndEngine(std::random_device{}());
+	std::default_random_engine rndEngine(benchmark.active ? 0 : std::random_device{}());
 	std::uniform_real_distribution<float> rndDist(0.0f, 1.0f);
 
 	std::vector<VirtualTexturePage> updatedPages;


### PR DESCRIPTION
These samples lack the check for benchmark.active when applying a random seed, which is done for other samples.

Tested locally, all samples continue to work fine as expected, in either mode.