### PR TITLE
Fix typos in example comments and docs

### DIFF
--- a/examples/descriptorheap/descriptorheap.cpp
+++ b/examples/descriptorheap/descriptorheap.cpp
@@ -142,7 +142,7 @@ public:
 			getBufferDeviceAddress(uniformBuffers[i]);
 		}
 
-		// Descriptor heaps have varying offset, size and alignment requirements, so we store it's properties for later user
+		// Descriptor heaps have varying offset, size and alignment requirements, so we store its properties for later use
 		VkPhysicalDeviceProperties2 deviceProps2{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2 };
 		descriptorHeapProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_PROPERTIES_EXT;
 		deviceProps2.pNext = &descriptorHeapProperties;

--- a/examples/descriptorindexing/descriptorindexing.cpp
+++ b/examples/descriptorindexing/descriptorindexing.cpp
@@ -288,7 +288,7 @@ public:
 			};
 		}
 		// [POI] Second and final descriptor is a texture array
-		// Unlike an array texture, these are adressed like typical arrays
+		// Unlike an array texture, these are addressed like typical arrays
 		VkWriteDescriptorSet textureArrayDescriptorWrite{
 			.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
 			.dstBinding = 1,

--- a/examples/graphicspipelinelibrary/graphicspipelinelibrary.cpp
+++ b/examples/graphicspipelinelibrary/graphicspipelinelibrary.cpp
@@ -526,7 +526,7 @@ public:
 	{
 		overlay->checkBox("Link time optimization", &linkTimeOptimization);
 		if (overlay->button("New pipeline")) {
-			// Spwan a thread to create a new pipeline in the background
+			// Spawn a thread to create a new pipeline in the background
 			std::thread pipelineGenerationThread(&VulkanExample::threadFn, this);
 			pipelineGenerationThread.detach();
 		}

--- a/examples/imgui/main.cpp
+++ b/examples/imgui/main.cpp
@@ -308,7 +308,7 @@ public:
 		VkPipelineDynamicStateCreateInfo dynamicState = vks::initializers::pipelineDynamicStateCreateInfo(dynamicStateEnables);
 		std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages{};
 
-		// Vertex bindings an attributes based on ImGui vertex definition
+		// Vertex bindings and attributes based on ImGui vertex definition
 		std::vector<VkVertexInputBindingDescription> vertexInputBindings = {
 			vks::initializers::vertexInputBindingDescription(0, sizeof(ImDrawVert), VK_VERTEX_INPUT_RATE_VERTEX),
 		};

--- a/examples/renderheadless/renderheadless.cpp
+++ b/examples/renderheadless/renderheadless.cpp
@@ -638,7 +638,7 @@ public:
 			pipelineCreateInfo.stageCount = static_cast<uint32_t>(shaderStages.size());
 			pipelineCreateInfo.pStages = shaderStages.data();
 
-			// Vertex bindings an attributes
+			// Vertex bindings and attributes
 			// Binding description
 			std::vector<VkVertexInputBindingDescription> vertexInputBindings = {
 				vks::initializers::vertexInputBindingDescription(0, sizeof(Vertex), VK_VERTEX_INPUT_RATE_VERTEX),

--- a/examples/texturemipmapgen/README.md
+++ b/examples/texturemipmapgen/README.md
@@ -60,7 +60,7 @@ vkCmdCopyBufferToImage(copyCmd, stagingBuffer, texture.image, VK_IMAGE_LAYOUT_TR
 ```
 
 ### Prepare base mip level
-As we are going to blit ***from*** the base mip-level just uploaded we also need to set insert an image memory barrier that sets the image layout to ```TRANSFER_SRC``` for the base mip level:
+As we are going to blit ***from*** the base mip-level just uploaded we also need to insert an image memory barrier that sets the image layout to ```TRANSFER_SRC``` for the base mip level:
 
 ```cpp
 VkImageSubresourceRange subresourceRange = {};
@@ -167,7 +167,7 @@ After the blit is done we can use this mip level as a base for the next level, s
 ```
 
 ### Final image layout transitions
-Once the loop is done we need to transition all mip levels of the image to their actual usage layout, which is ```SHADER_READ``` for this example. Note that after the loop all levels will be in the ```TRANSER_SRC``` layout allowing us to transfer the whole image at once:
+Once the loop is done we need to transition all mip levels of the image to their actual usage layout, which is ```SHADER_READ``` for this example. Note that after the loop all levels will be in the ```TRANSFER_SRC``` layout allowing us to transfer the whole image at once:
 
 ```cpp
   subresourceRange.levelCount = texture.mipLevels;

--- a/examples/texturemipmapgen/texturemipmapgen.cpp
+++ b/examples/texturemipmapgen/texturemipmapgen.cpp
@@ -403,7 +403,7 @@ public:
 				vks::initializers::writeDescriptorSet(descriptorSets[i], VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, &textureDescriptor)
 			};
 
-			// Binding 2: Contains an array of samplers that can be switched from the UI to demonstrate different filteirng modes
+			// Binding 2: Contains an array of samplers that can be switched from the UI to demonstrate different filtering modes
 			std::vector<VkDescriptorImageInfo> samplerDescriptors;
 			for (auto j = 0; j < samplers.size(); j++) {
 				samplerDescriptors.push_back(vks::initializers::descriptorImageInfo(samplers[j], VK_NULL_HANDLE, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));

--- a/examples/triangle/triangle.cpp
+++ b/examples/triangle/triangle.cpp
@@ -185,7 +185,7 @@ public:
 			fenceCI.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
 			// Create the fences in signaled state (so we don't wait on first render of each command buffer)
 			fenceCI.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-			// Fence used to ensure that command buffer has completed exection before using it again
+			// Fence used to ensure that command buffer has completed execution before using it again
 			VK_CHECK_RESULT(vkCreateFence(device, &fenceCI, nullptr, &waitFences[i]));
 		}
 		// Semaphores are used for correct command ordering within a queue

--- a/examples/trianglevulkan13/trianglevulkan13.cpp
+++ b/examples/trianglevulkan13/trianglevulkan13.cpp
@@ -175,7 +175,7 @@ public:
 	{
 		// Fences are per frame in flight
 		for (uint32_t i = 0; i < MAX_CONCURRENT_FRAMES; i++) {		
-			// Fence used to ensure that command buffer has completed exection before using it again
+			// Fence used to ensure that command buffer has completed execution before using it again
 			VkFenceCreateInfo fenceCI{
 				.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
 				// Create the fences in signaled state (so we don't wait on first render of each command buffer)

--- a/examples/vulkanscene/vulkanscene.cpp
+++ b/examples/vulkanscene/vulkanscene.cpp
@@ -1,7 +1,7 @@
 /*
 * Vulkan Demo Scene
 *
-* Don't take this a an example, it's more of a playground
+* Don't take this as an example, it's more of a playground
 *
 * Copyright (C) 2016-2025 by Sascha Willems - www.saschawillems.de
 *


### PR DESCRIPTION
A batch of small typo fixes in code comments and a couple of README lines (no code/behavior changes):

| File | Fix |
|---|---|
| `graphicspipelinelibrary.cpp` | `Spwan` → `Spawn` |
| `texturemipmapgen.cpp` | `filteirng` → `filtering` |
| `triangle.cpp`, `trianglevulkan13.cpp` | `exection` → `execution` |
| `descriptorindexing.cpp` | `adressed` → `addressed` |
| `vulkanscene.cpp` | `take this a an example` → `take this as an example` |
| `imgui/main.cpp`, `renderheadless.cpp` | `Vertex bindings an attributes` → `bindings and attributes` |
| `descriptorheap.cpp` | `store it's properties for later user` → `store its properties for later use` |
| `texturemipmapgen/README.md` | `TRANSER_SRC` → `TRANSFER_SRC`; `need to set insert an image` → `need to insert an image` |