### PR TITLE
Fix textoverlay Android build - include torusknot.gltf asset

### DIFF
--- a/android/examples/textoverlay/build.gradle
+++ b/android/examples/textoverlay/build.gradle
@@ -57,7 +57,7 @@ task copyTask {
     copy {
        from rootProject.ext.assetPath + 'models'
        into 'assets/models'
-       include 'cube.gltf'
+       include 'cube.gltf', 'torusknot.gltf'
     }
 
 


### PR DESCRIPTION
Fixes a problem where it wouldn't find the torusknot.gltf model on android.