### PR TITLE
Add screenshot capture to benchmark system for automated shader testing

### DIFF
--- a/base/benchmark.hpp
+++ b/base/benchmark.hpp
@@ -28,11 +28,13 @@ namespace vks
 		uint32_t duration = 10;
 		std::vector<double> frameTimes;
 		std::string filename = "";
+		std::string screenshotPath = "";
+		int32_t screenshotFrameIndex = -1;
 
 		double runtime = 0.0;
 		uint32_t frameCount = 0;
 
-		void run(std::function<void()> renderFunc, VkPhysicalDeviceProperties deviceProps) {
+		void run(std::function<void()> renderFunc, std::function<void(const std::string&)> screenshotFunc, VkPhysicalDeviceProperties deviceProps) {
 			active = true;
 			this->deviceProps = deviceProps;
 #if defined(_WIN32)
@@ -64,6 +66,10 @@ namespace vks
 					auto tDiff = std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now() - tStart).count();
 					runtime += tDiff;
 					frameTimes.push_back(tDiff);
+					// Capture screenshot at specified frame
+					if (screenshotFrameIndex >= 0 && frameCount == screenshotFrameIndex && !screenshotPath.empty()) {
+						screenshotFunc(screenshotPath);
+					}
 					frameCount++;
 					if (outputFrames != -1 && outputFrames == frameCount) break;
 				};
@@ -73,6 +79,9 @@ namespace vks
 				std::cout << "runtime: " << (runtime / 1000.0) << "\n";
 				std::cout << "frames : " << frameCount << "\n";
 				std::cout << "fps    : " << frameCount / (runtime / 1000.0) << "\n";
+				if (!screenshotPath.empty() && screenshotFrameIndex >= 0) {
+					std::cout << "screenshot saved to: " << screenshotPath << "\n";
+				}
 			}
 		}
 

--- a/base/vulkanexamplebase.h
+++ b/base/vulkanexamplebase.h
@@ -216,6 +216,10 @@ public:
 	float timerSpeed = 0.25f;
 	bool paused = false;
 
+	// Screenshot functionality
+	std::string screenshotPath = "";
+	int32_t screenshotFrameIndex = -1;
+
 	Camera camera;
 
 	std::string title = "Vulkan Example";
@@ -387,6 +391,8 @@ public:
 	virtual void setupRenderPass();
 	/** @brief (Virtual) Called after the physical device features have been read, can be used to set features to enable on the device */
 	virtual void getEnabledFeatures();
+	/** @brief Save screenshot of current swapchain image to file */
+	void saveScreenshot(const std::string& filename);
 	/** @brief (Virtual) Called after the physical device extensions have been read, can be used to enable extensions based on the supported extension listing*/
 	virtual void getEnabledExtensions();
 


### PR DESCRIPTION
- Add `saveScreenshot()` method to capture swapchain images as PPM files
- Extend benchmark class to support screenshot capture at specified frame
- Add command-line flags `--screenshot` and `--screenshotframe`

This enables automated differential testing (not included in this PR, but trivial to add on top. I am doing so in our Rust fork)