### PR TITLE
Restore MoltenVK layer setting for specialized queue families

### DIFF
--- a/base/vulkanexamplebase.cpp
+++ b/base/vulkanexamplebase.cpp
@@ -848,7 +848,7 @@ VulkanExampleBase::VulkanExampleBase()
 		{
 			for (VkExtensionProperties& extension : extensions)
 			{
-				if (std::find(supportedInstanceExtensions.begin(), supportedInstanceExtensions.end(), VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) != supportedInstanceExtensions.end())
+				if (std::strcmp(extension.extensionName, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0)
 				{
 					enabledInstanceExtensions.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
 
@@ -863,6 +863,8 @@ VulkanExampleBase::VulkanExampleBase()
 					static const VkBool32 layerSettingOn = VK_TRUE;
 					layerSetting.pValues = &layerSettingOn;
 					enabledLayerSettings.push_back(layerSetting);
+					
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
PR #1241 breaks enablement of the `MVK_CONFIG_SPECIALIZED_QUEUE_FAMILIES` layer setting for MoltenVK. The following line in `VulkanExampleBase::VulkanExampleBase()` is the issue since `supportedInstanceExtensions` is not yet populated (i.e. empty) when this code is run:

`if (std::find(supportedInstanceExtensions.begin(), supportedInstanceExtensions.end(), VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) != supportedInstanceExtensions.end())`

Instead, the comparison should test the `extension` variable like this:

`if (std::strcmp(extension.extensionName, VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0)`

This PR addresses this issue while retaining the original intent of PR #1241 which adds compatibility for KosmicKrisp.