### PR TITLE
Fix descriptor pool size in inlineuniformblocks

### DIFF
--- a/examples/inlineuniformblocks/inlineuniformblocks.cpp
+++ b/examples/inlineuniformblocks/inlineuniformblocks.cpp
@@ -115,7 +115,7 @@ public:
 		std::vector<VkDescriptorPoolSize> poolSizes = {
 			vks::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, maxConcurrentFrames),
 			/* [POI] Allocate inline uniform blocks */
-			vks::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT, static_cast<uint32_t>(objects.size()) * sizeof(Object::Material)),
+			vks::initializers::descriptorPoolSize(VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT, maxConcurrentFrames * static_cast<uint32_t>(objects.size()) * sizeof(Object::Material)),
 		};
 		VkDescriptorPoolCreateInfo descriptorPoolCI = vks::initializers::descriptorPoolCreateInfo(poolSizes, (static_cast<uint32_t>(objects.size()) + 1) * maxConcurrentFrames);
 		/*


### PR DESCRIPTION
The sample creates a pool with storage for `objects.size() * sizeof(Material) = 384` descriptors (or rather bytes) of type `INLINE_UNIFORM_BLOCK`. Then it tries to allocate `uniformBuffers.size() * objects.size() * sizeof(Material) = 768` from the pool.

It fails on AMD RX 7900. I didn't check any other GPUs. It may work on some due to additional alignments in the drivers.