### PR TITLE
Change Depth Store Default to Don't Care

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -3089,7 +3089,7 @@ void VulkanExampleBase::setupRenderPass()
 	attachments[1].format = depthFormat;
 	attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
 	attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+	attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 	attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 	attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 	attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;


### PR DESCRIPTION
Using the Gears example app to experiment with ARM's new [Frame Advisor](https://developer.arm.com/Tools%20and%20Software/Frame%20Advisor) performance tool for their Mali GPUs I noticed that the depth buffer was being written out:
 
![frameadvisor_gears_storing_depth](https://github.com/SaschaWillems/Vulkan/assets/1584013/35f2d0c5-541f-4ac5-a61f-f5c6b98b70fb)

With this one-line change to the base class, the depth isn't being written:
![frameadvisor_gears_not_storing_depth png](https://github.com/SaschaWillems/Vulkan/assets/1584013/96cd2dae-a2a0-44f2-b1f8-4b77fdf5a397)

If this base class change will have negative impacts on other examples, I could make a slightly more complex PR which allows derived examples to specify the depth buffer storage operation to the base class before it sets up its main renderpass in `VulkanExample::setupRenderPass()`.