### PR TITLE
Fix colorAttachmentCount error in dynamicrenderinglocalread example

### DIFF
--- a/apple/examples.h
+++ b/apple/examples.h
@@ -429,6 +429,10 @@
 #   include "../examples/dynamicrendering/dynamicrendering.cpp"
 #endif
 
+#ifdef MVK_dynamicrenderinglocalread
+#   include "../examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp"
+#endif
+
 #ifdef MVK_dynamicrenderingmultisampling
 #   include "../examples/dynamicrenderingmultisampling/dynamicrenderingmultisampling.cpp"
 #endif

--- a/apple/examples.h
+++ b/apple/examples.h
@@ -429,10 +429,6 @@
 #   include "../examples/dynamicrendering/dynamicrendering.cpp"
 #endif
 
-#ifdef MVK_dynamicrenderinglocalread
-#   include "../examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp"
-#endif
-
 #ifdef MVK_dynamicrenderingmultisampling
 #   include "../examples/dynamicrenderingmultisampling/dynamicrenderingmultisampling.cpp"
 #endif

--- a/examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp
+++ b/examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp
@@ -141,7 +141,7 @@ public:
 	{
 		// With VK_KHR_dynamic_rendering we no longer need a frame buffer, so skip the sample base framebuffer setup
 
-		if (attachments.width != width || attachments.height != height)
+		if (resized)
 		{
 			attachments.width = width;
 			attachments.height = height;
@@ -160,6 +160,7 @@ public:
 				writeDescriptorSets.push_back(vks::initializers::writeDescriptorSet(passes.composition.descriptorSet, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, static_cast<uint32_t>(i), &descriptorImageInfos[i]));
 			}
 			vkUpdateDescriptorSets(device, static_cast<uint32_t>(writeDescriptorSets.size()), writeDescriptorSets.data(), 0, nullptr);
+			resized = false;
 		}
 
 	}
@@ -458,6 +459,9 @@ public:
 		vkCmdEndRenderingKHR = reinterpret_cast<PFN_vkCmdEndRenderingKHR>(vkGetDeviceProcAddr(device, "vkCmdEndRenderingKHR"));
 		vkCmdPipelineBarrier2KHR = reinterpret_cast<PFN_vkCmdPipelineBarrier2KHR>(vkGetDeviceProcAddr(device, "vkCmdPipelineBarrier2KHR"));
 		vkCmdSetRenderingInputAttachmentIndicesKHR = reinterpret_cast<PFN_vkCmdSetRenderingInputAttachmentIndicesKHR>(vkGetDeviceProcAddr(device, "vkCmdSetRenderingInputAttachmentIndicesKHR"));
+
+		attachments.width = width;
+		attachments.height = height;
 
 		initLights();
 		createAttachments();

--- a/examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp
+++ b/examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp
@@ -103,8 +103,19 @@ public:
 		};
 		deviceCreatepNextChain = &enabledSynchronization2FeaturesKHR;
 
-		attachments.width = width;
-		attachments.height = height;
+#if (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_METAL_EXT)) && TARGET_OS_SIMULATOR
+		static const VkBool32 valueFalse = VK_FALSE;
+
+		// On iOS Simulator use layer setting to disable MoltenVK's Metal argument buffers - otherwise blank display
+		VkLayerSettingEXT layerSetting;
+		layerSetting.pLayerName = "MoltenVK";
+		layerSetting.pSettingName = "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS";
+		layerSetting.type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
+		layerSetting.pValues = &valueFalse;
+		layerSetting.valueCount = 1;
+
+		enabledLayerSettings.push_back( layerSetting );
+#endif
 	}
 
 	~VulkanExample()

--- a/examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp
+++ b/examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp
@@ -138,6 +138,8 @@ public:
 			for (auto& buffer : uniformBuffers) {
 				buffer.destroy();
 			}
+			vkDestroyBuffer(device, lightsBuffer.buffer, nullptr);
+			vkFreeMemory(device, lightsBuffer.memory, nullptr);
 		}
 	}
 
@@ -170,7 +172,7 @@ public:
 	}
 
 	// Enable physical device features required for this example
-	virtual void getEnabledFeatures()
+	virtual void getEnabledFeatures() override
 	{
 		// Enable anisotropic filtering if supported
 		if (deviceFeatures.samplerAnisotropy) {
@@ -454,7 +456,7 @@ public:
 		}
 	}
 
-	void prepare()
+	void prepare() override
 	{
 		VulkanExampleBase::prepare();
 		// Since we use an extension, we need to expliclity load the function pointers for extension related Vulkan commands
@@ -508,7 +510,7 @@ public:
 			colorAttachments[i] = {
 				.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
 				.imageView = imageViewList[i],
-				.imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
+				.imageLayout = (i == 0) ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
 				.resolveMode = VK_RESOLVE_MODE_NONE,
 				.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
 				.storeOp = VK_ATTACHMENT_STORE_OP_STORE,
@@ -579,6 +581,15 @@ public:
 		vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, passes.composition.pipelineLayout, 0, 1, &passes.composition.descriptorSet, 0, nullptr);
 		vkCmdDraw(cmdBuffer, 3, 1, 0, 0);
 
+		vkCmdEndRenderingKHR(cmdBuffer);
+
+		// Update renderingInfo to use current swapchain image as single color attachment for the UI
+		colorAttachments[0].imageView = swapChain.imageViews[currentImageIndex];
+		colorAttachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+		renderingInfo.colorAttachmentCount = 1;
+
+		vkCmdBeginRenderingKHR(cmdBuffer, &renderingInfo);
+
 		drawUI(cmdBuffer);
 
 		vkCmdEndRenderingKHR(cmdBuffer);
@@ -598,7 +609,7 @@ public:
 		VK_CHECK_RESULT(vkEndCommandBuffer(cmdBuffer));
 	}
 
-	virtual void render()
+	virtual void render() override
 	{
 		if (!prepared)
 			return;

--- a/examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp
+++ b/examples/dynamicrenderinglocalread/dynamicrenderinglocalread.cpp
@@ -495,7 +495,7 @@ public:
 			colorAttachments[i] = {
 				.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
 				.imageView = imageViewList[i],
-				.imageLayout = (i == 0) ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
+				.imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
 				.resolveMode = VK_RESOLVE_MODE_NONE,
 				.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
 				.storeOp = VK_ATTACHMENT_STORE_OP_STORE,
@@ -568,7 +568,7 @@ public:
 
 		vkCmdEndRenderingKHR(cmdBuffer);
 
-		// Update renderingInfo to use current swapchain image as single color attachment for the UI
+		// Update renderingInfo to specify and preserve the current swapchain image as the single color attachment for the UI
 		colorAttachments[0].imageView = swapChain.imageViews[currentImageIndex];
 		colorAttachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
 		renderingInfo.colorAttachmentCount = 1;


### PR DESCRIPTION
Fixes ~~#1267~~ #1271.

~~This change fixes startup resize for _dynamicrenderinglocalread_ to support non-default device screen sizes.~~

~~This also updates the iOS subproject to include this new sample and make it work on iOS devices and the Simulator.~~

**UPDATED**: Now fixes some validation layer errors in the example (all platforms):

1. ~~Wrong image layout validation error.~~ Original fix in this PR has now been reverted.  This remains an outstanding VVL bug, see https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12039
2. Fixes the non-matching color attachment count when drawing the UI (1 actual vs. 4 expected)
3. ~~Failure to destroy buffer and memory on exit.~~ Already fixed in master.
4. Fixes some missing overrides (static analysis warnings in IDE)