### PR TITLE
Update Apple iOS sub-project to support vulkanexamplebase changes

### DIFF
--- a/apple/MVKExample.cpp
+++ b/apple/MVKExample.cpp
@@ -9,10 +9,6 @@
 #include "MVKExample.h"
 #include "examples.h"
 
-void MVKExample::renderFrame() {
-	_vulkanExample->renderFrame();
-}
-
 void MVKExample::displayLinkOutputCb() {                        // SRS - expose VulkanExampleBase::displayLinkOutputCb() to DemoViewController
     _vulkanExample->displayLinkOutputCb();
 }
@@ -26,7 +22,6 @@ void MVKExample::keyPressed(uint32_t keyChar) {					// SRS - handle keyboard key
 		case KEY_1:												// SRS - support keyboards with no function keys
 		case KEY_F1:
 			_vulkanExample->ui.visible = !_vulkanExample->ui.visible;
-			_vulkanExample->ui.updated = true;
 			break;
 		default:
 			_vulkanExample->keyPressed(keyChar);
@@ -112,7 +107,6 @@ void MVKExample::mouseDragged(double x, double y) {
 
 void MVKExample::scrollWheel(short wheelDelta) {
     _vulkanExample->camera.translate(glm::vec3(0.0f, 0.0f, wheelDelta * 0.05f * _vulkanExample->camera.movementSpeed));
-	_vulkanExample->viewUpdated = true;
 }
 
 void MVKExample::fullScreen(bool fullscreen) {

--- a/apple/MVKExample.h
+++ b/apple/MVKExample.h
@@ -13,7 +13,6 @@
 class MVKExample {
 
 public:
-	void renderFrame();
     void displayLinkOutputCb();                     // SRS - expose VulkanExampleBase::displayLinkOutputCb() to DemoViewController
     
     void keyPressed(uint32_t keyChar);              // SRS - expose keyboard events to DemoViewController

--- a/apple/examples.h
+++ b/apple/examples.h
@@ -40,7 +40,7 @@
 #   include "../examples/triangle/triangle.cpp"
 #endif
 
-// Does not run. MoltenVK does not yet support Vulkan 1.3
+// Supported as of MoltenVK version 1.3.0 / Vulkan SDK 1.4.321.0
 #ifdef MVK_trianglevulkan13
 #   include "../examples/trianglevulkan13/trianglevulkan13.cpp"
 #endif

--- a/apple/macos/DemoViewController.mm
+++ b/apple/macos/DemoViewController.mm
@@ -26,8 +26,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink,
                                     CVOptionFlags flagsIn,
                                     CVOptionFlags* flagsOut,
                                     void* target) {
-    //((MVKExample*)target)->renderFrame();
-    ((MVKExample*)target)->displayLinkOutputCb();   // SRS - Call displayLinkOutputCb() to animate frames vs. renderFrame() for static image
+    ((MVKExample*)target)->displayLinkOutputCb();   // SRS - Call displayLinkOutputCb() to render/animate at displayLink frame rate
     return kCVReturnSuccess;
 }
 


### PR DESCRIPTION
This PR updates the iOS sub-project located in **apple/** to be compatible with recent changes to _vulkanexamplebase_.  Since PR #1224 the iOS sub-project will not build.

Specifically this PR removes iOS sub-project references to now-defunct objects:

1. `VulkanExampleBase::renderFrame()`
2. `VulkanExampleBase::viewUpdated`
3. `VulkanExampleBase::ui.updated`

This PR also updates a comment in **apple/examples.h** referencing MoltenVK 1.3.0/SDK 1.4.321.0 which now supports Vulkan 1.3 on iOS and macOS.

Question:  @SaschaWillems I see that you are working on Android CI.  Would you like me to re-enable CI for iOS?