### PR TITLE
Stop when Wayland library has a fatal error

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -299,12 +299,19 @@ void VulkanExampleBase::renderLoop()
 	if (benchmark.active) {
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
 		while (!configured)
-			wl_display_dispatch(display);
+		{
+			if (wl_display_dispatch(display) == -1)
+				break;
+		}
 		while (wl_display_prepare_read(display) != 0)
-			wl_display_dispatch_pending(display);
+		{
+			if (wl_display_dispatch_pending(display) == -1)
+				break;
+		}
 		wl_display_flush(display);
 		wl_display_read_events(display);
-		wl_display_dispatch_pending(display);
+		if (wl_display_dispatch_pending(display) == -1)
+			return;
 #endif
 
 		benchmark.run([=] { render(); }, vulkanDevice->properties);
@@ -522,12 +529,19 @@ void VulkanExampleBase::renderLoop()
 		}
 
 		while (!configured)
-			wl_display_dispatch(display);
+		{
+			if (wl_display_dispatch(display) == -1)
+				break;
+		}
 		while (wl_display_prepare_read(display) != 0)
-			wl_display_dispatch_pending(display);
+		{
+			if (wl_display_dispatch_pending(display) == -1)
+				break;
+		}
 		wl_display_flush(display);
 		wl_display_read_events(display);
-		wl_display_dispatch_pending(display);
+		if (wl_display_dispatch_pending(display) == -1)
+			break;
 
 		render();
 		frameCounter++;


### PR DESCRIPTION
Currently, if one abruptly disconnects their Wayland connection socket (for example, by killing the compositor but not the demo program), I observe example programs getting stuck in the following lines as part of an infinite loop. 
```
while (wl_display_prepare_read(display) != 0)
	wl_display_dispatch_pending(display);
```
After the socket is disconnected, libwayland will start returning -1 to all subsequent calls of functions that can return an error (like `wl_display_dispatch_pending()`, but not `wl_display_prepare_read()`), and silently do nothing when functions are called. As a result, it should be safe to delay checking for error and breaking out of the main loop until the final `wl_display_dispatch_pending()` call. (Eagerly checking for errors is possible but would make the code rather more complicated, as `wl_display_flush()` can have transient/EAGAIN failures.)

(The current code was added in commit https://github.com/SaschaWillems/Vulkan/commit/b69f87d5c3d29196d3380c5b14635a2cb57ba9d1, which likely used the function call pattern recommended by the Wayland documentation (see [wl_display_prepare_read_queue()](https://man.archlinux.org/man/wl_display.3.en#int_wl_display_prepare_read_queue_(struct_%3Cb%3Ewl_display%3C/b%3E_*_display,_struct_%3Cb%3Ewl_event_queue%3C/b%3E_*_queue) )); however, the example given there does not properly check for errors.)


