### PR TITLE
dynamicrenderingmultisampling: Added missing barrier for swapchain image

### DIFF
--- a/examples/dynamicrenderingmultisampling/dynamicrenderingmultisampling.cpp
+++ b/examples/dynamicrenderingmultisampling/dynamicrenderingmultisampling.cpp
@@ -203,6 +203,16 @@ public:
 				VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
 				VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
 				VkImageSubresourceRange{ VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1 });
+			vks::tools::insertImageMemoryBarrier(
+				drawCmdBuffers[i],
+				swapChain.images[i],
+				0,
+				VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+				VK_IMAGE_LAYOUT_UNDEFINED,
+				VK_IMAGE_LAYOUT_GENERAL,
+				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+				VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+				VkImageSubresourceRange{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 });
 
 			// New structures are used to define the attachments used in dynamic rendering
 			VkRenderingAttachmentInfoKHR colorAttachment{};


### PR DESCRIPTION
Fixes https://github.com/SaschaWillems/Vulkan/issues/1225