### PR TITLE
Fix resizing in multiview

### DIFF
--- a/examples/multiview/multiview.cpp
+++ b/examples/multiview/multiview.cpp
@@ -556,6 +556,8 @@ public:
 		vkDestroySampler(device, multiviewPass.sampler, nullptr);
 		vkDestroyFramebuffer(device, multiviewPass.frameBuffer, nullptr);
 
+		VK_CHECK_RESULT(vkResetDescriptorPool(device, descriptorPool, 0));
+
 		prepareMultiview();
 		updateDescriptors();
 		


### PR DESCRIPTION
We need to reset the descriptor pool when window is resize to be able to allocate descriptors for the new resources.