### PR TITLE
Make triangle example use base class logic for getting entrypoint name

### DIFF
--- a/examples/triangle/triangle.cpp
+++ b/examples/triangle/triangle.cpp
@@ -814,7 +814,7 @@ public:
 		// Load binary SPIR-V shader
 		shaderStages[0].module = loadSPIRVShader(getShadersPath() + "triangle/triangle.vert.spv");
 		// Main entry point for the shader
-		shaderStages[0].pName = "main";
+		shaderStages[0].pName = getShaderEntryPoint(VK_SHADER_STAGE_VERTEX_BIT);
 		assert(shaderStages[0].module != VK_NULL_HANDLE);
 
 		// Fragment shader
@@ -824,7 +824,7 @@ public:
 		// Load binary SPIR-V shader
 		shaderStages[1].module = loadSPIRVShader(getShadersPath() + "triangle/triangle.frag.spv");
 		// Main entry point for the shader
-		shaderStages[1].pName = "main";
+		shaderStages[1].pName = getShaderEntryPoint(VK_SHADER_STAGE_FRAGMENT_BIT);
 		assert(shaderStages[1].module != VK_NULL_HANDLE);
 
 		// Set pipeline shader stage info


### PR DESCRIPTION
This is needed as in my rust fork we modify the logic in the base class, but there is nothing rust-specific about this so it should probably go upstream.