### PR TITLE
Add single-sample shader compilation to GLSL/HLSL script

### DIFF
--- a/shaders/glsl/compileshaders.py
+++ b/shaders/glsl/compileshaders.py
@@ -9,6 +9,7 @@ import sys
 
 parser = argparse.ArgumentParser(description='Compile all GLSL shaders')
 parser.add_argument('--glslang', type=str, help='path to glslangvalidator executable')
+parser.add_argument('--sample', type=str, help='can be used to compile shaders for a single sample only')
 parser.add_argument('--g', action='store_true', help='compile with debug symbols')
 args = parser.parse_args()
 
@@ -32,10 +33,21 @@ def findGlslang():
 
 file_extensions = tuple([".vert", ".frag", ".comp", ".geom", ".tesc", ".tese", ".rgen", ".rchit", ".rmiss", ".mesh", ".task"])
 
+compile_single_sample = ""
+if args.sample != None:
+    compile_single_sample = args.sample
+    if (not os.path.isdir(compile_single_sample)):
+        print("ERROR: No directory found with name %s" % compile_single_sample)
+        exit(-1)
+
 glslang_path = findGlslang()
 dir_path = os.path.dirname(os.path.realpath(__file__))
 dir_path = dir_path.replace('\\', '/')
 for root, dirs, files in os.walk(dir_path):
+    folder_name = os.path.basename(root)
+    if (compile_single_sample != "" and folder_name != compile_single_sample):
+        continue
+
     for file in files:
         if file.endswith(file_extensions):
             input_file = os.path.join(root, file)
@@ -44,7 +56,6 @@ for root, dirs, files in os.walk(dir_path):
             add_params = ""
             if args.g:
                 add_params = "-g"
-
 
             # Ray tracing shaders require a different target environment           
             if file.endswith(".rgen") or file.endswith(".rchit") or file.endswith(".rmiss"):

--- a/shaders/hlsl/compileshaders.py
+++ b/shaders/hlsl/compileshaders.py
@@ -9,6 +9,7 @@ import sys
 
 parser = argparse.ArgumentParser(description='Compile all .hlsl shaders')
 parser.add_argument('--dxc', type=str, help='path to DXC executable')
+parser.add_argument('--sample', type=str, help='can be used to compile shaders for a single sample only')
 args = parser.parse_args()
 
 def findDXC():
@@ -29,12 +30,23 @@ def findDXC():
 
     sys.exit("Could not find DXC executable on PATH, and was not specified with --dxc")
 
+compile_single_sample = ""
+if args.sample != None:
+    compile_single_sample = args.sample
+    if (not os.path.isdir(compile_single_sample)):
+        print("ERROR: No directory found with name %s" % compile_single_sample)
+        exit(-1)
+
 file_extensions = tuple([".vert", ".frag", ".comp", ".geom", ".tesc", ".tese", ".rgen", ".rchit", ".rmiss", ".mesh", ".task"])
 
 dxc_path = findDXC()
 dir_path = os.path.dirname(os.path.realpath(__file__))
 dir_path = dir_path.replace('\\', '/')
 for root, dirs, files in os.walk(dir_path):
+    folder_name = os.path.basename(root)
+    if (compile_single_sample != "" and folder_name != compile_single_sample):
+        continue
+
     for file in files:
         if file.endswith(file_extensions):
             hlsl_file = os.path.join(root, file)


### PR DESCRIPTION
It's time-consuming to have to wait for all shaders of all samples to get compiled, so I replicated the behavior already in the slang script.

Tested it locally and it seems to work as expected.