### PR TITLE
Fix a few compiler warnings and startup/validation issues at runtime

### DIFF
--- a/examples/dynamicrenderingmultisampling/dynamicrenderingmultisampling.cpp
+++ b/examples/dynamicrenderingmultisampling/dynamicrenderingmultisampling.cpp
@@ -160,7 +160,7 @@ public:
 	}
 
 	// Enable physical device features required for this example
-	virtual void getEnabledFeatures()
+	virtual void getEnabledFeatures() override
 	{
 		// Enable anisotropic filtering if supported
 		if (deviceFeatures.samplerAnisotropy) {
@@ -174,7 +174,7 @@ public:
 		model.loadFromFile(getAssetPath() + "models/voyager.gltf", vulkanDevice, queue, glTFLoadingFlags);
 	}
 
-	void buildCommandBuffers()
+	void buildCommandBuffers() override
 	{
 		VkCommandBufferBeginInfo cmdBufInfo = vks::initializers::commandBufferBeginInfo();
 
@@ -365,7 +365,7 @@ public:
 		memcpy(uniformBuffer.mapped, &uniformData, sizeof(uniformData));
 	}
 
-	void prepare()
+	void prepare() override
 	{
 		VulkanExampleBase::prepare();
 
@@ -390,7 +390,7 @@ public:
 		VulkanExampleBase::submitFrame();
 	}
 
-	virtual void render()
+	virtual void render() override
 	{
 		if (!prepared)
 			return;

--- a/examples/hostimagecopy/hostimagecopy.cpp
+++ b/examples/hostimagecopy/hostimagecopy.cpp
@@ -420,7 +420,7 @@ public:
 		// Get the function pointers required host image copies
 		vkCopyMemoryToImageEXT = reinterpret_cast<PFN_vkCopyMemoryToImageEXT>(vkGetDeviceProcAddr(device, "vkCopyMemoryToImageEXT"));
 		vkTransitionImageLayoutEXT = reinterpret_cast<PFN_vkTransitionImageLayoutEXT>(vkGetDeviceProcAddr(device, "vkTransitionImageLayoutEXT"));
-		vkGetPhysicalDeviceFormatProperties2 = reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties2>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFormatProperties2"));
+		vkGetPhysicalDeviceFormatProperties2 = reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties2>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFormatProperties2KHR"));
 
 		loadAssets();
 		loadTexture();

--- a/examples/subpasses/subpasses.cpp
+++ b/examples/subpasses/subpasses.cpp
@@ -99,6 +99,8 @@ public:
 		camera.setRotation(glm::vec3(0.5f, 210.05f, 0.0f));
 		camera.setPerspective(60.0f, (float)width / (float)height, 0.1f, 256.0f);
 		ui.subpass = 2;
+
+		enabledFeatures.fragmentStoresAndAtomics = VK_TRUE;
 	}
 
 	~VulkanExample()

--- a/examples/trianglevulkan13/trianglevulkan13.cpp
+++ b/examples/trianglevulkan13/trianglevulkan13.cpp
@@ -140,6 +140,14 @@ public:
 		}
 	}
 
+	virtual void getEnabledFeatures() override
+	{
+		// Vulkan 1.3 device support is required for this example
+		if (deviceProperties.apiVersion < VK_API_VERSION_1_3) {
+			vks::tools::exitFatal("Selected GPU does not support support Vulkan 1.3", VK_ERROR_INCOMPATIBLE_DRIVER);
+		}
+	}
+
 	// This function is used to request a device memory type that supports all the property flags we request (e.g. device local, host visible)
 	// Upon success it will return the index of the memory type that fits our requested memory properties
 	// This is necessary as implementations can offer an arbitrary number of memory types with different memory properties
@@ -381,7 +389,7 @@ public:
 
 	// Create the depth (and stencil) buffer attachments
 	// While we don't do any depth testing in this sample, having depth testing is very common so it's a good idea to learn it from the very start
-	void setupDepthStencil()
+	void setupDepthStencil() override
 	{
 		// Create an optimal tiled image used as the depth stencil attachment
 		VkImageCreateInfo imageCI{ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
@@ -661,7 +669,7 @@ public:
 
 	}
 
-	void prepare()
+	void prepare() override
 	{
 		VulkanExampleBase::prepare();
 		createSynchronizationPrimitives();


### PR DESCRIPTION
Fixes #1190.

1. ~~Add missing `override` keywords to _dynamicrenderingmultisampling_ and _trianglevulkan13_ examples.~~ _Now fixed in master branch._
2. Add Vulkan 1.3 check in _trianglevulkan13_ to avoid crash if API version not available in the implementation.
3. Adjust _hostimagecopy_ example (API 1.0) to use `vkGetPhysicalDeviceFormatProperties2KHR`.
4. Add  `fragmentStoresAndAtomics` feature to _subpasses_ example to fix VVL warnings.

Tested on Windows 10, Manjaro Linux, macOS Ventura, and iOS 18 with Vulkan SDKs 1.3.296 and 1.4.304.