### PR TITLE
Add .rint compilation support to shaders/hlsl and shaders/glsl

### DIFF
--- a/shaders/glsl/compileshaders.py
+++ b/shaders/glsl/compileshaders.py
@@ -31,7 +31,7 @@ def findGlslang():
 
     sys.exit("Could not find glslangvalidator executable on PATH, and was not specified with --glslang")
 
-file_extensions = tuple([".vert", ".frag", ".comp", ".geom", ".tesc", ".tese", ".rgen", ".rchit", ".rmiss", ".mesh", ".task"])
+file_extensions = tuple([".vert", ".frag", ".comp", ".geom", ".tesc", ".tese", ".rgen", ".rchit", ".rint", ".rmiss", ".mesh", ".task"])
 
 compile_single_sample = ""
 if args.sample != None:
@@ -58,7 +58,7 @@ for root, dirs, files in os.walk(dir_path):
                 add_params = "-g"
 
             # Ray tracing shaders require a different target environment           
-            if file.endswith(".rgen") or file.endswith(".rchit") or file.endswith(".rmiss"):
+            if file.endswith(".rgen") or file.endswith(".rchit") or file.endswith(".rint") or file.endswith(".rmiss"):
                add_params = add_params + " --target-env vulkan1.2"
             # Same goes for samples that use ray queries
             if root.endswith("rayquery") and file.endswith(".frag"):

--- a/shaders/hlsl/compileshaders.py
+++ b/shaders/hlsl/compileshaders.py
@@ -37,7 +37,7 @@ if args.sample != None:
         print("ERROR: No directory found with name %s" % compile_single_sample)
         exit(-1)
 
-file_extensions = tuple([".vert", ".frag", ".comp", ".geom", ".tesc", ".tese", ".rgen", ".rchit", ".rmiss", ".mesh", ".task"])
+file_extensions = tuple([".vert", ".frag", ".comp", ".geom", ".tesc", ".tese", ".rgen", ".rchit", ".rint", ".rmiss", ".mesh", ".task"])
 
 dxc_path = findDXC()
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -69,6 +69,7 @@ for root, dirs, files in os.walk(dir_path):
                 profile = 'ds_6_1'
             elif(hlsl_file.find('.rgen') != -1 or
 				hlsl_file.find('.rchit') != -1 or
+				hlsl_file.find('.rint') != -1 or
 				hlsl_file.find('.rmiss') != -1):
                 target='-fspv-target-env=vulkan1.2'
                 profile = 'lib_6_3'


### PR DESCRIPTION
Unlike shaders/slang/compileshaders.py, the scripts in shaders/hlsl and shaders/glsl did not support .rint compilation.

As a result, intersection.rint in the raytracingintersection sample was not compiled correctly by the GLSL shader compilation script.

This PR adds the missing .rint compilation support to the HLSL and GLSL shader scripts.