### PR TITLE
Fix: shadowed fragments becoming transparent in rayquery example

### DIFF
--- a/shaders/glsl/rayquery/scene.frag
+++ b/shaders/glsl/rayquery/scene.frag
@@ -32,6 +32,6 @@ void main()
 
 	// If the intersection has hit a triangle, the fragment is shadowed
 	if (rayQueryGetIntersectionTypeEXT(rayQuery, true) == gl_RayQueryCommittedIntersectionTriangleEXT ) {
-		outFragColor *= 0.1;
+		outFragColor.rgb *= 0.1;
 	}
 }


### PR DESCRIPTION
Bug in the rayquery example's shadow shader "shaders/glsl/rayquery/scene.frag":

if (shadowed) {
      outFragcolor *= 0.1; // scales alpha too, not just rgb
}

This scaled the whole vec4 including alpha, so shadowed pixels ended up with alpha = 0.1 instead of just a darker rgb. 
Went unnoticed on platforms where the swapchain picks **VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR** (alpha is ignored on present), but on WSI backends that don't support OPAQUE (e.g.Weston, which falls back to **PRE MULTIPLIED/POST_MULTIPLIED** "base/VulkanSwapChain.cpp:272"), the compositor blends using that alpha, making shadows show whatever is behind the window instead of just looking darker.

Fix: outFragcolor,rgb *= 0.1; Scale only rgb so alpha stays pinned at 1.0 regardless of which compositeAlpha mode gets selected.

Images of the final render in RenderDoc, with Alpha enabled and disabled for visualization of issue:
<img width="360" height="507" alt="alpha_disabled" src="https://github.com/user-attachments/assets/57bb6540-a6fd-4b67-bd5e-e9fea3a0b96a" /> <img width="360" height="503" alt="alpha_enabled" src="https://github.com/user-attachments/assets/199d16ff-23c6-4d5a-8c61-e6eceab5feb6" />


