### PR TITLE
Adding-Command-Line-Argument-rp-for-Non-Mac-iOS-platforms

### DIFF
--- a/base/VulkanTools.cpp
+++ b/base/VulkanTools.cpp
@@ -12,6 +12,9 @@
 // iOS & macOS: getAssetPath() and getShaderBasePath() implemented externally for access to Obj-C++ path utilities
 const std::string getAssetPath()
 {
+if(vks::tools::resourcePathSet){
+	return vks::tools::resourcePath + "/assets/";
+}
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 	return "";
 #elif defined(VK_EXAMPLE_ASSETS_DIR)
@@ -21,8 +24,17 @@ const std::string getAssetPath()
 #endif
 }
 
+void setResourcePath(std::string path)
+{
+	vks::tools::resourcePath = path;
+	vks::tools::resourcePathSet = true;
+}
+
 const std::string getShaderBasePath()
 {
+if(vks::tools::resourcePathSet){
+	return vks::tools::resourcePath + "/shaders/";
+}
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 	return "shaders/";
 #elif defined(VK_EXAMPLE_SHADERS_DIR)
@@ -38,6 +50,8 @@ namespace vks
 	namespace tools
 	{
 		bool errorModeSilent = false;
+		bool resourcePathSet = false;
+		std::string resourcePath = "";
 
 		std::string errorString(VkResult errorCode)
 		{

--- a/base/VulkanTools.h
+++ b/base/VulkanTools.h
@@ -61,12 +61,17 @@
 #endif
 
 const std::string getAssetPath();
+void setResourcePath(std::string path);
 const std::string getShaderBasePath();
 
 namespace vks
 {
 	namespace tools
 	{
+		/** @brief Variables for Command Line Resource Path */
+		extern std::string resourcePath;
+		extern bool resourcePathSet;
+
 		/** @brief Disable message boxes on fatal errors */
 		extern bool errorModeSilent;
 
@@ -82,7 +87,7 @@ namespace vks
 		// Same as getSupportedDepthFormat but will only select formats that also have stencil
 		VkBool32 getSupportedDepthStencilFormat(VkPhysicalDevice physicalDevice, VkFormat* depthStencilFormat);
 
-		// Returns tru a given format support LINEAR filtering
+		// Returns true a given format support LINEAR filtering
 		VkBool32 formatIsFilterable(VkPhysicalDevice physicalDevice, VkFormat format, VkImageTiling tiling);
 		// Returns true if a given format has a stencil part
 		VkBool32 formatHasStencil(VkFormat format);

--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -783,26 +783,6 @@ void VulkanExampleBase::submitFrame()
 
 VulkanExampleBase::VulkanExampleBase()
 {
-#if !defined(VK_USE_PLATFORM_ANDROID_KHR)
-	// Check for a valid asset path
-	struct stat info;
-	if (stat(getAssetPath().c_str(), &info) != 0)
-	{
-#if defined(_WIN32)
-		std::string msg = "Could not locate asset path in \"" + getAssetPath() + "\" !";
-		MessageBox(NULL, msg.c_str(), "Fatal error", MB_OK | MB_ICONERROR);
-#else
-		std::cerr << "Error: Could not find asset path in " << getAssetPath() << "\n";
-#endif
-		exit(-1);
-	}
-#endif
-
-	// Validation for all samples can be forced at compile time using the FORCE_VALIDATION define
-#if defined(FORCE_VALIDATION)
-	settings.validation = true;
-#endif
-
 	// Command line arguments
 	commandLineParser.add("help", { "--help" }, 0, "Show help");
 	commandLineParser.add("validation", { "-v", "--validation" }, 0, "Enable validation layers");
@@ -819,7 +799,9 @@ VulkanExampleBase::VulkanExampleBase()
 	commandLineParser.add("benchmarkresultfile", { "-bf", "--benchfilename" }, 1, "Set file name for benchmark results");
 	commandLineParser.add("benchmarkresultframes", { "-bt", "--benchframetimes" }, 0, "Save frame times to benchmark results file");
 	commandLineParser.add("benchmarkframes", { "-bfs", "--benchmarkframes" }, 1, "Only render the given number of frames");
-
+#if (!(defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_METAL_EXT)))
+	commandLineParser.add("resourcepath", { "-rp", "--resourcepath" }, 1, "Set path for dir where assets and shaders folder is present");
+#endif
 	commandLineParser.parse(args);
 	if (commandLineParser.isSet("help")) {
 #if defined(_WIN32)
@@ -872,6 +854,32 @@ VulkanExampleBase::VulkanExampleBase()
 	if (commandLineParser.isSet("benchmarkframes")) {
 		benchmark.outputFrames = commandLineParser.getValueAsInt("benchmarkframes", benchmark.outputFrames);
 	}
+#if (!(defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_METAL_EXT)))
+	if(commandLineParser.isSet("resourcepath")) {
+		std::string path = commandLineParser.getValueAsString("resourcepath", "");
+		setResourcePath(path);
+	}
+#endif
+
+#if !defined(VK_USE_PLATFORM_ANDROID_KHR)
+	// Check for a valid asset path
+	struct stat info;
+	if (stat(getAssetPath().c_str(), &info) != 0)
+	{
+#if defined(_WIN32)
+		std::string msg = "Could not locate asset path in \"" + getAssetPath() + "\" !";
+		MessageBox(NULL, msg.c_str(), "Fatal error", MB_OK | MB_ICONERROR);
+#else
+		std::cerr << "Error: Could not find asset path in " << getAssetPath() << "\n";
+#endif
+		exit(-1);
+	}
+#endif
+
+	// Validation for all samples can be forced at compile time using the FORCE_VALIDATION define
+#if defined(FORCE_VALIDATION)
+	settings.validation = true;
+#endif
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 	// Vulkan library is loaded dynamically on Android


### PR DESCRIPTION
It helps in dynamically locating directory where shaders and assets folders present. Useful for cross compiled targets , where hard coded paths are based on source platforms which may non accessible on target platforms.