### PR TITLE
Trivial fix for building example 'computecullandlod' for Android target.

### DIFF
--- a/examples/computecullandlod/computecullandlod.cpp
+++ b/examples/computecullandlod/computecullandlod.cpp
@@ -14,7 +14,7 @@
 
 // Total number of objects (^3) in the scene
 #if defined(__ANDROID__)
-constexpr auto OBJECT_COUNT 32;
+constexpr auto OBJECT_COUNT = 32;
 #else
 constexpr auto OBJECT_COUNT = 64;
 #endif


### PR DESCRIPTION
The constexpr looks wrong in the ANDROID compile-time switch