### PR TITLE
Fix UI overlay scale factor for readable display on iOS devices

### DIFF
--- a/apple/ios/DemoViewController.mm
+++ b/apple/ios/DemoViewController.mm
@@ -36,9 +36,11 @@ CALayer* layer;
 
 	layer = [self.view layer];		// SRS - When creating a Vulkan Metal surface, need the layer backing the view
 
-	self.view.contentScaleFactor = UIScreen.mainScreen.nativeScale;
+	layer.contentsScale = UIScreen.mainScreen.nativeScale;
 
-	_mvkExample = new MVKExample(self.view, 1.0f);		// SRS - Use 1x scale factor for UIOverlay on iOS
+	// SRS - Calculate UI overlay scale factor based on backing layer scale factor and device type for readable UIOverlay on iOS devices
+	auto UIOverlayScale = layer.contentsScale * ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone ? 2.0/3.0 : 1.0 );
+	_mvkExample = new MVKExample(self.view, UIOverlayScale);
 	
 	// SRS - Enable AppDelegate to call into DemoViewController for handling app lifecycle events (e.g. termination)
 	auto appDelegate = (AppDelegate *)UIApplication.sharedApplication.delegate;


### PR DESCRIPTION
Fixes #1141.  Adjusts UI Overlay scale to value appropriate for iOS retina displays.  Affects iOS project only.

See the following results:


iPhone 15 on iOS simulator:
![Screenshot 2024-06-20 at 10 16 19 AM](https://github.com/SaschaWillems/Vulkan/assets/82544213/f6058268-c68f-4923-a868-c295e76435e7)

iPad Air (5th gen) on iOS simulator:
![Screenshot 2024-06-20 at 10 28 35 AM](https://github.com/SaschaWillems/Vulkan/assets/82544213/6d3e8d82-1c20-4fb3-97ca-de8b5933e13b)
